### PR TITLE
fix: SimplifiedChinese font range

### DIFF
--- a/UiFontHandler.cs
+++ b/UiFontHandler.cs
@@ -77,12 +77,12 @@ namespace Echoglossian
             this.AddCharsFromIntPtr(chars, (ushort*)io.Fonts.GetGlyphRangesDefault());
             this.AddCharsFromIntPtr(chars, (ushort*)io.Fonts.GetGlyphRangesVietnamese());
             this.AddCharsFromIntPtr(chars, (ushort*)io.Fonts.GetGlyphRangesCyrillic());
-            if (this.configuration.Lang is 16 or 21)
+            if (this.configuration.Lang is 16)
             {
               this.AddCharsFromIntPtr(chars, (ushort*)io.Fonts.GetGlyphRangesChineseSimplifiedCommon());
             }
 
-            if (this.configuration.Lang is 22)
+            if (this.configuration.Lang is 22 or 21)
             {
               this.AddCharsFromIntPtr(chars, (ushort*)io.Fonts.GetGlyphRangesChineseFull());
             }


### PR DESCRIPTION
For ChineseSimplified it's still necessary to add the full ranges, otherwise, some characters are missing.