### PR TITLE
fix: changing API returns on error to avoid crashes

### DIFF
--- a/ChatGPTTranslator.cs
+++ b/ChatGPTTranslator.cs
@@ -81,13 +81,13 @@ namespace Echoglossian
         }
         else
         {
-          pluginLog.Error($"Translation failed or exceeded 350 characters: {translatedText.Length} characters");
-          return null;
+          return $"[Translation Error: Exceeded character limit ({translatedText.Length} characters)]";
         }
       }
       catch (Exception ex)
       {
         pluginLog.Error($"Translation error: {ex.Message}");
+        return $"[Translation Error: {ex.Message}]";
       }
 
       return null;


### PR DESCRIPTION
now when the API fails or exceed the character limit to not break on dialogue box it will return a string, avoiding crashing the game.