### PR TITLE
Fix fonts

### DIFF
--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -146,7 +146,7 @@ namespace Echoglossian
         this.PluginAssetsChecker();
       }
 
-      PluginInterface.UiBuilder.BuildFonts += this.LoadConfigFont;
+      PluginInterface.UiBuilder.BuildFonts += this.LoadLanguageComboFont;
       PluginInterface.UiBuilder.BuildFonts += this.LoadFont;
 
       // this.ListCultureInfos();
@@ -246,9 +246,11 @@ namespace Echoglossian
       Framework.Update -= this.Tick;
 
       PluginInterface.UiBuilder.BuildFonts -= this.LoadFont;
-      PluginInterface.UiBuilder.BuildFonts -= this.LoadConfigFont;
-
-      PluginInterface.UiBuilder.RebuildFonts();
+      PluginInterface.UiBuilder.BuildFonts -= this.LoadLanguageComboFont;
+      this.glyphRangeMainText?.Free();
+      this.glyphRangeConfigText?.Free();
+      this.glyphRangeMainText = null;
+      this.glyphRangeConfigText = null;
 
       CommandManager.RemoveHandler(SlashCommand);
     }
@@ -258,7 +260,7 @@ namespace Echoglossian
       if (!this.configuration.Translate)
       {
 #if DEBUG
-        PluginLog.Log("Translations are disabled!");
+        // PluginLog.Log("Translations are disabled!");
 #endif
         return;
       }
@@ -310,7 +312,7 @@ namespace Echoglossian
         return;
       }
 
-      if (!this.ConfigFontLoaded && !this.ConfigFontLoadFailed)
+      if (!this.LanguageComboFontLoaded && !this.LanguageComboFontLoadFailed)
       {
         PluginInterface.UiBuilder.RebuildFonts();
         return;
@@ -334,7 +336,7 @@ namespace Echoglossian
           this.configuration.FontChangeTime = 0;
           this.FontLoadFailed = false;
 
-          this.ReloadFont();
+          PluginInterface.UiBuilder.RebuildFonts();
         }
       }
 

--- a/Utils.cs
+++ b/Utils.cs
@@ -218,5 +218,16 @@ namespace Echoglossian
       ImageConverter imageConverter = new ImageConverter();
       return (byte[])imageConverter.ConvertTo(image, typeof(byte[]));
     }
+
+    private static bool AssignIfChanged<T>(ref T target, T newValue) where T : IEquatable<T>
+    {
+      if (target.Equals(newValue))
+      {
+        return false;
+      }
+
+      target = newValue;
+      return true;
+    }
   }
 }


### PR DESCRIPTION
1. Call only `RebuildFonts` when you need fonts updated. Don't call `AddFont...` functions outside `OnBuildFonts` event callback - it may cause crashes.
2. Changed to skip calling `this.SaveConfig` everywhere from config draw handler, and instead save it once at the end of function.
3. Pretty sure it doesn't matter, but used `GCHandle` instead of small scoped `fixed` from `Load...Font` functions.
4. Renamed `ConfigFont` to `LanguageComboFont` to reduce confusion, and made it characters for all languages only for characters that are used to display the language combobox in config.