### PR TITLE
fix: refresh actionmenu canonical version reuse

### DIFF
--- a/Cache/ActionTooltipCacheManager.cs
+++ b/Cache/ActionTooltipCacheManager.cs
@@ -119,13 +119,69 @@ public static class ActionTooltipCacheManager
             return null;
         }
 
-        return rows.FirstOrDefault(row =>
-            row.TranslationLang == lang &&
-            row.TranslationEngine == engine &&
-            GameVersionLookupHelper.MatchesStoredVersion(
-                row.GameVersion,
-                gameVersion) &&
-            row.SourceContentHash == sourceContentHash);
+        return rows
+            .Where(row =>
+                RuntimeLanguageHelper.LanguagesMatch(
+                    row.TranslationLang,
+                    lang) &&
+                row.TranslationEngine == engine &&
+                GameVersionLookupHelper.MatchesStoredVersion(
+                    row.GameVersion,
+                    gameVersion) &&
+                row.SourceContentHash == sourceContentHash)
+            .OrderByDescending(row => ComputeCanonicalMatchScore(
+                row,
+                gameVersion))
+            .ThenByDescending(row => row.UpdatedDate)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    ///     Tries to find one historical version-specific canonical
+    ///     action-tooltip row whose source hash still matches the current
+    ///     payload.
+    /// </summary>
+    /// <param name="actionId">The action row identifier.</param>
+    /// <param name="lang">The target language code.</param>
+    /// <param name="engine">The translation engine identifier.</param>
+    /// <param name="requestedGameVersion">The current game version.</param>
+    /// <param name="sourceContentHash">The stable source-content hash.</param>
+    /// <returns>The best matching historical row, or <see langword="null" />.</returns>
+    public static ActionTooltip? TryFindHistoricalCanonicalMatch(
+        uint actionId,
+        string lang,
+        int engine,
+        string? requestedGameVersion,
+        string sourceContentHash)
+    {
+        if (actionId == 0 ||
+            string.IsNullOrWhiteSpace(lang) ||
+            string.IsNullOrWhiteSpace(requestedGameVersion) ||
+            string.IsNullOrWhiteSpace(sourceContentHash))
+        {
+            return null;
+        }
+
+        if (!Cache.TryGetValue(actionId, out var rows) || rows.Count == 0)
+        {
+            return null;
+        }
+
+        return rows
+            .Where(row =>
+                RuntimeLanguageHelper.LanguagesMatch(
+                    row.TranslationLang,
+                    lang) &&
+                row.TranslationEngine == engine &&
+                row.SourceContentHash == sourceContentHash &&
+                !string.IsNullOrWhiteSpace(row.GameVersion) &&
+                !string.Equals(
+                    row.GameVersion,
+                    requestedGameVersion,
+                    StringComparison.Ordinal))
+            .OrderByDescending(static row => HasAnyTranslatedContent(row))
+            .ThenByDescending(row => row.UpdatedDate)
+            .FirstOrDefault();
     }
 
     /// <summary>
@@ -662,6 +718,58 @@ public static class ActionTooltipCacheManager
         }
 
         return score;
+    }
+
+    /// <summary>
+    ///     Computes one ordering score for exact source-hash matches so fully
+    ///     translated reusable rows beat current-version placeholders.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <param name="gameVersion">The requested game version.</param>
+    /// <returns>The ordering score.</returns>
+    private static int ComputeCanonicalMatchScore(
+        ActionTooltip row,
+        string? gameVersion)
+    {
+        var score = 0;
+
+        if (HasCompleteTranslation(row))
+        {
+            score += 10_000;
+        }
+        else if (HasAnyTranslatedContent(row))
+        {
+            score += 1_000;
+        }
+
+        if (!string.IsNullOrWhiteSpace(gameVersion) &&
+            string.Equals(
+                row.GameVersion,
+                gameVersion,
+                StringComparison.Ordinal))
+        {
+            score += 100;
+        }
+
+        if (string.IsNullOrWhiteSpace(row.GameVersion))
+        {
+            score += 10;
+        }
+
+        return score;
+    }
+
+    /// <summary>
+    ///     Gets whether the row carries any translated canonical payload that
+    ///     can be promoted to a newer game version.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <returns>True when the row contains translated content.</returns>
+    private static bool HasAnyTranslatedContent(ActionTooltip row)
+    {
+        return !string.IsNullOrWhiteSpace(row.TranslatedActionName) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedActionDescription) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTooltipText);
     }
 
     /// <summary>

--- a/Cache/ItemTooltipCacheManager.cs
+++ b/Cache/ItemTooltipCacheManager.cs
@@ -110,13 +110,69 @@ public static class ItemTooltipCacheManager
             return null;
         }
 
-        return rows.FirstOrDefault(row =>
-            row.TranslationLang == lang &&
-            row.TranslationEngine == engine &&
-            GameVersionLookupHelper.MatchesStoredVersion(
-                row.GameVersion,
-                gameVersion) &&
-            row.SourceContentHash == sourceContentHash);
+        return rows
+            .Where(row =>
+                RuntimeLanguageHelper.LanguagesMatch(
+                    row.TranslationLang,
+                    lang) &&
+                row.TranslationEngine == engine &&
+                GameVersionLookupHelper.MatchesStoredVersion(
+                    row.GameVersion,
+                    gameVersion) &&
+                row.SourceContentHash == sourceContentHash)
+            .OrderByDescending(row => ComputeCanonicalMatchScore(
+                row,
+                gameVersion))
+            .ThenByDescending(row => row.UpdatedDate)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    ///     Tries to find one historical version-specific canonical
+    ///     item-tooltip row whose source hash still matches the current
+    ///     payload.
+    /// </summary>
+    /// <param name="itemId">The item row identifier.</param>
+    /// <param name="lang">The target language code.</param>
+    /// <param name="engine">The translation engine identifier.</param>
+    /// <param name="requestedGameVersion">The current game version.</param>
+    /// <param name="sourceContentHash">The stable source-content hash.</param>
+    /// <returns>The best matching historical row, or <see langword="null" />.</returns>
+    public static ItemTooltip? TryFindHistoricalCanonicalMatch(
+        uint itemId,
+        string lang,
+        int engine,
+        string? requestedGameVersion,
+        string sourceContentHash)
+    {
+        if (itemId == 0 ||
+            string.IsNullOrWhiteSpace(lang) ||
+            string.IsNullOrWhiteSpace(requestedGameVersion) ||
+            string.IsNullOrWhiteSpace(sourceContentHash))
+        {
+            return null;
+        }
+
+        if (!Cache.TryGetValue(itemId, out var rows) || rows.Count == 0)
+        {
+            return null;
+        }
+
+        return rows
+            .Where(row =>
+                RuntimeLanguageHelper.LanguagesMatch(
+                    row.TranslationLang,
+                    lang) &&
+                row.TranslationEngine == engine &&
+                row.SourceContentHash == sourceContentHash &&
+                !string.IsNullOrWhiteSpace(row.GameVersion) &&
+                !string.Equals(
+                    row.GameVersion,
+                    requestedGameVersion,
+                    StringComparison.Ordinal))
+            .OrderByDescending(static row => HasAnyTranslatedContent(row))
+            .ThenByDescending(row => row.UpdatedDate)
+            .FirstOrDefault();
     }
 
     /// <summary>
@@ -219,6 +275,58 @@ public static class ItemTooltipCacheManager
         }
 
         return score;
+    }
+
+    /// <summary>
+    ///     Computes one ordering score for exact source-hash matches so fully
+    ///     translated reusable rows beat current-version placeholders.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <param name="gameVersion">The requested game version.</param>
+    /// <returns>The ordering score.</returns>
+    private static int ComputeCanonicalMatchScore(
+        ItemTooltip row,
+        string? gameVersion)
+    {
+        var score = 0;
+
+        if (HasCompleteTranslation(row))
+        {
+            score += 10_000;
+        }
+        else if (HasAnyTranslatedContent(row))
+        {
+            score += 1_000;
+        }
+
+        if (!string.IsNullOrWhiteSpace(gameVersion) &&
+            string.Equals(
+                row.GameVersion,
+                gameVersion,
+                StringComparison.Ordinal))
+        {
+            score += 100;
+        }
+
+        if (string.IsNullOrWhiteSpace(row.GameVersion))
+        {
+            score += 10;
+        }
+
+        return score;
+    }
+
+    /// <summary>
+    ///     Gets whether the row carries any translated canonical payload that
+    ///     can be promoted to a newer game version.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <returns>True when the row contains translated content.</returns>
+    private static bool HasAnyTranslatedContent(ItemTooltip row)
+    {
+        return !string.IsNullOrWhiteSpace(row.TranslatedItemName) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedItemDescription) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTooltipText);
     }
 
     /// <summary>

--- a/Cache/TraitCacheManager.cs
+++ b/Cache/TraitCacheManager.cs
@@ -119,13 +119,68 @@ public static class TraitCacheManager
             return null;
         }
 
-        return rows.FirstOrDefault(row =>
-            row.TranslationLang == lang &&
-            row.TranslationEngine == engine &&
-            GameVersionLookupHelper.MatchesStoredVersion(
-                row.GameVersion,
-                gameVersion) &&
-            row.SourceContentHash == sourceContentHash);
+        return rows
+            .Where(row =>
+                RuntimeLanguageHelper.LanguagesMatch(
+                    row.TranslationLang,
+                    lang) &&
+                row.TranslationEngine == engine &&
+                GameVersionLookupHelper.MatchesStoredVersion(
+                    row.GameVersion,
+                    gameVersion) &&
+                row.SourceContentHash == sourceContentHash)
+            .OrderByDescending(row => ComputeCanonicalMatchScore(
+                row,
+                gameVersion))
+            .ThenByDescending(row => row.UpdatedDate)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    ///     Tries to find one historical version-specific canonical trait row
+    ///     whose source hash still matches the current payload.
+    /// </summary>
+    /// <param name="traitId">The trait row identifier.</param>
+    /// <param name="lang">The target language code.</param>
+    /// <param name="engine">The translation engine identifier.</param>
+    /// <param name="requestedGameVersion">The current game version.</param>
+    /// <param name="sourceContentHash">The stable source-content hash.</param>
+    /// <returns>The best matching historical row, or <see langword="null" />.</returns>
+    public static Trait? TryFindHistoricalCanonicalMatch(
+        uint traitId,
+        string lang,
+        int engine,
+        string? requestedGameVersion,
+        string sourceContentHash)
+    {
+        if (traitId == 0 ||
+            string.IsNullOrWhiteSpace(lang) ||
+            string.IsNullOrWhiteSpace(requestedGameVersion) ||
+            string.IsNullOrWhiteSpace(sourceContentHash))
+        {
+            return null;
+        }
+
+        if (!Cache.TryGetValue(traitId, out var rows) || rows.Count == 0)
+        {
+            return null;
+        }
+
+        return rows
+            .Where(row =>
+                RuntimeLanguageHelper.LanguagesMatch(
+                    row.TranslationLang,
+                    lang) &&
+                row.TranslationEngine == engine &&
+                row.SourceContentHash == sourceContentHash &&
+                !string.IsNullOrWhiteSpace(row.GameVersion) &&
+                !string.Equals(
+                    row.GameVersion,
+                    requestedGameVersion,
+                    StringComparison.Ordinal))
+            .OrderByDescending(static row => HasAnyTranslatedContent(row))
+            .ThenByDescending(row => row.UpdatedDate)
+            .FirstOrDefault();
     }
 
     /// <summary>
@@ -658,6 +713,58 @@ public static class TraitCacheManager
         }
 
         return score;
+    }
+
+    /// <summary>
+    ///     Computes one ordering score for exact source-hash matches so fully
+    ///     translated reusable rows beat current-version placeholders.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <param name="gameVersion">The requested game version.</param>
+    /// <returns>The ordering score.</returns>
+    private static int ComputeCanonicalMatchScore(
+        Trait row,
+        string? gameVersion)
+    {
+        var score = 0;
+
+        if (HasCompleteTranslation(row))
+        {
+            score += 10_000;
+        }
+        else if (HasAnyTranslatedContent(row))
+        {
+            score += 1_000;
+        }
+
+        if (!string.IsNullOrWhiteSpace(gameVersion) &&
+            string.Equals(
+                row.GameVersion,
+                gameVersion,
+                StringComparison.Ordinal))
+        {
+            score += 100;
+        }
+
+        if (string.IsNullOrWhiteSpace(row.GameVersion))
+        {
+            score += 10;
+        }
+
+        return score;
+    }
+
+    /// <summary>
+    ///     Gets whether the row carries any translated canonical payload that
+    ///     can be promoted to a newer game version.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <returns>True when the row contains translated content.</returns>
+    private static bool HasAnyTranslatedContent(Trait row)
+    {
+        return !string.IsNullOrWhiteSpace(row.TranslatedTraitName) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTraitDescription) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTooltipText);
     }
 
     /// <summary>

--- a/DBHelpers/ActionItemTooltipDbOperations.cs
+++ b/DBHelpers/ActionItemTooltipDbOperations.cs
@@ -36,7 +36,22 @@ public partial class Echoglossian
             probe.SourceContentHash);
         if (cached != null)
         {
+            if (!HasTranslatedActionTooltipContent(cached))
+            {
+                var promotedCached = this.TryPromoteHistoricalActionTooltip(probe);
+                if (promotedCached != null)
+                {
+                    return promotedCached;
+                }
+            }
+
             return cached;
+        }
+
+        var historical = this.TryPromoteHistoricalActionTooltip(probe);
+        if (historical != null)
+        {
+            return historical;
         }
 
         var row = ActionTooltipPersistenceHelper.FindActionTooltip(
@@ -86,7 +101,22 @@ public partial class Echoglossian
             probe.SourceContentHash);
         if (cached != null)
         {
+            if (!HasTranslatedTraitContent(cached))
+            {
+                var promotedCached = this.TryPromoteHistoricalTrait(probe);
+                if (promotedCached != null)
+                {
+                    return promotedCached;
+                }
+            }
+
             return cached;
+        }
+
+        var historical = this.TryPromoteHistoricalTrait(probe);
+        if (historical != null)
+        {
+            return historical;
         }
 
         var row = TraitPersistenceHelper.FindTrait(
@@ -136,7 +166,22 @@ public partial class Echoglossian
             probe.SourceContentHash);
         if (cached != null)
         {
+            if (!HasTranslatedItemTooltipContent(cached))
+            {
+                var promotedCached = this.TryPromoteHistoricalItemTooltip(probe);
+                if (promotedCached != null)
+                {
+                    return promotedCached;
+                }
+            }
+
             return cached;
+        }
+
+        var historical = this.TryPromoteHistoricalItemTooltip(probe);
+        if (historical != null)
+        {
+            return historical;
         }
 
         var row = ItemTooltipPersistenceHelper.FindItemTooltip(
@@ -161,5 +206,232 @@ public partial class Echoglossian
             ConfigDirectory,
             row,
             ItemTooltipCacheManager.Update);
+    }
+
+    /// <summary>
+    ///     Promotes one translated historical action-tooltip row to the
+    ///     current game version when the original payload hash still matches.
+    /// </summary>
+    /// <param name="probe">The current-version probe row.</param>
+    /// <returns>The promoted row, or <see langword="null" />.</returns>
+    private ActionTooltip? TryPromoteHistoricalActionTooltip(ActionTooltip probe)
+    {
+        if (!GameVersionLookupHelper.HasRequestedVersion(probe.GameVersion))
+        {
+            return null;
+        }
+
+        var translationLang = probe.TranslationLang!;
+        var sourceContentHash = probe.SourceContentHash!;
+        var historical = ActionTooltipCacheManager.TryFindHistoricalCanonicalMatch(
+            probe.ActionId,
+            translationLang,
+            probe.TranslationEngine ?? this.configuration.ChosenTransEngine,
+            probe.GameVersion,
+            sourceContentHash);
+        if (historical == null || !HasTranslatedActionTooltipContent(historical))
+        {
+            return null;
+        }
+
+        var promoted = CloneActionTooltipForGameVersion(historical, probe.GameVersion);
+        this.InsertActionTooltip(promoted);
+        return promoted;
+    }
+
+    /// <summary>
+    ///     Promotes one translated historical trait row to the current game
+    ///     version when the original payload hash still matches.
+    /// </summary>
+    /// <param name="probe">The current-version probe row.</param>
+    /// <returns>The promoted row, or <see langword="null" />.</returns>
+    private Trait? TryPromoteHistoricalTrait(Trait probe)
+    {
+        if (!GameVersionLookupHelper.HasRequestedVersion(probe.GameVersion))
+        {
+            return null;
+        }
+
+        var translationLang = probe.TranslationLang!;
+        var sourceContentHash = probe.SourceContentHash!;
+        var historical = TraitCacheManager.TryFindHistoricalCanonicalMatch(
+            probe.TraitId,
+            translationLang,
+            probe.TranslationEngine ?? this.configuration.ChosenTransEngine,
+            probe.GameVersion,
+            sourceContentHash);
+        if (historical == null || !HasTranslatedTraitContent(historical))
+        {
+            return null;
+        }
+
+        var promoted = CloneTraitForGameVersion(historical, probe.GameVersion);
+        this.InsertTrait(promoted);
+        return promoted;
+    }
+
+    /// <summary>
+    ///     Promotes one translated historical item-tooltip row to the current
+    ///     game version when the original payload hash still matches.
+    /// </summary>
+    /// <param name="probe">The current-version probe row.</param>
+    /// <returns>The promoted row, or <see langword="null" />.</returns>
+    private ItemTooltip? TryPromoteHistoricalItemTooltip(ItemTooltip probe)
+    {
+        if (!GameVersionLookupHelper.HasRequestedVersion(probe.GameVersion))
+        {
+            return null;
+        }
+
+        var translationLang = probe.TranslationLang!;
+        var sourceContentHash = probe.SourceContentHash!;
+        var historical = ItemTooltipCacheManager.TryFindHistoricalCanonicalMatch(
+            probe.ItemId,
+            translationLang,
+            probe.TranslationEngine ?? this.configuration.ChosenTransEngine,
+            probe.GameVersion,
+            sourceContentHash);
+        if (historical == null || !HasTranslatedItemTooltipContent(historical))
+        {
+            return null;
+        }
+
+        var promoted = CloneItemTooltipForGameVersion(historical, probe.GameVersion);
+        this.InsertItemTooltip(promoted);
+        return promoted;
+    }
+
+    /// <summary>
+    ///     Clones one canonical action-tooltip row for a newer game version.
+    /// </summary>
+    /// <param name="source">The historical row.</param>
+    /// <param name="gameVersion">The requested game version.</param>
+    /// <returns>The cloned row.</returns>
+    private static ActionTooltip CloneActionTooltipForGameVersion(
+        ActionTooltip source,
+        string? gameVersion)
+    {
+        return new ActionTooltip
+        {
+            ActionId = source.ActionId,
+            IconId = source.IconId,
+            ActionCategoryId = source.ActionCategoryId,
+            ClassJobId = source.ClassJobId,
+            ClassJobCategoryId = source.ClassJobCategoryId,
+            ActionName = source.ActionName,
+            ActionDescription = source.ActionDescription,
+            OriginalTooltipText = source.OriginalTooltipText,
+            OriginalLang = source.OriginalLang,
+            TranslatedActionName = source.TranslatedActionName,
+            TranslatedActionDescription = source.TranslatedActionDescription,
+            TranslatedTooltipText = source.TranslatedTooltipText,
+            TranslationLang = source.TranslationLang,
+            TranslationEngine = source.TranslationEngine,
+            GameVersion = gameVersion,
+            SourceContentHash = source.SourceContentHash,
+            CanonicalPayloadAsText = source.CanonicalPayloadAsText,
+        };
+    }
+
+    /// <summary>
+    ///     Clones one canonical trait row for a newer game version.
+    /// </summary>
+    /// <param name="source">The historical row.</param>
+    /// <param name="gameVersion">The requested game version.</param>
+    /// <returns>The cloned row.</returns>
+    private static Trait CloneTraitForGameVersion(
+        Trait source,
+        string? gameVersion)
+    {
+        return new Trait
+        {
+            TraitId = source.TraitId,
+            IconId = source.IconId,
+            ClassJobId = source.ClassJobId,
+            ClassJobCategoryId = source.ClassJobCategoryId,
+            TraitName = source.TraitName,
+            TraitDescription = source.TraitDescription,
+            OriginalTooltipText = source.OriginalTooltipText,
+            OriginalLang = source.OriginalLang,
+            TranslatedTraitName = source.TranslatedTraitName,
+            TranslatedTraitDescription = source.TranslatedTraitDescription,
+            TranslatedTooltipText = source.TranslatedTooltipText,
+            TranslationLang = source.TranslationLang,
+            TranslationEngine = source.TranslationEngine,
+            GameVersion = gameVersion,
+            SourceContentHash = source.SourceContentHash,
+            CanonicalPayloadAsText = source.CanonicalPayloadAsText,
+        };
+    }
+
+    /// <summary>
+    ///     Clones one canonical item-tooltip row for a newer game version.
+    /// </summary>
+    /// <param name="source">The historical row.</param>
+    /// <param name="gameVersion">The requested game version.</param>
+    /// <returns>The cloned row.</returns>
+    private static ItemTooltip CloneItemTooltipForGameVersion(
+        ItemTooltip source,
+        string? gameVersion)
+    {
+        return new ItemTooltip
+        {
+            ItemId = source.ItemId,
+            IconId = source.IconId,
+            ItemActionId = source.ItemActionId,
+            ItemUiCategoryId = source.ItemUiCategoryId,
+            ClassJobCategoryId = source.ClassJobCategoryId,
+            ItemName = source.ItemName,
+            ItemDescription = source.ItemDescription,
+            OriginalTooltipText = source.OriginalTooltipText,
+            OriginalLang = source.OriginalLang,
+            TranslatedItemName = source.TranslatedItemName,
+            TranslatedItemDescription = source.TranslatedItemDescription,
+            TranslatedTooltipText = source.TranslatedTooltipText,
+            TranslationLang = source.TranslationLang,
+            TranslationEngine = source.TranslationEngine,
+            GameVersion = gameVersion,
+            SourceContentHash = source.SourceContentHash,
+            CanonicalPayloadAsText = source.CanonicalPayloadAsText,
+        };
+    }
+
+    /// <summary>
+    ///     Gets whether one action-tooltip row already contains translated
+    ///     canonical content.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <returns>True when the row contains translated content.</returns>
+    private static bool HasTranslatedActionTooltipContent(ActionTooltip row)
+    {
+        return !string.IsNullOrWhiteSpace(row.TranslatedActionName) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedActionDescription) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTooltipText);
+    }
+
+    /// <summary>
+    ///     Gets whether one trait row already contains translated canonical
+    ///     content.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <returns>True when the row contains translated content.</returns>
+    private static bool HasTranslatedTraitContent(Trait row)
+    {
+        return !string.IsNullOrWhiteSpace(row.TranslatedTraitName) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTraitDescription) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTooltipText);
+    }
+
+    /// <summary>
+    ///     Gets whether one item-tooltip row already contains translated
+    ///     canonical content.
+    /// </summary>
+    /// <param name="row">The candidate row.</param>
+    /// <returns>True when the row contains translated content.</returns>
+    private static bool HasTranslatedItemTooltipContent(ItemTooltip row)
+    {
+        return !string.IsNullOrWhiteSpace(row.TranslatedItemName) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedItemDescription) ||
+               !string.IsNullOrWhiteSpace(row.TranslatedTooltipText);
     }
 }

--- a/Echoglossian.Tests/ActionTooltipCacheManagerTests.cs
+++ b/Echoglossian.Tests/ActionTooltipCacheManagerTests.cs
@@ -146,6 +146,105 @@ public class ActionTooltipCacheManagerTests
     }
 
     /// <summary>
+    ///     Ensures a same-hash translation from an older concrete game
+    ///     version can be recovered for promotion into the current version.
+    /// </summary>
+    [Fact]
+    public void TryFindHistoricalCanonicalMatch_ReturnsPreviousVersionSameHashRow()
+    {
+        ActionTooltipCacheManager.Clear();
+
+        try
+        {
+            ActionTooltipCacheManager.Update(new ActionTooltip
+            {
+                Id = 1,
+                ActionId = 15998,
+                ActionName = "Technical Step",
+                TranslationLang = "pt-BR",
+                TranslationEngine = 0,
+                GameVersion = "7.3",
+                SourceContentHash = "hash-exact",
+            });
+            ActionTooltipCacheManager.Update(new ActionTooltip
+            {
+                Id = 2,
+                ActionId = 15998,
+                ActionName = "Technical Step",
+                TranslatedActionName = "Passo Técnico",
+                TranslationLang = "pt-BR",
+                TranslationEngine = 0,
+                GameVersion = "7.2",
+                SourceContentHash = "hash-exact",
+            });
+
+            var found = ActionTooltipCacheManager.TryFindHistoricalCanonicalMatch(
+                15998,
+                "pt-BR",
+                0,
+                "7.3",
+                "hash-exact");
+
+            Assert.NotNull(found);
+            Assert.Equal("7.2", found.GameVersion);
+            Assert.Equal("Passo Técnico", found.TranslatedActionName);
+        }
+        finally
+        {
+            ActionTooltipCacheManager.Clear();
+        }
+    }
+
+    /// <summary>
+    ///     Ensures an untranslated current-version placeholder does not hide a
+    ///     reusable translated row with the same source hash.
+    /// </summary>
+    [Fact]
+    public void TryFindCanonicalMatch_PrefersTranslatedReusableRowOverCurrentPlaceholder()
+    {
+        ActionTooltipCacheManager.Clear();
+
+        try
+        {
+            ActionTooltipCacheManager.Update(new ActionTooltip
+            {
+                Id = 1,
+                ActionId = 15998,
+                ActionName = "Technical Step",
+                TranslationLang = "pt-BR",
+                TranslationEngine = 0,
+                GameVersion = "7.3",
+                SourceContentHash = "hash-exact",
+            });
+            ActionTooltipCacheManager.Update(new ActionTooltip
+            {
+                Id = 2,
+                ActionId = 15998,
+                ActionName = "Technical Step",
+                TranslatedActionName = "Passo Técnico",
+                TranslationLang = "pt-BR",
+                TranslationEngine = 0,
+                GameVersion = null,
+                SourceContentHash = "hash-exact",
+            });
+
+            var found = ActionTooltipCacheManager.TryFindCanonicalMatch(
+                15998,
+                "pt-BR",
+                0,
+                "7.3",
+                "hash-exact");
+
+            Assert.NotNull(found);
+            Assert.Equal("Passo Técnico", found.TranslatedActionName);
+        }
+        finally
+        {
+            ActionTooltipCacheManager.Clear();
+        }
+    }
+
+    /// <summary>
     ///     Ensures reverse lookup resolves a canonical original text from an
     ///     exact translated action name.
     /// </summary>

--- a/NativeUI/Helpers/ActionDetailPrefetchRuntime.cs
+++ b/NativeUI/Helpers/ActionDetailPrefetchRuntime.cs
@@ -41,7 +41,7 @@ public unsafe partial class Echoglossian
     /// </summary>
     private void TickActionDetailPrefetch()
     {
-        if (!this.ShouldPrefetchStructuredTooltips() ||
+        if (!this.ShouldPrefetchActionAdjacentCanonicalTooltips() ||
             DateTime.UtcNow - this.actionDetailPrefetchLastTickUtc <
             ActionDetailPrefetchTickInterval)
         {
@@ -118,7 +118,7 @@ public unsafe partial class Echoglossian
         byte currentClassJobId)
     {
         if (actionId == 0 ||
-            !this.ShouldPrefetchStructuredTooltips() ||
+            !this.ShouldPrefetchActionAdjacentCanonicalTooltips() ||
             !TryBuildActionTooltipCanonicalPayload(
                 actionId,
                 currentClassJobId,

--- a/NativeUI/Helpers/ItemDetailPrefetchRuntime.cs
+++ b/NativeUI/Helpers/ItemDetailPrefetchRuntime.cs
@@ -157,6 +157,19 @@ public unsafe partial class Echoglossian
     }
 
     /// <summary>
+    ///     Gets whether action-adjacent canonical tooltip rows should be
+    ///     prefetched for consumers such as <c>ActionMenu</c>.
+    /// </summary>
+    /// <returns>True when action-adjacent canonical prefetch should run.</returns>
+    private bool ShouldPrefetchActionAdjacentCanonicalTooltips()
+    {
+        return this.configuration.Translate &&
+               ClientStateInterface.IsLoggedIn &&
+               (this.configuration.TranslateTooltips ||
+                this.configuration.TranslateActionMenuWindow);
+    }
+
+    /// <summary>
     ///     Prefetches one canonical item-tooltip payload and any missing translations.
     /// </summary>
     /// <param name="itemId">The item row identifier.</param>

--- a/NativeUI/Helpers/TraitDetailPrefetchRuntime.cs
+++ b/NativeUI/Helpers/TraitDetailPrefetchRuntime.cs
@@ -32,7 +32,7 @@ public unsafe partial class Echoglossian
     /// </summary>
     private void TickTraitDetailPrefetch()
     {
-        if (!this.ShouldPrefetchStructuredTooltips() ||
+        if (!this.ShouldPrefetchActionAdjacentCanonicalTooltips() ||
             DateTime.UtcNow - this.traitDetailPrefetchLastTickUtc <
             TraitDetailPrefetchTickInterval)
         {


### PR DESCRIPTION
## Summary

- reuse canonical action, trait, and item tooltip rows across game versions when the original source hash did not change
- make `ActionMenu` prime action-adjacent canonical rows even when structured tooltip translation is disabled
- stop untranslated current-version placeholders from hiding reusable translated canonical rows

## Root Cause

`ActionMenu` was relying on exact current-version canonical tooltip rows too aggressively.
When the game version changed, older translated canonical rows with the same `SourceContentHash` were ignored, and a current-version placeholder or partial `GameWindow` row could win instead. That left some action labels untranslated even though the canonical translation already existed.

## What Changed

- added historical same-hash canonical lookup for `ActionTooltip`, `ItemTooltip`, and `Trait`
- promoted matching translated historical rows into the current game version during DB-first lookup
- ranked exact hash matches so translated reusable rows beat current-version untranslated placeholders
- widened action-adjacent canonical prefetch so `ActionMenu` can hydrate action/trait rows without requiring `TranslateTooltips`
- added regression coverage around same-hash historical reuse and placeholder-vs-translated selection

## Validation

- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build Echoglossian.csproj -c Release --no-restore`
  - the first `Release` attempt hit the known transient `DalamudPackager` lock on `Echoglossian.json`; rerunning passed cleanly