### PR TITLE
ci: update chatgpt action to 1.4

### DIFF
--- a/.github/workflows/chatgpt.yml
+++ b/.github/workflows/chatgpt.yml
@@ -8,9 +8,9 @@ jobs:
     name: ChatGTP explain code
     steps:
       - name: ChatGTP explain code
-        uses: cirolini/chatgpt-github-actions@v1
+        uses: cirolini/chatgpt-github-actions@v1.4
         with:
           openai_api_key: ${{ secrets.openai_api_key }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_pr_id: ${{ github.event.number }}
-      
+          openai_engine: "gpt-3.5-turbo-instruct"


### PR DESCRIPTION
It uses the recommended openai engine, the default engine used by `cirolini/chatgpt-github-actions` is deprecated and it doesn't work. 

You can see it working here: https://github.com/samulopez/Echoglossian/pull/1