### PR TITLE
Issue #135: Fix summary node id

### DIFF
--- a/UiJournalHandler.cs
+++ b/UiJournalHandler.cs
@@ -239,7 +239,7 @@ namespace Echoglossian
 
         var summaryText = string.Empty;
         AtkTextNode* summaryNode = null;
-        var summaryBox = journalBox->UldManager.SearchNodeById(48);
+        var summaryBox = journalBox->UldManager.SearchNodeById(52);
         if (summaryBox != null && summaryBox->IsVisible())
         {
           var summaryResNode = summaryBox->GetComponent()->UldManager.SearchNodeById(2);


### PR DESCRIPTION
Fix for #135 

I only fixed summary node Id. 

But found another Issues:

- [ ] Null pointer inside Quests window
- [ ] Text nodes have to be moved by Y coordinate after translation
- [ ] Long summaries or descriptions have to be translated. I saw the MultipurposeNode inside UI Debug Window

```
01:29:05.630 | ERR | [Echoglossian] Error: System.NullReferenceException: Object reference not set to an instance of an object.
	   at Echoglossian.Echoglossian.TranslateJournalQuests() in /work/repo/UiJournalHandler.cs:line 413
```
