### PR TITLE
feat: unify game main menu controls and plugin terms

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -614,6 +614,156 @@ public class Config : IPluginConfiguration
   public JournalTranslationDisplayMode ActionMenuWindowTranslationDisplayMode =
       JournalTranslationDisplayMode.NativeUiTranslation;
 
+  /// <summary>
+  /// Gets a value indicating whether the game main menu scope is enabled.
+  /// </summary>
+  [JsonIgnore]
+  public bool TranslateGameMainMenu =>
+      this.TranslateMainCommandWindow ||
+      this.TranslateAddonContextMenuTitle;
+
+  /// <summary>
+  /// Gets the unified display mode for the game main menu scope.
+  /// </summary>
+  [JsonIgnore]
+  public JournalTranslationDisplayMode GameMainMenuWindowTranslationDisplayMode =>
+      this.ResolveGameMainMenuTranslationDisplayMode();
+
+  /// <summary>
+  /// Synchronizes the legacy MainCommand and AddonContextMenuTitle toggles so
+  /// they behave as one combined game-main-menu scope.
+  /// </summary>
+  /// <returns>
+  /// <see langword="true" /> when one or more values changed; otherwise
+  /// <see langword="false" />.
+  /// </returns>
+  public bool NormalizeGameMainMenuTranslationSettings()
+  {
+    var changed = false;
+    var unifiedEnabled = this.TranslateGameMainMenu;
+    var unifiedDisplayMode = this.ResolveGameMainMenuTranslationDisplayMode();
+
+    if (this.TranslateMainCommandWindow != unifiedEnabled)
+    {
+      this.TranslateMainCommandWindow = unifiedEnabled;
+      changed = true;
+    }
+
+    if (this.TranslateAddonContextMenuTitle != unifiedEnabled)
+    {
+      this.TranslateAddonContextMenuTitle = unifiedEnabled;
+      changed = true;
+    }
+
+    if (this.MainCommandWindowTranslationDisplayMode != unifiedDisplayMode)
+    {
+      this.MainCommandWindowTranslationDisplayMode = unifiedDisplayMode;
+      changed = true;
+    }
+
+    if (this.AddonContextMenuTitleTranslationDisplayMode != unifiedDisplayMode)
+    {
+      this.AddonContextMenuTitleTranslationDisplayMode = unifiedDisplayMode;
+      changed = true;
+    }
+
+    return changed;
+  }
+
+  /// <summary>
+  /// Sets the unified game-main-menu scope toggle and display mode.
+  /// </summary>
+  /// <param name="enabled">Whether translation is enabled for the scope.</param>
+  /// <param name="displayMode">The unified display mode.</param>
+  /// <returns>
+  /// <see langword="true" /> when one or more values changed; otherwise
+  /// <see langword="false" />.
+  /// </returns>
+  public bool SetGameMainMenuTranslationSettings(
+      bool enabled,
+      JournalTranslationDisplayMode displayMode)
+  {
+    var changed = false;
+
+    if (this.TranslateMainCommandWindow != enabled)
+    {
+      this.TranslateMainCommandWindow = enabled;
+      changed = true;
+    }
+
+    if (this.TranslateAddonContextMenuTitle != enabled)
+    {
+      this.TranslateAddonContextMenuTitle = enabled;
+      changed = true;
+    }
+
+    if (this.MainCommandWindowTranslationDisplayMode != displayMode)
+    {
+      this.MainCommandWindowTranslationDisplayMode = displayMode;
+      changed = true;
+    }
+
+    if (this.AddonContextMenuTitleTranslationDisplayMode != displayMode)
+    {
+      this.AddonContextMenuTitleTranslationDisplayMode = displayMode;
+      changed = true;
+    }
+
+    return changed;
+  }
+
+  /// <summary>
+  /// Resolves the unified display mode for the combined game main menu scope.
+  /// </summary>
+  /// <returns>The resolved unified display mode.</returns>
+  private JournalTranslationDisplayMode ResolveGameMainMenuTranslationDisplayMode()
+  {
+    if (this.AddonContextMenuTitleTranslationDisplayMode ==
+        this.MainCommandWindowTranslationDisplayMode)
+    {
+      return this.AddonContextMenuTitleTranslationDisplayMode;
+    }
+
+    if (this.TranslateAddonContextMenuTitle &&
+        !this.TranslateMainCommandWindow)
+    {
+      return this.AddonContextMenuTitleTranslationDisplayMode;
+    }
+
+    if (this.TranslateMainCommandWindow &&
+        !this.TranslateAddonContextMenuTitle)
+    {
+      return this.MainCommandWindowTranslationDisplayMode;
+    }
+
+    var mainCommandUsesDefault =
+        this.MainCommandWindowTranslationDisplayMode ==
+        JournalTranslationDisplayMode.NativeUiTranslation;
+    var addonContextUsesDefault =
+        this.AddonContextMenuTitleTranslationDisplayMode ==
+        JournalTranslationDisplayMode.NativeUiTranslation;
+
+    if (!this.AddonContextMenuTitleTranslationDisplayMode.Equals(
+            this.MainCommandWindowTranslationDisplayMode))
+    {
+      if (!this.AddonContextMenuTitleTranslationDisplayMode.Equals(
+              JournalTranslationDisplayMode.NativeUiTranslation) &&
+          mainCommandUsesDefault)
+      {
+        return this.AddonContextMenuTitleTranslationDisplayMode;
+      }
+
+      if (!this.MainCommandWindowTranslationDisplayMode.Equals(
+              JournalTranslationDisplayMode.NativeUiTranslation) &&
+          addonContextUsesDefault)
+      {
+        return this.MainCommandWindowTranslationDisplayMode;
+      }
+    }
+
+    return this.AddonContextMenuTitleTranslationDisplayMode;
+  }
+
   /// <summary>Translate HUD window text surfaces backed by StringArrayData.</summary>
   [DefaultValue(false)] public bool TranslateHudWindow = false;
 

--- a/Echoglossian.Tests/GameMainMenuConfigNormalizationTests.cs
+++ b/Echoglossian.Tests/GameMainMenuConfigNormalizationTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="GameMainMenuConfigNormalizationTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers unified config behavior for the shared game-main-menu scope.
+/// </summary>
+public class GameMainMenuConfigNormalizationTests
+{
+    /// <summary>
+    ///     Ensures the shared game-main-menu scope normalizes the
+    ///     AddonContextMenuTitle toggle and display mode when only MainCommand
+    ///     was previously enabled.
+    /// </summary>
+    [Fact]
+    public void NormalizeGameMainMenuTranslationSettings_MainCommandOnly_SynchronizesAddonContext()
+    {
+        var config = new Config
+        {
+            TranslateMainCommandWindow = true,
+            MainCommandWindowTranslationDisplayMode =
+                JournalTranslationDisplayMode.TooltipTranslation,
+            TranslateAddonContextMenuTitle = false,
+            AddonContextMenuTitleTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslation,
+            TranslateActionMenuWindow = false,
+            ActionMenuWindowTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslation,
+        };
+
+        var changed = config.NormalizeGameMainMenuTranslationSettings();
+
+        Assert.True(changed);
+        Assert.True(config.TranslateGameMainMenu);
+        Assert.True(config.TranslateMainCommandWindow);
+        Assert.True(config.TranslateAddonContextMenuTitle);
+        Assert.Equal(
+            JournalTranslationDisplayMode.TooltipTranslation,
+            config.GameMainMenuWindowTranslationDisplayMode);
+        Assert.Equal(
+            JournalTranslationDisplayMode.TooltipTranslation,
+            config.MainCommandWindowTranslationDisplayMode);
+        Assert.Equal(
+            JournalTranslationDisplayMode.TooltipTranslation,
+            config.AddonContextMenuTitleTranslationDisplayMode);
+        Assert.False(config.TranslateActionMenuWindow);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslation,
+            config.ActionMenuWindowTranslationDisplayMode);
+    }
+
+    /// <summary>
+    ///     Ensures the shared game-main-menu scope normalizes MainCommand when
+    ///     only AddonContextMenuTitle was previously enabled.
+    /// </summary>
+    [Fact]
+    public void NormalizeGameMainMenuTranslationSettings_AddonContextOnly_SynchronizesMainCommand()
+    {
+        var config = new Config
+        {
+            TranslateMainCommandWindow = false,
+            MainCommandWindowTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslation,
+            TranslateAddonContextMenuTitle = true,
+            AddonContextMenuTitleTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            TranslateActionMenuWindow = true,
+            ActionMenuWindowTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+        };
+
+        var changed = config.NormalizeGameMainMenuTranslationSettings();
+
+        Assert.True(changed);
+        Assert.True(config.TranslateGameMainMenu);
+        Assert.True(config.TranslateMainCommandWindow);
+        Assert.True(config.TranslateAddonContextMenuTitle);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            config.GameMainMenuWindowTranslationDisplayMode);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            config.MainCommandWindowTranslationDisplayMode);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            config.AddonContextMenuTitleTranslationDisplayMode);
+        Assert.True(config.TranslateActionMenuWindow);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            config.ActionMenuWindowTranslationDisplayMode);
+    }
+
+    /// <summary>
+    ///     Ensures explicit updates to the shared game-main-menu settings touch
+    ///     only MainCommand and AddonContextMenuTitle, not ActionMenu.
+    /// </summary>
+    [Fact]
+    public void SetGameMainMenuTranslationSettings_DoesNotModifyActionMenuSettings()
+    {
+        var config = new Config
+        {
+            TranslateMainCommandWindow = false,
+            TranslateAddonContextMenuTitle = false,
+            TranslateActionMenuWindow = true,
+            ActionMenuWindowTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+        };
+
+        var changed = config.SetGameMainMenuTranslationSettings(
+            true,
+            JournalTranslationDisplayMode.TooltipTranslation);
+
+        Assert.True(changed);
+        Assert.True(config.TranslateMainCommandWindow);
+        Assert.True(config.TranslateAddonContextMenuTitle);
+        Assert.Equal(
+            JournalTranslationDisplayMode.TooltipTranslation,
+            config.MainCommandWindowTranslationDisplayMode);
+        Assert.Equal(
+            JournalTranslationDisplayMode.TooltipTranslation,
+            config.AddonContextMenuTitleTranslationDisplayMode);
+        Assert.True(config.TranslateActionMenuWindow);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            config.ActionMenuWindowTranslationDisplayMode);
+    }
+
+    /// <summary>
+    ///     Ensures ActionMenu remains independent and does not enable the
+    ///     shared game-main-menu scope by itself.
+    /// </summary>
+    [Fact]
+    public void NormalizeGameMainMenuTranslationSettings_ActionMenuOnly_RemainsIndependent()
+    {
+        var config = new Config
+        {
+            TranslateMainCommandWindow = false,
+            TranslateAddonContextMenuTitle = false,
+            TranslateActionMenuWindow = true,
+            ActionMenuWindowTranslationDisplayMode =
+                JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+        };
+
+        var changed = config.NormalizeGameMainMenuTranslationSettings();
+
+        Assert.False(changed);
+        Assert.False(config.TranslateGameMainMenu);
+        Assert.False(config.TranslateMainCommandWindow);
+        Assert.False(config.TranslateAddonContextMenuTitle);
+        Assert.True(config.TranslateActionMenuWindow);
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            config.ActionMenuWindowTranslationDisplayMode);
+    }
+}

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -238,6 +238,7 @@ public partial class Echoglossian : IDalamudPlugin
 
     this.MigrateOverlayStyleSettings();
     this.MigrateOverlayDisplayModes();
+    this.MigrateGameMainMenuTranslationSettings();
     this.MigrateTranslationEngineSelection(loadedConfigVersion);
 
     SelectedLanguage = this.languagesDictionary[this.configuration.Lang];

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -32,6 +32,19 @@
             <param name="sourceContentHash">The stable source-content hash.</param>
             <returns>The matching row, or <see langword="null" />.</returns>
         </member>
+        <member name="M:Echoglossian.Cache.ActionTooltipCacheManager.TryFindHistoricalCanonicalMatch(System.UInt32,System.String,System.Int32,System.String,System.String)">
+            <summary>
+                Tries to find one historical version-specific canonical
+                action-tooltip row whose source hash still matches the current
+                payload.
+            </summary>
+            <param name="actionId">The action row identifier.</param>
+            <param name="lang">The target language code.</param>
+            <param name="engine">The translation engine identifier.</param>
+            <param name="requestedGameVersion">The current game version.</param>
+            <param name="sourceContentHash">The stable source-content hash.</param>
+            <returns>The best matching historical row, or <see langword="null" />.</returns>
+        </member>
         <member name="M:Echoglossian.Cache.ActionTooltipCacheManager.TryFindIdentityMatch(System.UInt32,System.String,System.Int32,System.String,System.UInt32,System.UInt32)">
             <summary>
                 Tries to find the best translated action-tooltip row by stable
@@ -192,6 +205,23 @@
                 The preferred class-job-category identifier.
             </param>
             <returns>The ordering score.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.ActionTooltipCacheManager.ComputeCanonicalMatchScore(Echoglossian.EFCoreSqlite.Models.ActionTooltip,System.String)">
+            <summary>
+                Computes one ordering score for exact source-hash matches so fully
+                translated reusable rows beat current-version placeholders.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <param name="gameVersion">The requested game version.</param>
+            <returns>The ordering score.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.ActionTooltipCacheManager.HasAnyTranslatedContent(Echoglossian.EFCoreSqlite.Models.ActionTooltip)">
+            <summary>
+                Gets whether the row carries any translated canonical payload that
+                can be promoted to a newer game version.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <returns>True when the row contains translated content.</returns>
         </member>
         <member name="M:Echoglossian.Cache.ActionTooltipCacheManager.HasCompleteTranslation(Echoglossian.EFCoreSqlite.Models.ActionTooltip)">
             <summary>
@@ -363,6 +393,19 @@
             <param name="sourceContentHash">The stable source-content hash.</param>
             <returns>The matching row, or <see langword="null" />.</returns>
         </member>
+        <member name="M:Echoglossian.Cache.ItemTooltipCacheManager.TryFindHistoricalCanonicalMatch(System.UInt32,System.String,System.Int32,System.String,System.String)">
+            <summary>
+                Tries to find one historical version-specific canonical
+                item-tooltip row whose source hash still matches the current
+                payload.
+            </summary>
+            <param name="itemId">The item row identifier.</param>
+            <param name="lang">The target language code.</param>
+            <param name="engine">The translation engine identifier.</param>
+            <param name="requestedGameVersion">The current game version.</param>
+            <param name="sourceContentHash">The stable source-content hash.</param>
+            <returns>The best matching historical row, or <see langword="null" />.</returns>
+        </member>
         <member name="M:Echoglossian.Cache.ItemTooltipCacheManager.TryFindIdentityMatch(System.UInt32,System.String,System.Int32,System.String,System.UInt32)">
             <summary>
                 Tries to find the best translated item-tooltip row by stable
@@ -393,6 +436,23 @@
                 The preferred class-job-category identifier.
             </param>
             <returns>The ordering score.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.ItemTooltipCacheManager.ComputeCanonicalMatchScore(Echoglossian.EFCoreSqlite.Models.ItemTooltip,System.String)">
+            <summary>
+                Computes one ordering score for exact source-hash matches so fully
+                translated reusable rows beat current-version placeholders.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <param name="gameVersion">The requested game version.</param>
+            <returns>The ordering score.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.ItemTooltipCacheManager.HasAnyTranslatedContent(Echoglossian.EFCoreSqlite.Models.ItemTooltip)">
+            <summary>
+                Gets whether the row carries any translated canonical payload that
+                can be promoted to a newer game version.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <returns>True when the row contains translated content.</returns>
         </member>
         <member name="M:Echoglossian.Cache.ItemTooltipCacheManager.HasCompleteTranslation(Echoglossian.EFCoreSqlite.Models.ItemTooltip)">
             <summary>
@@ -965,6 +1025,18 @@
             <param name="sourceContentHash">The stable source-content hash.</param>
             <returns>The matching row, or <see langword="null" />.</returns>
         </member>
+        <member name="M:Echoglossian.Cache.TraitCacheManager.TryFindHistoricalCanonicalMatch(System.UInt32,System.String,System.Int32,System.String,System.String)">
+            <summary>
+                Tries to find one historical version-specific canonical trait row
+                whose source hash still matches the current payload.
+            </summary>
+            <param name="traitId">The trait row identifier.</param>
+            <param name="lang">The target language code.</param>
+            <param name="engine">The translation engine identifier.</param>
+            <param name="requestedGameVersion">The current game version.</param>
+            <param name="sourceContentHash">The stable source-content hash.</param>
+            <returns>The best matching historical row, or <see langword="null" />.</returns>
+        </member>
         <member name="M:Echoglossian.Cache.TraitCacheManager.TryFindIdentityMatch(System.UInt32,System.String,System.Int32,System.String,System.UInt32,System.UInt32)">
             <summary>
                 Tries to find the best translated trait row by stable identity when
@@ -1123,6 +1195,23 @@
                 The preferred class-job-category identifier.
             </param>
             <returns>The ordering score.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.TraitCacheManager.ComputeCanonicalMatchScore(Echoglossian.EFCoreSqlite.Models.Trait,System.String)">
+            <summary>
+                Computes one ordering score for exact source-hash matches so fully
+                translated reusable rows beat current-version placeholders.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <param name="gameVersion">The requested game version.</param>
+            <returns>The ordering score.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.TraitCacheManager.HasAnyTranslatedContent(Echoglossian.EFCoreSqlite.Models.Trait)">
+            <summary>
+                Gets whether the row carries any translated canonical payload that
+                can be promoted to a newer game version.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <returns>True when the row contains translated content.</returns>
         </member>
         <member name="M:Echoglossian.Cache.TraitCacheManager.HasCompleteTranslation(Echoglossian.EFCoreSqlite.Models.Trait)">
             <summary>
@@ -1648,6 +1737,43 @@
         <member name="F:Echoglossian.Config.ActionMenuWindowTranslationDisplayMode">
             <summary>Display mode for the ActionMenu window.</summary>
         </member>
+        <member name="P:Echoglossian.Config.TranslateGameMainMenu">
+            <summary>
+            Gets a value indicating whether the game main menu scope is enabled.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Config.GameMainMenuWindowTranslationDisplayMode">
+            <summary>
+            Gets the unified display mode for the game main menu scope.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Config.NormalizeGameMainMenuTranslationSettings">
+            <summary>
+            Synchronizes the legacy MainCommand and AddonContextMenuTitle toggles so
+            they behave as one combined game-main-menu scope.
+            </summary>
+            <returns>
+            <see langword="true" /> when one or more values changed; otherwise
+            <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.Config.SetGameMainMenuTranslationSettings(System.Boolean,Echoglossian.JournalTranslationDisplayMode)">
+            <summary>
+            Sets the unified game-main-menu scope toggle and display mode.
+            </summary>
+            <param name="enabled">Whether translation is enabled for the scope.</param>
+            <param name="displayMode">The unified display mode.</param>
+            <returns>
+            <see langword="true" /> when one or more values changed; otherwise
+            <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.Config.ResolveGameMainMenuTranslationDisplayMode">
+            <summary>
+            Resolves the unified display mode for the combined game main menu scope.
+            </summary>
+            <returns>The resolved unified display mode.</returns>
+        </member>
         <member name="F:Echoglossian.Config.TranslateHudWindow">
             <summary>Translate HUD window text surfaces backed by StringArrayData.</summary>
         </member>
@@ -1980,6 +2106,78 @@
             </summary>
             <param name="row">The row to persist.</param>
             <returns>A status message describing the result.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryPromoteHistoricalActionTooltip(Echoglossian.EFCoreSqlite.Models.ActionTooltip)">
+            <summary>
+                Promotes one translated historical action-tooltip row to the
+                current game version when the original payload hash still matches.
+            </summary>
+            <param name="probe">The current-version probe row.</param>
+            <returns>The promoted row, or <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryPromoteHistoricalTrait(Echoglossian.EFCoreSqlite.Models.Trait)">
+            <summary>
+                Promotes one translated historical trait row to the current game
+                version when the original payload hash still matches.
+            </summary>
+            <param name="probe">The current-version probe row.</param>
+            <returns>The promoted row, or <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryPromoteHistoricalItemTooltip(Echoglossian.EFCoreSqlite.Models.ItemTooltip)">
+            <summary>
+                Promotes one translated historical item-tooltip row to the current
+                game version when the original payload hash still matches.
+            </summary>
+            <param name="probe">The current-version probe row.</param>
+            <returns>The promoted row, or <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.CloneActionTooltipForGameVersion(Echoglossian.EFCoreSqlite.Models.ActionTooltip,System.String)">
+            <summary>
+                Clones one canonical action-tooltip row for a newer game version.
+            </summary>
+            <param name="source">The historical row.</param>
+            <param name="gameVersion">The requested game version.</param>
+            <returns>The cloned row.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.CloneTraitForGameVersion(Echoglossian.EFCoreSqlite.Models.Trait,System.String)">
+            <summary>
+                Clones one canonical trait row for a newer game version.
+            </summary>
+            <param name="source">The historical row.</param>
+            <param name="gameVersion">The requested game version.</param>
+            <returns>The cloned row.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.CloneItemTooltipForGameVersion(Echoglossian.EFCoreSqlite.Models.ItemTooltip,System.String)">
+            <summary>
+                Clones one canonical item-tooltip row for a newer game version.
+            </summary>
+            <param name="source">The historical row.</param>
+            <param name="gameVersion">The requested game version.</param>
+            <returns>The cloned row.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.HasTranslatedActionTooltipContent(Echoglossian.EFCoreSqlite.Models.ActionTooltip)">
+            <summary>
+                Gets whether one action-tooltip row already contains translated
+                canonical content.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <returns>True when the row contains translated content.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.HasTranslatedTraitContent(Echoglossian.EFCoreSqlite.Models.Trait)">
+            <summary>
+                Gets whether one trait row already contains translated canonical
+                content.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <returns>True when the row contains translated content.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.HasTranslatedItemTooltipContent(Echoglossian.EFCoreSqlite.Models.ItemTooltip)">
+            <summary>
+                Gets whether one item-tooltip row already contains translated
+                canonical content.
+            </summary>
+            <param name="row">The candidate row.</param>
+            <returns>True when the row contains translated content.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.GetActiveConfiguration">
             <summary>
@@ -2525,6 +2723,13 @@
                 The configuration version loaded from disk
                 before migrations.
             </param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.MigrateGameMainMenuTranslationSettings">
+            <summary>
+                Migrates legacy separate MainCommand and AddonContextMenuTitle
+                translation settings into one unified game-main-menu scope while
+                preserving the existing persisted config fields.
+            </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.SaveConfig(Echoglossian.Config)">
             <summary>
@@ -3954,6 +4159,13 @@
                 Gets whether structured action/item tooltips should be prefetched.
             </summary>
             <returns>True when the background prefetch should run.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ShouldPrefetchActionAdjacentCanonicalTooltips">
+            <summary>
+                Gets whether action-adjacent canonical tooltip rows should be
+                prefetched for consumers such as <c>ActionMenu</c>.
+            </summary>
+            <returns>True when action-adjacent canonical prefetch should run.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.PrefetchItemDetail(System.UInt32)">
             <summary>
@@ -12423,7 +12635,7 @@
             <param name="snapshot">The cached original snapshot.</param>
             <returns>True when the scope already has an original snapshot.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.RememberJournalDetailOriginalSnapshot(FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase*,System.String,System.String,System.String,System.String,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.RememberJournalDetailOriginalSnapshot(System.String,System.String,System.String,System.String,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
                 Remembers the original JournalDetail texts for the current quest
                 scope so mode switches can restore native UI state correctly.
@@ -12433,8 +12645,6 @@
             <param name="questMessage">The original quest description.</param>
             <param name="objectiveText">The original visible objective text.</param>
             <param name="summaryText">The original visible summary text.</param>
-            <param name="descriptionNode">The live description text node.</param>
-            <param name="objectiveNode">The live objective text node, if any.</param>
             <param name="summaryNode">The live primary summary text node, if any.</param>
             <param name="summaryContainerNode">
                 The live summary container node, if any.
@@ -12445,119 +12655,6 @@
             <param name="additionalSummaryTexts">
                 The original visible supplemental summary texts.
             </param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.MergeJournalDetailOriginalSnapshotAdditionalNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase*,System.String,Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr})">
-            <summary>
-                Merges newly discovered supplemental summary nodes into the existing
-                JournalDetail original snapshot so later native restores and hover
-                bounds stay stable even if the addon exposes more summary nodes on a
-                later repaint.
-            </summary>
-            <param name="scopeKey">The current quest-detail scope key.</param>
-            <param name="originalSnapshot">The original snapshot for that scope.</param>
-            <param name="visibleAdditionalSummaryNodes">
-                The supplemental summary nodes visible on the current repaint.
-            </param>
-            <returns>The merged snapshot.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CreateJournalDetailOriginalSnapshot(FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase*,System.String,System.String,System.String,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String})">
-            <summary>
-                Creates one JournalDetail original snapshot, including the ordered
-                native reflow blocks and container chain used by native translation.
-            </summary>
-            <param name="journalBox">The live JournalDetail body component.</param>
-            <param name="questName">The original quest name.</param>
-            <param name="questMessage">The original quest message.</param>
-            <param name="objectiveText">The original visible objective text.</param>
-            <param name="summaryText">The original visible summary text.</param>
-            <param name="descriptionNode">The live description text node.</param>
-            <param name="objectiveNode">The live objective text node, if any.</param>
-            <param name="summaryNode">The live primary summary text node, if any.</param>
-            <param name="summaryContainerNode">The live summary container node, if any.</param>
-            <param name="additionalSummaryNodeAddresses">The supplemental summary nodes.</param>
-            <param name="additionalSummaryTexts">The original supplemental summary texts.</param>
-            <returns>The captured original snapshot.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.ApplyJournalDetailNativeTextNodePresentation(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,System.String)">
-            <summary>
-                Applies the native multiline presentation used by JournalDetail body
-                nodes when translated text is written into the game UI.
-            </summary>
-            <param name="textNode">The target text node.</param>
-            <param name="originalWidth">The original node width.</param>
-            <param name="originalTextFlags">The original text flags.</param>
-            <param name="originalFontSize">The original font size.</param>
-            <param name="text">The translated text to render.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.RestoreJournalDetailTextNodePresentation(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,System.String)">
-            <summary>
-                Restores the original JournalDetail presentation for a body text
-                node after leaving native translation mode.
-            </summary>
-            <param name="textNode">The target text node.</param>
-            <param name="originalWidth">The original node width.</param>
-            <param name="originalTextFlags">The original text flags.</param>
-            <param name="originalFontSize">The original font size.</param>
-            <param name="text">The original text to restore.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CaptureTextNodeLayout(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
-            <summary>
-                Captures the current layout metadata of a visible JournalDetail text
-                node so native mode can restore both presentation and position.
-            </summary>
-            <param name="textNode">The text node to snapshot.</param>
-            <returns>The captured layout, or <c>null</c> when the node is unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CaptureVisibleTextNodeLayouts(System.Collections.Generic.IEnumerable{System.IntPtr})">
-            <summary>
-                Captures the current layout metadata of the supplied text-node
-                addresses in their current display order.
-            </summary>
-            <param name="nodes">The visible text-node addresses.</param>
-            <returns>The captured node layouts.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.ApplyJournalDetailNativeSummaryFlow(Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IReadOnlyList{System.String})">
-            <summary>
-                Applies the translated JournalDetail summary block to the primary
-                summary node while clearing the supplemental summary nodes that would
-                otherwise leak original text underneath the native translation.
-            </summary>
-            <param name="originalSnapshot">The original quest-detail snapshot.</param>
-            <param name="summaryContainerNode">The live summary container node, if any.</param>
-            <param name="translatedSections">The translated summary sections in order.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.RestoreJournalDetailOriginalSummaryFlow(Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
-            <summary>
-                Restores the original JournalDetail summary-node positions,
-                presentation, and texts after leaving native translation mode.
-            </summary>
-            <param name="originalSnapshot">The original quest-detail snapshot.</param>
-            <param name="summaryContainerNode">The live summary container node, if any.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.TryApplyJournalDetailNativeBodyFlow(Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.Collections.Generic.IReadOnlyList{System.String})">
-            <summary>
-                Applies the translated JournalDetail native body flow using the
-                shared block-reflow helper when a flow snapshot is available.
-            </summary>
-            <param name="originalSnapshot">The original quest-detail snapshot.</param>
-            <param name="descriptionNode">The live description text node.</param>
-            <param name="translatedDescriptionText">The translated description text.</param>
-            <param name="objectiveNode">The live objective text node.</param>
-            <param name="translatedObjectiveText">The translated objective text.</param>
-            <param name="summaryNode">The live primary summary text node.</param>
-            <param name="translatedSummarySections">The translated summary sections.</param>
-            <returns><c>true</c> when the shared reflow helper handled the body flow.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.TryRestoreJournalDetailOriginalBodyFlow(Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
-            <summary>
-                Restores the original JournalDetail body flow using the shared
-                reflow helper when a flow snapshot is available.
-            </summary>
-            <param name="originalSnapshot">The original quest-detail snapshot.</param>
-            <param name="descriptionNode">The live description text node.</param>
-            <param name="objectiveNode">The live objective text node.</param>
-            <param name="summaryNode">The live primary summary text node.</param>
-            <returns><c>true</c> when the shared reflow helper handled the restore.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.TryGetJournalDetailCachedText(System.String,System.String,System.String@)">
             <summary>
@@ -12611,43 +12708,15 @@
             <param name="sections">The summary sections to join.</param>
             <returns>A deduplicated summary block for the JournalDetail body.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.NormalizeJournalDetailSummaryCandidateText(System.String)">
-            <summary>
-                Normalizes JournalDetail summary text for stable node-content
-                matching across live addon refreshes and native writes.
-            </summary>
-            <param name="text">The summary text to normalize.</param>
-            <returns>The normalized summary text.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.BuildJournalDetailSummaryTextCandidates(System.Collections.Generic.IEnumerable{System.String})">
-            <summary>
-                Builds the set of summary texts that should be considered part of the
-                active JournalDetail summary block on the current repaint.
-            </summary>
-            <param name="summarySections">The known summary sections.</param>
-            <returns>The normalized summary text candidates.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.MatchesJournalDetailSummaryCandidate(System.String,System.Collections.Generic.IReadOnlyCollection{System.String})">
-            <summary>
-                Gets whether a visible JournalDetail text node looks like one of the
-                known summary paragraphs for the active quest.
-            </summary>
-            <param name="visibleText">The current visible text of the node.</param>
-            <param name="summaryTextCandidates">The known summary texts.</param>
-            <returns><c>true</c> when the node text matches the summary set.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CollectVisibleAdditionalSummaryNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.Collections.Generic.IReadOnlyCollection{System.String})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CollectVisibleAdditionalSummaryNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
             <summary>
                 Collects the visible JournalDetail supplemental summary nodes in their
                 current display order.
             </summary>
-            <param name="journalBox">The live JournalDetail body component.</param>
+            <param name="journalBox">The live JournalDetail box component.</param>
             <param name="descriptionNode">The live description text node.</param>
             <param name="objectiveNode">The live objective text node.</param>
             <param name="summaryNode">The live primary summary text node, if any.</param>
-            <param name="summaryTextCandidates">
-                The normalized summary texts expected for the active quest.
-            </param>
             <returns>The visible supplemental summary text nodes.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CaptureVisibleTextNodeTexts(System.Collections.Generic.IEnumerable{System.IntPtr})">
@@ -12656,51 +12725,6 @@
             </summary>
             <param name="nodes">The visible text nodes.</param>
             <returns>The current visible text for each node.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CollectVisibleJournalDetailFlowTextNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr})">
-            <summary>
-                Collects the visible JournalDetail body-flow text nodes that should
-                participate in native vertical reflow.
-            </summary>
-            <param name="journalBox">The live JournalDetail body component.</param>
-            <param name="descriptionNode">The live description text node.</param>
-            <param name="objectiveNode">The live objective text node, if any.</param>
-            <param name="summaryNode">The live primary summary text node, if any.</param>
-            <param name="additionalSummaryNodeAddresses">The supplemental summary nodes.</param>
-            <returns>The ordered text-node addresses that belong to the body flow.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.CaptureJournalDetailNativeFlowContainers(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot})">
-            <summary>
-                Captures the container chain that should grow together with the
-                JournalDetail native body flow.
-            </summary>
-            <param name="flowRoot">The JournalDetail body-flow root node.</param>
-            <param name="flowBlocks">The captured ordered body-flow blocks.</param>
-            <returns>The captured container chain snapshots.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.BuildJournalDetailNativeFlowTextMap(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String})">
-            <summary>
-                Builds the translated or original text payloads that the JournalDetail
-                native body-flow reflow should apply.
-            </summary>
-            <param name="descriptionNode">The description text node.</param>
-            <param name="descriptionText">The description text to render.</param>
-            <param name="objectiveNode">The objective text node.</param>
-            <param name="objectiveText">The objective text to render.</param>
-            <param name="summaryNode">The primary summary text node.</param>
-            <param name="additionalSummaryNodeAddresses">The supplemental summary nodes.</param>
-            <param name="summarySections">The summary sections in display order.</param>
-            <returns>The node-address keyed text payloads.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.BuildJournalDetailSummaryNodeTextAssignments(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String})">
-            <summary>
-                Distributes JournalDetail summary sections across the currently
-                visible native summary nodes.
-            </summary>
-            <param name="summaryNode">The primary summary text node.</param>
-            <param name="additionalSummaryNodeAddresses">The supplemental summary nodes.</param>
-            <param name="summarySections">The summary sections in display order.</param>
-            <returns>The summary text payload keyed by node address.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.TryResolveTranslatedSummaryText(Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate,System.String,System.String,System.String,System.String@)">
             <summary>
@@ -12809,20 +12833,6 @@
             <param name="AdditionalSummaryTexts">
                 The original visible supplemental summary texts.
             </param>
-            <param name="DescriptionNodeWidth">The original description-node width.</param>
-            <param name="DescriptionNodeTextFlags">
-                The original description-node text flags.
-            </param>
-            <param name="DescriptionNodeFontSize">
-                The original description-node font size.
-            </param>
-            <param name="ObjectiveNodeWidth">The original objective-node width.</param>
-            <param name="ObjectiveNodeTextFlags">
-                The original objective-node text flags.
-            </param>
-            <param name="ObjectiveNodeFontSize">
-                The original objective-node font size.
-            </param>
             <param name="SummaryNodeWidth">The original primary summary node width.</param>
             <param name="SummaryContainerHeight">
                 The original summary container height.
@@ -12833,21 +12843,8 @@
             <param name="SummaryNodeFontSize">
                 The original primary summary node font size.
             </param>
-            <param name="SummaryNodeLayout">
-                The original primary summary node layout.
-            </param>
-            <param name="AdditionalSummaryNodeLayouts">
-                The original supplemental summary node layouts.
-            </param>
-            <param name="NativeFlowBlocks">
-                The ordered native body-flow block snapshots captured for reflow.
-            </param>
-            <param name="NativeFlowContainerSnapshots">
-                The container chain that should grow and restore with the native body
-                flow.
-            </param>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.#ctor(System.String,System.String,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String},System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout,System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout},System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot},System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.#ctor(System.String,System.String,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.IntPtr},System.Collections.Generic.IReadOnlyList{System.String},System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte)">
             <summary>
                 Stores the original JournalDetail texts for a single visible quest
                 scope so mode changes can restore native UI state and drive swap
@@ -12863,20 +12860,6 @@
             <param name="AdditionalSummaryTexts">
                 The original visible supplemental summary texts.
             </param>
-            <param name="DescriptionNodeWidth">The original description-node width.</param>
-            <param name="DescriptionNodeTextFlags">
-                The original description-node text flags.
-            </param>
-            <param name="DescriptionNodeFontSize">
-                The original description-node font size.
-            </param>
-            <param name="ObjectiveNodeWidth">The original objective-node width.</param>
-            <param name="ObjectiveNodeTextFlags">
-                The original objective-node text flags.
-            </param>
-            <param name="ObjectiveNodeFontSize">
-                The original objective-node font size.
-            </param>
             <param name="SummaryNodeWidth">The original primary summary node width.</param>
             <param name="SummaryContainerHeight">
                 The original summary container height.
@@ -12886,19 +12869,6 @@
             </param>
             <param name="SummaryNodeFontSize">
                 The original primary summary node font size.
-            </param>
-            <param name="SummaryNodeLayout">
-                The original primary summary node layout.
-            </param>
-            <param name="AdditionalSummaryNodeLayouts">
-                The original supplemental summary node layouts.
-            </param>
-            <param name="NativeFlowBlocks">
-                The ordered native body-flow block snapshots captured for reflow.
-            </param>
-            <param name="NativeFlowContainerSnapshots">
-                The container chain that should grow and restore with the native body
-                flow.
             </param>
         </member>
         <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.QuestName">
@@ -12923,32 +12893,6 @@
                 The original visible supplemental summary texts.
             </summary>
         </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.DescriptionNodeWidth">
-            <summary>The original description-node width.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.DescriptionNodeTextFlags">
-            <summary>
-                The original description-node text flags.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.DescriptionNodeFontSize">
-            <summary>
-                The original description-node font size.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.ObjectiveNodeWidth">
-            <summary>The original objective-node width.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.ObjectiveNodeTextFlags">
-            <summary>
-                The original objective-node text flags.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.ObjectiveNodeFontSize">
-            <summary>
-                The original objective-node font size.
-            </summary>
-        </member>
         <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.SummaryNodeWidth">
             <summary>The original primary summary node width.</summary>
         </member>
@@ -12966,74 +12910,6 @@
             <summary>
                 The original primary summary node font size.
             </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.SummaryNodeLayout">
-            <summary>
-                The original primary summary node layout.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.AdditionalSummaryNodeLayouts">
-            <summary>
-                The original supplemental summary node layouts.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.NativeFlowBlocks">
-            <summary>
-                The ordered native body-flow block snapshots captured for reflow.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailOriginalSnapshot.NativeFlowContainerSnapshots">
-            <summary>
-                The container chain that should grow and restore with the native body
-                flow.
-            </summary>
-        </member>
-        <member name="T:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout">
-            <summary>
-                Captures the original layout state for a JournalDetail body text
-                node.
-            </summary>
-            <param name="NodeAddress">The live text-node address.</param>
-            <param name="X">The original local X position.</param>
-            <param name="Y">The original local Y position.</param>
-            <param name="Width">The original node width.</param>
-            <param name="Height">The original node height.</param>
-            <param name="TextFlags">The original text flags.</param>
-            <param name="FontSize">The original font size.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.#ctor(System.IntPtr,System.Int16,System.Int16,System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte)">
-            <summary>
-                Captures the original layout state for a JournalDetail body text
-                node.
-            </summary>
-            <param name="NodeAddress">The live text-node address.</param>
-            <param name="X">The original local X position.</param>
-            <param name="Y">The original local Y position.</param>
-            <param name="Width">The original node width.</param>
-            <param name="Height">The original node height.</param>
-            <param name="TextFlags">The original text flags.</param>
-            <param name="FontSize">The original font size.</param>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.NodeAddress">
-            <summary>The live text-node address.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.X">
-            <summary>The original local X position.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.Y">
-            <summary>The original local Y position.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.Width">
-            <summary>The original node width.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.Height">
-            <summary>The original node height.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.TextFlags">
-            <summary>The original text flags.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.AddonHandlers.Quest.JournalDetailHandler.JournalDetailTextNodeLayout.FontSize">
-            <summary>The original font size.</summary>
         </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Quest.JournalHandler">
             <summary>
@@ -17937,228 +17813,6 @@
             <param name="body">The body text.</param>
             <returns>The combined tooltip text.</returns>
         </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper">
-            <summary>
-                Provides shared snapshot, reflow, and restore helpers for native UI
-                text flows where translated text can grow beyond the original English
-                layout budget.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.ResolveFlowWrapperNodeAddress(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
-            <summary>
-                Resolves the visual wrapper node address for one text node inside a
-                given flow root.
-            </summary>
-            <param name="flowRoot">The visual flow root that owns the blocks.</param>
-            <param name="textNode">The text node whose wrapper should be resolved.</param>
-            <returns>The resolved wrapper-node address.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.CaptureOrderedFlowBlocks(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Collections.Generic.IEnumerable{System.IntPtr})">
-            <summary>
-                Captures the ordered flow-block snapshots for the supplied text nodes.
-            </summary>
-            <param name="flowRoot">The visual flow root that owns the blocks.</param>
-            <param name="textNodeAddresses">The text nodes that participate in the flow.</param>
-            <returns>The captured ordered flow blocks.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.CaptureContainerSnapshot(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Int16,System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot})">
-            <summary>
-                Captures one container snapshot for a text flow.
-            </summary>
-            <param name="containerNode">The container node to snapshot.</param>
-            <param name="flowOriginY">
-                The vertical origin of the flow inside the container.
-            </param>
-            <param name="flowBlocks">The captured flow blocks.</param>
-            <returns>The captured container snapshot, or <see langword="null" />.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.ApplyVerticalTextFlow(System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot},System.Collections.Generic.IReadOnlyDictionary{System.IntPtr,System.String},Echoglossian.NativeUI.Helpers.NativeTextFlowApplyDelegate,System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot})">
-            <summary>
-                Applies translated text to an ordered native text flow and reflows
-                later blocks by cumulative height delta.
-            </summary>
-            <param name="flowBlocks">The ordered flow blocks.</param>
-            <param name="translatedTextsByTextNode">
-                The translated text keyed by text-node address.
-            </param>
-            <param name="applyText">
-                Delegate used to apply translated text with the desired presentation.
-            </param>
-            <param name="containerSnapshots">
-                The containers whose heights should grow with the flow.
-            </param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.RestoreVerticalTextFlow(System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot},System.Collections.Generic.IReadOnlyDictionary{System.IntPtr,System.String},Echoglossian.NativeUI.Helpers.NativeTextFlowApplyDelegate,System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot})">
-            <summary>
-                Restores an ordered native text flow to its original layout and text.
-            </summary>
-            <param name="flowBlocks">The ordered flow blocks.</param>
-            <param name="originalTextsByTextNode">
-                The original text keyed by text-node address.
-            </param>
-            <param name="restoreText">
-                Delegate used to restore the original text presentation.
-            </param>
-            <param name="containerSnapshots">
-                The container snapshots captured before native mutation.
-            </param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.ResolveWrapperNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
-            <summary>
-                Resolves the nearest visual wrapper node for a text node inside a
-                given flow root.
-            </summary>
-            <param name="flowRoot">The flow root owning the text flow.</param>
-            <param name="textNode">The text node being wrapped.</param>
-            <returns>The resolved wrapper node.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.CalculateNodeOffsetToAncestor(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
-            <summary>
-                Calculates the local offset between one node and one ancestor node.
-            </summary>
-            <param name="node">The descendant node.</param>
-            <param name="ancestorNode">The ancestor node.</param>
-            <returns>The accumulated local offset from the ancestor to the node.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.ApplyContainerHeights(System.Collections.Generic.IReadOnlyList{Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot},System.Single)">
-            <summary>
-                Applies container height growth after the text flow has been reflowed.
-            </summary>
-            <param name="containerSnapshots">The captured container snapshots.</param>
-            <param name="finalBottom">The last occupied vertical pixel of the flow.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowReflowHelper.ClampToShort(System.Single)">
-            <summary>
-                Clamps one local coordinate to the short range expected by native
-                node positioning helpers.
-            </summary>
-            <param name="value">The coordinate to clamp.</param>
-            <returns>The clamped coordinate.</returns>
-        </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.NativeTextFlowApplyDelegate">
-            <summary>
-                Applies one translated or restored text payload to a native text node
-                using its original presentation metadata.
-            </summary>
-            <param name="textNode">The target text node.</param>
-            <param name="originalWidth">The original text-node width.</param>
-            <param name="originalTextFlags">The original text flags.</param>
-            <param name="originalFontSize">The original font size.</param>
-            <param name="text">The text to render.</param>
-        </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot">
-            <summary>
-                Captures one reflowable native text block.
-            </summary>
-            <param name="WrapperNodeAddress">The wrapper node address.</param>
-            <param name="WrapperX">The original wrapper X.</param>
-            <param name="WrapperY">The original wrapper Y.</param>
-            <param name="WrapperWidth">The original wrapper width.</param>
-            <param name="WrapperHeight">The original wrapper height.</param>
-            <param name="TextNodeAddress">The inner text-node address.</param>
-            <param name="TextOffsetX">The original text offset X inside the wrapper.</param>
-            <param name="TextOffsetY">The original text offset Y inside the wrapper.</param>
-            <param name="TextWidth">The original text-node width.</param>
-            <param name="TextHeight">The original text-node height.</param>
-            <param name="TextFlags">The original text flags.</param>
-            <param name="FontSize">The original font size.</param>
-            <param name="BottomPadding">
-                The original bottom padding between the text bottom and wrapper bottom.
-            </param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.#ctor(System.IntPtr,System.Int16,System.Int16,System.UInt16,System.UInt16,System.IntPtr,System.Int16,System.Int16,System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,System.Int16)">
-            <summary>
-                Captures one reflowable native text block.
-            </summary>
-            <param name="WrapperNodeAddress">The wrapper node address.</param>
-            <param name="WrapperX">The original wrapper X.</param>
-            <param name="WrapperY">The original wrapper Y.</param>
-            <param name="WrapperWidth">The original wrapper width.</param>
-            <param name="WrapperHeight">The original wrapper height.</param>
-            <param name="TextNodeAddress">The inner text-node address.</param>
-            <param name="TextOffsetX">The original text offset X inside the wrapper.</param>
-            <param name="TextOffsetY">The original text offset Y inside the wrapper.</param>
-            <param name="TextWidth">The original text-node width.</param>
-            <param name="TextHeight">The original text-node height.</param>
-            <param name="TextFlags">The original text flags.</param>
-            <param name="FontSize">The original font size.</param>
-            <param name="BottomPadding">
-                The original bottom padding between the text bottom and wrapper bottom.
-            </param>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.WrapperNodeAddress">
-            <summary>The wrapper node address.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.WrapperX">
-            <summary>The original wrapper X.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.WrapperY">
-            <summary>The original wrapper Y.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.WrapperWidth">
-            <summary>The original wrapper width.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.WrapperHeight">
-            <summary>The original wrapper height.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.TextNodeAddress">
-            <summary>The inner text-node address.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.TextOffsetX">
-            <summary>The original text offset X inside the wrapper.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.TextOffsetY">
-            <summary>The original text offset Y inside the wrapper.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.TextWidth">
-            <summary>The original text-node width.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.TextHeight">
-            <summary>The original text-node height.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.TextFlags">
-            <summary>The original text flags.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.FontSize">
-            <summary>The original font size.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowBlockSnapshot.BottomPadding">
-            <summary>
-                The original bottom padding between the text bottom and wrapper bottom.
-            </summary>
-        </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot">
-            <summary>
-                Captures one container that should grow together with a native text
-                flow.
-            </summary>
-            <param name="ContainerNodeAddress">The container node address.</param>
-            <param name="FlowOriginY">The flow origin Y inside the container.</param>
-            <param name="Height">The original container height.</param>
-            <param name="BottomPadding">The original bottom padding below the flow.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot.#ctor(System.IntPtr,System.Int16,System.UInt16,System.Int16)">
-            <summary>
-                Captures one container that should grow together with a native text
-                flow.
-            </summary>
-            <param name="ContainerNodeAddress">The container node address.</param>
-            <param name="FlowOriginY">The flow origin Y inside the container.</param>
-            <param name="Height">The original container height.</param>
-            <param name="BottomPadding">The original bottom padding below the flow.</param>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot.ContainerNodeAddress">
-            <summary>The container node address.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot.FlowOriginY">
-            <summary>The flow origin Y inside the container.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot.Height">
-            <summary>The original container height.</summary>
-        </member>
-        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextFlowContainerSnapshot.BottomPadding">
-            <summary>The original bottom padding below the flow.</summary>
-        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.PayloadStabilityTracker">
             <summary>
                 Tracks whether one payload signature has remained unchanged for long
@@ -19555,6 +19209,14 @@
         <member name="M:Echoglossian.PluginUI.Tabs.GameWindowsTab.Draw(Echoglossian.Config)">
             <summary>
                 Draws the game-windows settings tab.
+            </summary>
+            <param name="config">The current plugin configuration.</param>
+            <returns><c>true</c> when a setting changed.</returns>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Tabs.GameWindowsTab.DrawGameMainMenuSection(Echoglossian.Config)">
+            <summary>
+                Draws the unified game-main-menu section that controls both
+                <c>_MainCommand</c> and <c>AddonContextMenuTitle</c>.
             </summary>
             <param name="config">The current plugin configuration.</param>
             <returns><c>true</c> when a setting changed.</returns>

--- a/GeneralHelpers/RuntimeConfigurationRefresh.cs
+++ b/GeneralHelpers/RuntimeConfigurationRefresh.cs
@@ -163,10 +163,9 @@ public partial class Echoglossian
     return JsonConvert.SerializeObject(
         new
         {
-          this.configuration.TranslateAddonContextMenuTitle,
           this.configuration.TranslateOperationGuideWindow,
           this.configuration.TranslateHudWindow,
-          this.configuration.TranslateMainCommandWindow,
+          this.configuration.TranslateGameMainMenu,
           this.configuration.TranslateActionMenuWindow,
           this.configuration.TranslateCharacterWindow,
           this.configuration.TranslateTalk,

--- a/GeneralHelpers/Utils.cs
+++ b/GeneralHelpers/Utils.cs
@@ -421,10 +421,24 @@ public partial class Echoglossian
   }
 
   /// <summary>
+  ///     Migrates legacy separate MainCommand and AddonContextMenuTitle
+  ///     translation settings into one unified game-main-menu scope while
+  ///     preserving the existing persisted config fields.
+  /// </summary>
+  public void MigrateGameMainMenuTranslationSettings()
+  {
+    if (this.configuration.NormalizeGameMainMenuTranslationSettings())
+    {
+      SaveConfig(this.configuration);
+    }
+  }
+
+  /// <summary>
   ///     Saves the current configuration to the plugin config file.
   /// </summary>
   public static void SaveConfig(Config config)
   {
+    config.NormalizeGameMainMenuTranslationSettings();
     TranslationEngineSelectionMigrationHelper.NormalizeAndSyncSelection(
         config,
         config.Version);
@@ -449,6 +463,7 @@ public partial class Echoglossian
   /// </summary>
   public void RebuildTranslationServiceSafely()
   {
+    this.configuration.NormalizeGameMainMenuTranslationSettings();
     TranslationEngineSelectionMigrationHelper.NormalizeAndSyncSelection(
         this.configuration,
         this.configuration.Version,

--- a/NativeUI/AddonHandlers/MainMenu/AddonContextMenuTitleHandler.cs
+++ b/NativeUI/AddonHandlers/MainMenu/AddonContextMenuTitleHandler.cs
@@ -30,11 +30,11 @@ public class AddonContextMenuTitleHandler : DbFirstGameWindowAddonHandler
             hoverTooltipManager: hoverTooltipManager,
             translationService: translationService,
             enabledSelector: static configuration =>
-                configuration.TranslateAddonContextMenuTitle,
+                configuration.TranslateGameMainMenu,
             useAtkValues: false,
             useTextNodes: true,
             displayModeSelector: static configuration =>
-                configuration.AddonContextMenuTitleTranslationDisplayMode)
+                configuration.GameMainMenuWindowTranslationDisplayMode)
     {
     }
 

--- a/NativeUI/AddonHandlers/MainMenu/MainCommandHandler.cs
+++ b/NativeUI/AddonHandlers/MainMenu/MainCommandHandler.cs
@@ -39,11 +39,11 @@ public unsafe class MainCommandHandler : DbFirstGameWindowAddonHandler
             hoverTooltipManager: hoverTooltipManager,
             translationService: translationService,
             enabledSelector: static configuration =>
-                configuration.TranslateMainCommandWindow,
+                configuration.TranslateGameMainMenu,
             useAtkValues: true,
             useTextNodes: false,
             displayModeSelector: static configuration =>
-                configuration.MainCommandWindowTranslationDisplayMode)
+                configuration.GameMainMenuWindowTranslationDisplayMode)
     {
         this.config = config;
     }
@@ -187,7 +187,7 @@ public unsafe class MainCommandHandler : DbFirstGameWindowAddonHandler
         }
 
         var displayMode = TranslationDisplayModeHelper.GetEffectiveDisplayMode(
-            this.config.MainCommandWindowTranslationDisplayMode,
+            this.config.GameMainMenuWindowTranslationDisplayMode,
             this.config.OverlayOnlyLanguage);
 
         if (TranslationDisplayModeHelper.WritesNativeTranslation(displayMode))

--- a/NativeUI/Helpers/AddonHandlerWiring.cs
+++ b/NativeUI/Helpers/AddonHandlerWiring.cs
@@ -18,16 +18,6 @@ public partial class Echoglossian
         [
         ];
 
-    if (this.configuration.TranslateAddonContextMenuTitle)
-    {
-      this.registeredAddonHandlers.Add(
-          (AddonName: "AddonContextMenuTitle",
-              Handler: new AddonContextMenuTitleHandler(
-                  this.configuration,
-                  this.hoverTooltipManager,
-                  TranslationService)));
-    }
-
     if (this.configuration.TranslateOperationGuideWindow)
     {
       this.registeredAddonHandlers.Add(
@@ -54,8 +44,14 @@ public partial class Echoglossian
                   TranslationService)));
     }
 
-    if (this.configuration.TranslateMainCommandWindow)
+    if (this.configuration.TranslateGameMainMenu)
     {
+      this.registeredAddonHandlers.Add(
+          (AddonName: "AddonContextMenuTitle",
+              Handler: new AddonContextMenuTitleHandler(
+                  this.configuration,
+                  this.hoverTooltipManager,
+                  TranslationService)));
       this.registeredAddonHandlers.Add(
           (AddonName: "_MainCommand",
               Handler: new MainCommandHandler(

--- a/PluginUI/Tabs/GameWindowsTab.cs
+++ b/PluginUI/Tabs/GameWindowsTab.cs
@@ -25,11 +25,7 @@ public static class GameWindowsTab
             Resources.TranslateCharacterWindow,
             ref config.TranslateCharacterWindow,
             ref config.CharacterWindowTranslationDisplayMode);
-        changed |= DrawWindowSection(
-            config,
-            Resources.TranslateMainCommandWindow,
-            ref config.TranslateMainCommandWindow,
-            ref config.MainCommandWindowTranslationDisplayMode);
+        changed |= DrawGameMainMenuSection(config);
         changed |= DrawWindowSection(
             config,
             Resources.TranslateActionMenuWindow,
@@ -45,12 +41,6 @@ public static class GameWindowsTab
             Resources.TranslateOperationGuideWindow,
             ref config.TranslateOperationGuideWindow,
             ref config.OperationGuideTranslationDisplayMode);
-        changed |= DrawWindowSection(
-            config,
-            Resources.TranslateAddonContextMenuTitleWindow,
-            ref config.TranslateAddonContextMenuTitle,
-            ref config.AddonContextMenuTitleTranslationDisplayMode);
-
         if (changed)
         {
             FieldValidationHelper.MarkAllRequiredFieldsTouched(config);
@@ -58,6 +48,38 @@ public static class GameWindowsTab
         }
 
         return changed;
+    }
+
+    /// <summary>
+    ///     Draws the unified game-main-menu section that controls both
+    ///     <c>_MainCommand</c> and <c>AddonContextMenuTitle</c>.
+    /// </summary>
+    /// <param name="config">The current plugin configuration.</param>
+    /// <returns><c>true</c> when a setting changed.</returns>
+    private static bool DrawGameMainMenuSection(Config config)
+    {
+        var enabled = config.TranslateGameMainMenu;
+        var displayMode = config.GameMainMenuWindowTranslationDisplayMode;
+        var changed = false;
+
+        ImGui.Spacing();
+        ImGui.TextUnformatted(Resources.TranslateMainCommandWindow);
+        ImGui.Separator();
+
+        changed |= ImGui.Checkbox(Resources.TranslateMainCommandWindow, ref enabled);
+        changed |= TranslationDisplayModeUiHelper.DrawDisplayModeCombo(
+            Resources.TranslateMainCommandWindow,
+            ref displayMode,
+            config.OverlayOnlyLanguage);
+
+        if (!changed)
+        {
+            return false;
+        }
+
+        return config.SetGameMainMenuTranslationSettings(
+            enabled,
+            displayMode);
     }
 
     /// <summary>

--- a/Properties/Resources.da.resx
+++ b/Properties/Resources.da.resx
@@ -68,7 +68,7 @@
     <comment>Shown in plugin install window</comment>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Juster de indstillinger, der er relateret til oversættelsesoverlejringen:</value>
+    <value>Juster de indstillinger, der er relateret til Plugin Overlay:</value>
   </data>
   <data name="LangIdentError" xml:space="preserve">
     <value>Sproget kunne ikke identificeres med en acceptabel grad af sikkerhed</value>
@@ -77,7 +77,7 @@
     <value>Det valgte sprog understøttes ikke af den aktuelt tilgængelige oversættelses-backend</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>Det valgte sprog understøttes kun ved hjælp af plugin-overlejringer på grund af begrænsningerne i det oprindelige spil Font</value>
+    <value>Det valgte sprog understøttes kun ved hjælp af Plugin Overlay på grund af begrænsningerne i det oprindelige spil Font</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>Hvilket sprog du skal oversætte de in-game dialogbokse til.</value>
@@ -89,25 +89,25 @@
     <value>Den ikke-udtømmende liste over spørgsmål og TODO'er er tilgængelig i linket nedenfor:</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Juster placeringen, hvis overlejringen ikke er centreret i forhold til spillets tekstboks til brugergrænsefladen.</value>
+    <value>Juster placeringen, hvis Plugin Overlay ikke er centreret i forhold til spillets tekstboks til brugergrænsefladen.</value>
   </data>
   <data name="OverlayColorSelectName" xml:space="preserve">
     <value>OverlayColorSelect</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Klik her for at vælge skriftfarven overlejring</value>
+    <value>Klik her for at vælge skriftfarven Plugin Overlay</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Justere skriftskalaen Overlejring</value>
+    <value>Justere skriftskalaen Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Overlejring af skriftstørrelse</value>
+    <value>Plugin Overlay af skriftstørrelse</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Vælge skriftstørrelsen for tekstoverlejringen</value>
+    <value>Vælge skriftstørrelsen for tekstPlugin Overlay</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Multiplikator for overlejring af oversættelsesoverlejring</value>
+    <value>Multiplikator for Plugin Overlay af Plugin Overlay</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Battle talk (Enenies dialog linjer) oversættelse</value>
@@ -117,13 +117,13 @@
     <value>Positionsjustering</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Vis oversat tekstoverlejring over tekstboksen i brugergrænsefladen i spillet i stedet for at erstatte teksten med oversættelsen</value>
+    <value>Vis oversat tekstPlugin Overlay over tekstboksen i brugergrænsefladen i spillet i stedet for at erstatte teksten med oversættelsen</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Juster bredden af overlejring af oversættelse</value>
+    <value>Juster bredden af Plugin Overlay af oversættelse</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplikator for overlejring af oversættelsesoverlejring</value>
+    <value>Multiplikator for Plugin Overlay af Plugin Overlay</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Absolut sti til Echoglossian mappe (inde XIVLauncher -&gt; pluginConfigs mappe)</value>
@@ -159,13 +159,13 @@
     <value>Indstillinger for Google Translate:</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Vis original dialogtekst i Overlejring og Oversat i dialogboksen Spilgrænseflade</value>
+    <value>Vis original dialogtekst i Plugin Overlay og Oversat i dialogboksen Spilgrænseflade</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Juster bredden af overlejring af toastoversættelse</value>
+    <value>Juster bredden af Plugin Overlay af toastoversættelse</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplikator for toastoverlejringsbredde</value>
+    <value>Multiplikator for Plugin Overlay</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>TODOs Liste på Github</value>
@@ -210,7 +210,7 @@
     <value>Oversættelser aktiveret!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Brug overlejring til at vise Toasts-oversættelser</value>
+    <value>Brug Plugin Overlay til at vise Toasts-oversættelser</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>Afventer oversættelse...</value>
@@ -618,10 +618,10 @@
     <value>Detaljevisningstilstand</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Denne tilstand styrer overfladerne ActionDetail og ItemDetail. Native UI skriver den oversatte detaljetekst ind i spiltilføjelsen, kun overlejring holder den oprindelige tilføjelse intakt og bruger Echoglossian overlejringer, og native-med-original-overlejring skriver indbygget oversættelse, mens originalen vises i vores overlejring.</value>
+    <value>Denne tilstand styrer ActionDetail- og ItemDetail-overfladerne. Native UI skriver den oversatte detaljetekst ind i spiltilføjelsen, Plugin Overlay translation only holder den oprindelige tilføjelse intakt og bruger Plugin Overlays, og Native UI translation + original Plugin Overlay skriver oversættelsen nativt, mens originalen vises i vores Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Aktiver oversættelse af handlings-/elementdetaljer og delte værktøjstip til svævemarkering</value>
+    <value>Aktiver oversættelse af handlings-/elementdetaljer og delte Plugin Tooltips</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Kunne ikke hente modeller. Kører Ollama lokalt?</value>
@@ -633,46 +633,46 @@
     <value>Spil vinduer</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Disse farver gælder for Echoglossian hover værktøjstip, der bruges af quest og DB-first UI overflader.</value>
+    <value>Disse farver gælder for Plugin Tooltips, der bruges af quest- og DB-first-UI-overflader.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Hover værktøjstip udseende</value>
+    <value>Hover Plugin Tooltip udseende</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Værktøjstip baggrundsfarve</value>
+    <value>Plugin Tooltip baggrundsfarve</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Værktøjstip baggrundsopacitet</value>
+    <value>Plugin Tooltip baggrundsopacitet</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Værktøjstip tekstfarve</value>
+    <value>Plugin Tooltip tekstfarve</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Denne tilstand styrer Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept og JournalResult. Værktøjstip for svævejournal følger denne tilstand direkte; det globale værktøjstip-skift påvirker kun andre oversatte brugergrænseflader.</value>
+    <value>Denne tilstand styrer Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept og JournalResult. Journal Plugin Tooltips følger denne tilstand direkte; det globale Plugin Tooltip-skift påvirker kun anden oversat UI.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Visningstilstand for Journal quest</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>Indbygget erstatningstilstand er aktiv for denne toasttype. Overlay-stilkontroller bruges ikke i denne tilstand.</value>
+    <value>Indbygget erstatningstilstand er aktiv for denne toasttype. Plugin Overlay-stilkontroller bruges ikke i denne tilstand.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Denne tilstand styrer, hvordan den oversatte tekst præsenteres. Native UI skriver direkte ind i spiltilføjelsen, kun overlejring lader den native tilføjelse være urørt, og native-med-original-overlay skriver oversættelse native, mens originalen vises i overlejringen.</value>
+    <value>Denne tilstand styrer, hvordan den oversatte tekst præsenteres. Native UI skriver direkte ind i spiltilføjelsen, kun Plugin Overlay lader den native tilføjelse være urørt, og Native UI translation + original Plugin Overlay skriver oversættelse native, mens originalen vises i Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Native UI oversættelse + original overlejring</value>
+    <value>Native UI oversættelse + original Plugin Overlay</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
-    <value>Kun overlejringsoversættelse</value>
+    <value>Kun Plugin Overlay</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Vis overlejringstitellinje med højttalernavn, når det er tilgængeligt</value>
+    <value>Vis Plugin Overlay med højttalernavn, når det er tilgængeligt</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>Kun overlejringssprog er aktivt, så alle toasttyper gengives gennem overlejringer.</value>
+    <value>Kun Plugin Overlay er aktivt, så alle toasttyper gengives gennem Plugin Overlay.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>Det valgte sprog understøtter ikke den oprindelige spilskrifttype, så denne overflade er begrænset til Echoglossian overlejringer og brugerdefinerede værktøjstip.</value>
+    <value>Det valgte sprog understøtter ikke den oprindelige spilskrifttype, så denne overflade er begrænset til Plugin Overlays og Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -681,7 +681,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Denne tilstand styrer, hvordan dette questvindue præsenteres. Native UI skriver oversættelsen til tilføjelsen, kun værktøjstip holder tilføjelsen intakt, og native-med-original-værktøjstip skriver oversættelse native, mens originalen vises i værktøjstip.</value>
+    <value>Denne tilstand styrer, hvordan dette questvindue præsenteres. Native UI skriver oversættelsen til tilføjelsen, Plugin Tooltip translation only holder tilføjelsen intakt, og Native UI translation + original Plugin Tooltips skriver oversættelsen nativt, mens originalen vises i Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Quest-visningstilstand</value>
@@ -690,10 +690,10 @@
     <value>Native UI oversættelse</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI oversættelse + originale værktøjstip</value>
+    <value>Native UI oversættelse + originale Plugin Tooltip</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Kun oversættelse af værktøjstip</value>
+    <value>Kun oversættelse af Plugin Tooltip</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Quest vinduer</value>
@@ -720,10 +720,10 @@
     <value>Oversættelse er i øjeblikket deaktiveret, fordi det valgte sprog kræver ekstra skrifttypeaktiver. Åbn konfigurationsvinduet for at downloade eller validere de nødvendige filer.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Hver toasttype kan vælge uafhængigt mellem native erstatning og overlay-gengivelse.</value>
+    <value>Hver toasttype kan vælge uafhængigt mellem native erstatning og Plugin Overlay-gengivelse.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Når en toasttype bruger overlejringstilstand, kan du også bytte tekster, så overlejringen beholder den oprindelige linje, mens den oprindelige toast viser oversættelsen.</value>
+    <value>Når en toasttype bruger Plugin Overlay, kan du også bytte tekster, så Plugin Overlay beholder den oprindelige linje, mens den oprindelige toast viser oversættelsen.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Område Toast</value>
@@ -732,7 +732,7 @@
     <value>Baggrundens uigennemsigtighed</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Styrer, hvor uigennemsigtig toast-overlay-baggrunden skal være. Brug 0 for en fuldstændig gennemsigtig baggrund.</value>
+    <value>Styrer, hvor uigennemsigtig Plugin Overlay-baggrunden skal være. Brug 0 for en fuldstændig gennemsigtig baggrund.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Klasse / Job Skift Toast</value>
@@ -795,7 +795,7 @@
     <value>Oversæt JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Oversæt Main Command</value>
+      <value>Oversæt spillets hovedmenu</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Oversæt MiniTalk</value>

--- a/Properties/Resources.de.resx
+++ b/Properties/Resources.de.resx
@@ -81,7 +81,7 @@
     <value>(?)</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Passen Sie die Optionen für das Übersetzungs-Overlay an:</value>
+    <value>Passen Sie die Optionen für das Plugin Overlay an:</value>
   </data>
   <data name="LangIdentError" xml:space="preserve">
     <value>Die Sprache konnte nicht mit einem akzeptablen Grad an Sicherheit identifiziert werden.</value>
@@ -90,7 +90,7 @@
     <value>Die ausgewählte Sprache wird vom aktuell verfügbaren Übersetzungs-Backend nicht unterstützt.</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>Die gewählte Sprache wird aufgrund von Einschränkungen der nativen Spielschrift nur über die Plugin-Overlays unterstützt</value>
+    <value>Die gewählte Sprache wird aufgrund von Einschränkungen der nativen Spielschrift nur über die Plugin Overlay unterstützt</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>In welche Sprache die Dialogfelder im Spiel übersetzt werden sollen.</value>
@@ -111,25 +111,25 @@
     <value>Die nicht erschöpfende Liste der Probleme und TODOs finden Sie unter dem folgenden Link:</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Bitte passen Sie die Position an, wenn Ihr Overlay nicht relativ zum UI-Textfeld des Spiels zentriert ist.</value>
+    <value>Bitte passen Sie die Position an, wenn Ihr Plugin Overlay nicht relativ zum UI-Textfeld des Spiels zentriert ist.</value>
   </data>
   <data name="OverlayColorSelectName" xml:space="preserve">
     <value>OverlayColorSelect</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Klicken Sie hier, um die Overlay-Schriftfarbe auszuwählen</value>
+    <value>Klicken Sie hier, um die Plugin Overlay-Schriftfarbe auszuwählen</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Anpassen der Überlagerungs-Schriftskala</value>
+    <value>Anpassen der Plugin Overlay-Schriftskala</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
     <value>Schriftgrad überlagern</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Auswählen der Schriftgröße für die Textüberlagerung</value>
+    <value>Auswählen der Schriftgröße für die TextPlugin Overlay</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Multiplikator für die Höhe der Übersetzungsüberlagerung</value>
+    <value>Multiplikator für die Höhe der ÜbersetzungsPlugin Overlay</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Schlachtgespräch (Enenies-Dialogzeilen) Übersetzung</value>
@@ -139,13 +139,13 @@
     <value>Positionsverstellung</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Übersetzte Textüberlagerung über dem Textfeld der Spielbenutzeroberfläche anzeigen, anstatt den Text durch die Übersetzung zu ersetzen</value>
+    <value>Übersetzte TextPlugin Overlay über dem Textfeld der Spielbenutzeroberfläche anzeigen, anstatt den Text durch die Übersetzung zu ersetzen</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Überlagerungsbreite der Übersetzung anpassen</value>
+    <value>Plugin Overlay der Übersetzung anpassen</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplikator der Übersetzungs-Overlay-Breite</value>
+    <value>Multiplikator der Plugin Overlay-Breite</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Absoluter Pfad zum Echoglossian-Ordner (innerhalb von XIVLauncher -&gt; pluginConfigs-Ordner)</value>
@@ -190,10 +190,10 @@
     <value>Original-Dialogtext im Dialogfeld "Überlagern" und "Übersetzt" im Dialogfeld "Spiel-UI" anzeigen</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Anpassen der Overlaybreite für die Popupübersetzung</value>
+    <value>Anpassen der Plugin Overlay für die Popupübersetzung</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplikator für die Breite der Popupüberlagerung</value>
+    <value>Multiplikator für die Breite der Plugin Overlay</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>TODOs-Liste auf Github</value>
@@ -238,7 +238,7 @@
     <value>Übersetzungen aktiviert!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Verwenden von Overlay zum Anzeigen von Popups-Übersetzungen</value>
+    <value>Verwenden von Plugin Overlay zum Anzeigen von Popups-Übersetzungen</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>Warten auf Übersetzung...</value>
@@ -646,10 +646,10 @@
     <value>Detailanzeigemodus</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Dieser Modus steuert die Oberflächen ActionDetail und ItemDetail. Native UI schreibt den übersetzten Detailtext in das Spiel-Add-on, „Overlay-only“ behält das native Add-on intakt und verwendet Echoglossian-Overlays, und „native-with-original-overlay“ schreibt die Übersetzung nativ, während das Original in unserem Overlay angezeigt wird.</value>
+    <value>Dieser Modus steuert die Oberflächen ActionDetail und ItemDetail. Native UI schreibt den übersetzten Detailtext in das Spiel-Add-on, Plugin Overlay translation only behält das native Add-on intakt und verwendet Plugin Overlays, und Native UI translation + original Plugin Overlay schreibt die Übersetzung nativ, während das Original in unserem Plugin Overlay angezeigt wird.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Aktivieren Sie die Übersetzung von Aktions-/Elementdetails und gemeinsame Hover-Tooltips</value>
+    <value>Aktivieren Sie die Übersetzung von Aktions-/Elementdetails und gemeinsame Plugin Tooltips</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Modelle konnten nicht abgerufen werden. Läuft Ollama lokal?</value>
@@ -661,46 +661,46 @@
     <value>Spielfenster</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Diese Farben gelten für Echoglossian Hover-Tooltips, die von Quest- und DB-First-UI-Oberflächen verwendet werden.</value>
+    <value>Diese Farben gelten für Plugin Tooltips, die von Quest- und DB-First-UI-Oberflächen verwendet werden.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Erscheinungsbild des Hover-Tooltips</value>
+    <value>Erscheinungsbild des Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Tooltip-Hintergrundfarbe</value>
+    <value>Plugin Tooltip-Hintergrundfarbe</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Tooltip-Hintergrundopazität</value>
+    <value>Plugin Tooltip-Hintergrundopazität</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Farbe des Tooltip-Textes</value>
+    <value>Farbe des Plugin Tooltip-Textes</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Dieser Modus steuert Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept und JournalResult. Journal-Hover-Tooltips folgen direkt diesem Modus; Die globale Tooltip-Umschaltung betrifft nur andere übersetzte Benutzeroberflächen.</value>
+    <value>Dieser Modus steuert Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept und JournalResult. Journal Plugin Tooltips folgen diesem Modus direkt; die globale Plugin Tooltip-Umschaltung betrifft nur andere übersetzte UI.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Anzeigemodus für Journalquests</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>Für diesen Toasttyp ist der native Ersetzungsmodus aktiv. In diesem Modus werden keine Steuerelemente für den Overlay-Stil verwendet.</value>
+    <value>Für diesen Toasttyp ist der native Ersetzungsmodus aktiv. In diesem Modus werden keine Steuerelemente für den Plugin Overlay-Stil verwendet.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Dieser Modus steuert, wie der übersetzte Text dargestellt wird. Native UI schreibt direkt in das Spiel-Add-on, „overlay-only“ lässt das native Add-on unberührt und „native-with-original-overlay“ schreibt die Übersetzung nativ, während das Original im Overlay angezeigt wird.</value>
+    <value>Dieser Modus steuert, wie der übersetzte Text dargestellt wird. Native UI schreibt direkt in das Spiel-Add-on, „Plugin Overlay translation only“ lässt das native Add-on unberührt und „Native UI translation + original Plugin Overlay“ schreibt die Übersetzung nativ, während das Original im Plugin Overlay angezeigt wird.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Native UI Übersetzung + Original-Overlay</value>
+    <value>Native UI Übersetzung + Original-Plugin Overlay</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
-    <value>Nur Overlay-Übersetzung</value>
+    <value>Nur Plugin Overlay-Übersetzung</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Overlay-Titelleiste mit Sprechernamen anzeigen, sofern verfügbar</value>
+    <value>Plugin Overlay-Titelleiste mit Sprechernamen anzeigen, sofern verfügbar</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>Die Nur-Overlay-Sprache ist aktiv, sodass alle Toasttypen über Overlays gerendert werden.</value>
+    <value>Die Nur-Plugin Overlay-Sprache ist aktiv, sodass alle Toasttypen über Plugin Overlay gerendert werden.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>Die ausgewählte Sprache unterstützt die native Spielschriftart nicht, daher ist diese Oberfläche auf Echoglossian-Overlays und benutzerdefinierte Tooltips beschränkt.</value>
+    <value>Die ausgewählte Sprache unterstützt die native Spielschriftart nicht, daher ist diese Oberfläche auf Plugin Overlays und Plugin Tooltips beschränkt.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Dieser Modus steuert, wie dieses Questfenster dargestellt wird. Native UI schreibt die Übersetzung in das Add-on, „tooltip-only“ hält das Add-on intakt und „native-with-original-tooltips“ schreibt die Übersetzung nativ, während das Original in den Tooltips angezeigt wird.</value>
+    <value>Dieser Modus steuert, wie dieses Questfenster dargestellt wird. Native UI schreibt die Übersetzung in das Add-on, Plugin Tooltip translation only hält das Add-on intakt, und Native UI translation + original Plugin Tooltips schreibt die Übersetzung nativ, während das Original in Plugin Tooltips angezeigt wird.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Quest-Anzeigemodus</value>
@@ -718,10 +718,10 @@
     <value>Native UI Übersetzung</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI Übersetzung + Original-Tooltips</value>
+    <value>Native UI Übersetzung + Original-Plugin Tooltip</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Nur Tooltip-Übersetzung</value>
+    <value>Nur Plugin Tooltip-Übersetzung</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Questfenster</value>
@@ -748,10 +748,10 @@
     <value>Die Übersetzung ist derzeit deaktiviert, weil die ausgewählte Sprache zusätzliche Schriftart-Assets benötigt. Öffnen Sie das Konfigurationsfenster, um die erforderlichen Dateien herunterzuladen oder zu überprüfen.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Jeder Toasttyp kann unabhängig zwischen nativer Ersetzung und Overlay-Rendering wählen.</value>
+    <value>Jeder Toasttyp kann unabhängig zwischen nativer Ersetzung und Plugin Overlay-Rendering wählen.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Wenn ein Toasttyp den Overlay-Modus verwendet, können Sie die Texte auch austauschen, sodass das Overlay die ursprüngliche Zeile beibehält, während der native Toast die Übersetzung anzeigt.</value>
+    <value>Wenn ein Toasttyp den Plugin Overlay-Modus verwendet, können Sie die Texte auch austauschen, sodass das Plugin Overlay die ursprüngliche Zeile beibehält, während der native Toast die Übersetzung anzeigt.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Flächentoast</value>
@@ -760,7 +760,7 @@
     <value>Hintergrundopazität</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Steuert, wie undurchsichtig der Toast-Overlay-Hintergrund sein soll. Verwenden Sie 0 für einen vollständig transparenten Hintergrund.</value>
+    <value>Steuert, wie undurchsichtig der Toast-Plugin Overlay-Hintergrund sein soll. Verwenden Sie 0 für einen vollständig transparenten Hintergrund.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Toast auf Klassen-/Jobwechsel</value>
@@ -823,7 +823,7 @@
     <value>Übersetzen Sie JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Übersetzen Sie Main Command</value>
+      <value>Spielhauptmenü übersetzen</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Übersetzen Sie MiniTalk</value>

--- a/Properties/Resources.el.resx
+++ b/Properties/Resources.el.resx
@@ -89,7 +89,7 @@
     <value>Ενεργοποιήστε τη μετάφραση κειμένου παιχνιδιού σε πραγματικό χρόνο</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Χρώμα γραμματοσειράς επικάλυψης:</value>
+    <value>Χρώμα γραμματοσειράς Plugin Overlay:</value>
   </data>
   <data name="HelpMessage" xml:space="preserve">
     <value>Ανοίγει το παράθυρο ρύθμισης παραμέτρων Echoglossian</value>
@@ -99,7 +99,7 @@
     <value>(?)</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Προσαρμόστε τις επιλογές που σχετίζονται με την επικάλυψη μετάφρασης:</value>
+    <value>Προσαρμόστε τις επιλογές που σχετίζονται με την Plugin Overlay μετάφρασης:</value>
   </data>
   <data name="LangIdentError" xml:space="preserve">
     <value>Η γλώσσα δεν μπορούσε να προσδιοριστεί με αποδεκτό βαθμό βεβαιότητας</value>
@@ -108,7 +108,7 @@
     <value>Η επιλεγμένη γλώσσα δεν υποστηρίζεται από το τρέχον διαθέσιμο backend μετάφρασης</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>Η επιλεγμένη γλώσσα υποστηρίζεται μόνο χρησιμοποιώντας τις επικαλύψεις plugin λόγω περιορισμών της εγγενούς γραμματοσειράς παιχνιδιού</value>
+    <value>Η επιλεγμένη γλώσσα υποστηρίζεται μόνο χρησιμοποιώντας τις Plugin Overlay λόγω περιορισμών της εγγενούς γραμματοσειράς παιχνιδιού</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>Σε ποια γλώσσα θα μεταφραστούν τα πλαίσια διαλόγου εντός του παιχνιδιού.</value>
@@ -129,25 +129,25 @@
     <value>Ο μη εξαντλητικός κατάλογος θεμάτων και TODO είναι διαθέσιμος στον παρακάτω σύνδεσμο:</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Προσαρμόστε τη θέση εάν η επικάλυψη δεν είναι κεντραρισμένη σε σχέση με το πλαίσιο κειμένου διεπαφής χρήστη του παιχνιδιού.</value>
+    <value>Προσαρμόστε τη θέση εάν η Plugin Overlay δεν είναι κεντραρισμένη σε σχέση με το πλαίσιο κειμένου διεπαφής χρήστη του παιχνιδιού.</value>
   </data>
   <data name="OverlayColorSelectName" xml:space="preserve">
     <value>ΕπικάλυψηΧρώμαΕπιλογή</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Κάντε κλικ για να επιλέξετε το χρώμα γραμματοσειράς επικάλυψης</value>
+    <value>Κάντε κλικ για να επιλέξετε το χρώμα γραμματοσειράς Plugin Overlay</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Προσαρμογή της κλίμακας γραμματοσειράς επικάλυψης</value>
+    <value>Προσαρμογή της κλίμακας γραμματοσειράς Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Μέγεθος γραμματοσειράς επικάλυψης</value>
+    <value>Μέγεθος γραμματοσειράς Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Επιλέξτε το μέγεθος γραμματοσειράς για την επικάλυψη κειμένου</value>
+    <value>Επιλέξτε το μέγεθος γραμματοσειράς για την Plugin Overlay κειμένου</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Πολλαπλασιαστής ύψους επικάλυψης μετάφρασης</value>
+    <value>Πολλαπλασιαστής ύψους Plugin Overlay μετάφρασης</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Ομιλία μάχης (γραμμές διαλόγου Enenies) μετάφραση</value>
@@ -157,13 +157,13 @@
     <value>Ρύθμιση θέσης</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Εμφάνιση επικάλυψης μεταφρασμένου κειμένου πάνω από το πλαίσιο κειμένου περιβάλλοντος εργασίας χρήστη παιχνιδιού αντί να αντικαταστήσετε το κείμενό του με τη μετάφραση</value>
+    <value>Εμφάνιση Plugin Overlay μεταφρασμένου κειμένου πάνω από το πλαίσιο κειμένου περιβάλλοντος εργασίας χρήστη παιχνιδιού αντί να αντικαταστήσετε το κείμενό του με τη μετάφραση</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Προσαρμογή πλάτους επικάλυψης μετάφρασης</value>
+    <value>Προσαρμογή πλάτους Plugin Overlay μετάφρασης</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Πολλαπλασιαστής πλάτους επικάλυψης μετάφρασης</value>
+    <value>Πολλαπλασιαστής πλάτους Plugin Overlay μετάφρασης</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Απόλυτη διαδρομή προς το φάκελο Echoglossian (μέσα στο φάκελο XIVLauncher -&gt; pluginConfigs)</value>
@@ -211,13 +211,13 @@
     <value>Echoglossian ρυθμίσεις επαναφορά στην προεπιλογή με επιτυχία!</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Εμφάνιση κειμένου διαλόγου "Πρωτότυπο" στην "Επικάλυψη" και "Μεταφρασμένο" στο παράθυρο διαλόγου "Περιβάλλον εργασίας χρήστη παιχνιδιού"</value>
+    <value>Εμφάνιση κειμένου διαλόγου "Πρωτότυπο" στην "Plugin Overlay" και "Μεταφρασμένο" στο παράθυρο διαλόγου "Περιβάλλον εργασίας χρήστη παιχνιδιού"</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Προσαρμογή πλάτους επικάλυψης αναδυόμενης μετάφρασης</value>
+    <value>Προσαρμογή πλάτους Plugin Overlay αναδυόμενης μετάφρασης</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Πολλαπλασιαστής πλάτους επικάλυψης τοστ</value>
+    <value>Πολλαπλασιαστής πλάτους Plugin Overlay τοστ</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>Λίστα TODO στο Github</value>
@@ -262,7 +262,7 @@
     <value>Οι μεταφράσεις είναι ενεργοποιημένες!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Χρήση επικάλυψης για εμφάνιση αναδυόμενων μεταφράσεων (WIP)</value>
+    <value>Χρήση Plugin Overlay για εμφάνιση αναδυόμενων μεταφράσεων (WIP)</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>Εν αναμονή μετάφρασης...</value>
@@ -646,10 +646,10 @@
     <value>Λειτουργία εμφάνισης λεπτομερειών</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Αυτή η λειτουργία ελέγχει τις επιφάνειες ActionDetail και ItemDetail. Το Native UI γράφει το μεταφρασμένο κείμενο λεπτομερειών στο πρόσθετο του παιχνιδιού, μόνο με επικάλυψη διατηρεί ανέπαφο το εγγενές πρόσθετο και χρησιμοποιεί επικαλύψεις Echoglossian και το εγγενές-με-πρωτότυπο-επικάλυψη γράφει μετάφραση εγγενώς ενώ εμφανίζει το πρωτότυπο στην επικάλυψη μας.</value>
+    <value>Αυτή η λειτουργία ελέγχει τις επιφάνειες ActionDetail και ItemDetail. Το Native UI γράφει το μεταφρασμένο κείμενο λεπτομερειών στο πρόσθετο του παιχνιδιού, το Plugin Overlay translation only διατηρεί ανέπαφο το εγγενές πρόσθετο και χρησιμοποιεί Plugin Overlays, και το Native UI translation + original Plugin Overlay γράφει τη μετάφραση εγγενώς ενώ εμφανίζει το πρωτότυπο στο Plugin Overlay μας.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Ενεργοποιήστε τη μετάφραση λεπτομερειών δράσης/αντικειμένου και κοινές συμβουλές εργαλείων τοποθέτησης του δείκτη</value>
+    <value>Ενεργοποιήστε τη μετάφραση λεπτομερειών δράσης/αντικειμένου και τα κοινά Plugin Tooltips</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Δεν ήταν δυνατή η ανάκτηση μοντέλων. Το Ollama εκτελείται τοπικά;</value>
@@ -661,7 +661,7 @@
     <value>Παράθυρα παιχνιδιών</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Αυτά τα χρώματα ισχύουν για Echoglossian συμβουλές εργαλείων αιώρησης που χρησιμοποιούνται από επιφάνειες διεπαφής χρήστη quest και DB-first.</value>
+    <value>Αυτά τα χρώματα ισχύουν για τα Plugin Tooltips που χρησιμοποιούνται από τις επιφάνειες UI quest και DB-first.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
     <value>Εμφάνιση επεξήγησης εργαλείου με το δείκτη του ποντικιού</value>
@@ -676,31 +676,31 @@
     <value>Χρώμα κειμένου επεξήγησης εργαλείου</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Αυτή η λειτουργία ελέγχει το Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept και JournalResult. Οι συμβουλές εργαλείων αιώρησης περιοδικών ακολουθούν αυτήν τη λειτουργία απευθείας. η καθολική εναλλαγή επεξήγησης εργαλείου επηρεάζει μόνο άλλες μεταφρασμένες διεπαφές.</value>
+    <value>Αυτή η λειτουργία ελέγχει το Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept και JournalResult. Τα Plugin Tooltips του Journal ακολουθούν αυτήν τη λειτουργία άμεσα· η global εναλλαγή Plugin Tooltip επηρεάζει μόνο άλλη μεταφρασμένη UI.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Λειτουργία εμφάνισης αναζήτησης περιοδικού</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>Η λειτουργία εγγενούς αντικατάστασης είναι ενεργή για αυτόν τον τύπο τοστ. Τα στοιχεία ελέγχου στυλ επικάλυψης δεν χρησιμοποιούνται σε αυτήν τη λειτουργία.</value>
+    <value>Η λειτουργία εγγενούς αντικατάστασης είναι ενεργή για αυτόν τον τύπο τοστ. Τα στοιχεία ελέγχου στυλ Plugin Overlay δεν χρησιμοποιούνται σε αυτήν τη λειτουργία.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Αυτή η λειτουργία ελέγχει τον τρόπο παρουσίασης του μεταφρασμένου κειμένου. Το Native UI γράφει απευθείας στο πρόσθετο του παιχνιδιού, η επικάλυψη μόνο αφήνει ανέγγιχτο το εγγενές πρόσθετο και το εγγενές πρόσθετο-με-πρωτότυπο-επικάλυψη γράφει τη μετάφραση εγγενώς ενώ εμφανίζει το πρωτότυπο στην επικάλυψη.</value>
+    <value>Αυτή η λειτουργία ελέγχει τον τρόπο παρουσίασης του μεταφρασμένου κειμένου. Το Native UI γράφει απευθείας στο πρόσθετο του παιχνιδιού, η Plugin Overlay μόνο αφήνει ανέγγιχτο το εγγενές πρόσθετο και το εγγενές πρόσθετο-με-πρωτότυπο-Plugin Overlay γράφει τη μετάφραση εγγενώς ενώ εμφανίζει το πρωτότυπο στην Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Native UI μετάφραση + πρωτότυπη επικάλυψη</value>
+    <value>Native UI μετάφραση + πρωτότυπη Plugin Overlay</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
-    <value>Μόνο μετάφραση επικάλυψης</value>
+    <value>Μόνο μετάφραση Plugin Overlay</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Εμφάνιση γραμμής τίτλου επικάλυψης με όνομα ηχείου όταν είναι διαθέσιμο</value>
+    <value>Εμφάνιση γραμμής τίτλου Plugin Overlay με όνομα ηχείου όταν είναι διαθέσιμο</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>Η γλώσσα μόνο για επικάλυψη είναι ενεργή, επομένως όλοι οι τύποι τοστ θα αποδίδονται μέσω επικαλύψεων.</value>
+    <value>Η γλώσσα μόνο για Plugin Overlay είναι ενεργή, επομένως όλοι οι τύποι τοστ θα αποδίδονται μέσω επικαλύψεων.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>Η επιλεγμένη γλώσσα δεν υποστηρίζει την εγγενή γραμματοσειρά του παιχνιδιού, επομένως αυτή η επιφάνεια περιορίζεται σε Echoglossian επικαλύψεις και προσαρμοσμένες συμβουλές εργαλείων.</value>
+    <value>Η επιλεγμένη γλώσσα δεν υποστηρίζει την εγγενή γραμματοσειρά του παιχνιδιού, επομένως αυτή η επιφάνεια περιορίζεται σε Plugin Overlays και Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Αυτή η λειτουργία ελέγχει τον τρόπο με τον οποίο παρουσιάζεται αυτό το παράθυρο αποστολής. Το Native UI γράφει τη μετάφραση στο πρόσθετο, το tooltip-only διατηρεί το πρόσθετο ανέπαφο και το native-with-original-tooltips γράφει τη μετάφραση εγγενώς ενώ εμφανίζει το πρωτότυπο στις επεξηγήσεις εργαλείων.</value>
+    <value>Αυτή η λειτουργία ελέγχει τον τρόπο με τον οποίο παρουσιάζεται αυτό το παράθυρο αποστολής. Το Native UI γράφει τη μετάφραση στο πρόσθετο, το Plugin Tooltip translation only διατηρεί το πρόσθετο ανέπαφο και το Native UI translation + original Plugin Tooltips γράφει τη μετάφραση εγγενώς ενώ εμφανίζει το πρωτότυπο στα Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Λειτουργία εμφάνισης αναζήτησης</value>
@@ -718,7 +718,7 @@
     <value>Native UI μετάφραση</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI μετάφραση + πρωτότυπες συμβουλές εργαλείων</value>
+    <value>Native UI μετάφραση + πρωτότυπες Plugin Tooltip</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
     <value>Μόνο μετάφραση επεξήγησης εργαλείου</value>
@@ -748,10 +748,10 @@
     <value>Η μετάφραση είναι αυτή τη στιγμή απενεργοποιημένη, επειδή η επιλεγμένη γλώσσα απαιτεί επιπλέον αρχεία γραμματοσειράς. Ανοίξτε το παράθυρο ρυθμίσεων για να κατεβάσετε ή να ελέγξετε τα απαιτούμενα αρχεία.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Κάθε τύπος τοστ μπορεί να επιλέξει ανεξάρτητα μεταξύ εγγενούς αντικατάστασης και απόδοσης επικάλυψης.</value>
+    <value>Κάθε τύπος τοστ μπορεί να επιλέξει ανεξάρτητα μεταξύ εγγενούς αντικατάστασης και απόδοσης Plugin Overlay.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Όταν ένας τύπος τοστ χρησιμοποιεί λειτουργία επικάλυψης, μπορείτε επίσης να ανταλλάξετε τα κείμενα έτσι ώστε η επικάλυψη να διατηρεί την αρχική γραμμή ενώ το εγγενές τοστ δείχνει τη μετάφραση.</value>
+    <value>Όταν ένας τύπος τοστ χρησιμοποιεί λειτουργία Plugin Overlay, μπορείτε επίσης να ανταλλάξετε τα κείμενα έτσι ώστε η Plugin Overlay να διατηρεί την αρχική γραμμή ενώ το εγγενές τοστ δείχνει τη μετάφραση.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Τοστ περιοχής</value>
@@ -760,7 +760,7 @@
     <value>Αδιαφάνεια φόντου</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Ελέγχει πόσο αδιαφανές θα πρέπει να είναι το φόντο της επικάλυψης του τοστ. Χρησιμοποιήστε το 0 για ένα πλήρως διαφανές φόντο.</value>
+    <value>Ελέγχει πόσο αδιαφανές θα πρέπει να είναι το φόντο της Plugin Overlay του τοστ. Χρησιμοποιήστε το 0 για ένα πλήρως διαφανές φόντο.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Τοστ αλλαγής τάξης / εργασίας</value>
@@ -823,7 +823,7 @@
     <value>Μετάφραση JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Μετάφραση Main Command</value>
+      <value>Μετάφραση κύριου μενού του παιχνιδιού</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Μετάφραση MiniTalk</value>

--- a/Properties/Resources.es.resx
+++ b/Properties/Resources.es.resx
@@ -30,13 +30,13 @@
     <value>Idioma al que traducir</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Ajuste la posición si su superposición no está centrada en relación con la ventana emergente de conversación.</value>
+    <value>Ajuste la posición si su Plugin Overlay no está centrada en relación con la ventana emergente de conversación.</value>
   </data>
   <data name="OverlayPositionAdjustmentLabel" xml:space="preserve">
     <value>Ajuste de posición</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Mostrar la superposición con texto traducido sobre el cuadro de diálogo de la IU del juego en lugar de reemplazar su texto con la traducción</value>
+    <value>Mostrar la Plugin Overlay con texto traducido sobre el cuadro de diálogo de la IU del juego en lugar de reemplazar su texto con la traducción</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
     <value>Multiplicador de ancho de diálogo</value>
@@ -57,13 +57,13 @@
     <value>A la espera de traducción...</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Tamaño de fuente de superposición</value>
+    <value>Tamaño de fuente de Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Seleccione el tamaño de fuente para la superposición de texto del diálogo</value>
+    <value>Seleccione el tamaño de fuente para la Plugin Overlay de texto del diálogo</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajustar el ancho de la superposición de traducción</value>
+    <value>Ajustar el ancho de la Plugin Overlay de traducción</value>
   </data>
   <data name="SendPixButton" xml:space="preserve">
     <value>¡Envíame un PIX!</value>
@@ -93,16 +93,16 @@
     <value>Configuración de Charla de batalla</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajustar el ancho de la superposición de traducción de mensajes sistema</value>
+    <value>Ajustar el ancho de la Plugin Overlay de traducción de mensajes sistema</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
     <value>Multiplicador de ancho de mensajes de sistema</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Color de fuente de la superposición:</value>
+    <value>Color de fuente de la Plugin Overlay:</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Haga clic para elegir el color de fuente de la superposición</value>
+    <value>Haga clic para elegir el color de fuente de la Plugin Overlay</value>
   </data>
   <data name="TranslateAreaToastToggleText" xml:space="preserve">
     <value>Traducir Mensajes del sistema del nombre del área</value>
@@ -129,10 +129,10 @@
     <value>LanguageInfo de la ventana de configuración:</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Mostrar texto de diálogo original en Superposición y traducido en el cuadro de diálogo de la IU del juego</value>
+    <value>Mostrar texto de diálogo original en Plugin Overlay y traducido en el cuadro de diálogo de la IU del juego</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Ajustar la escala de fuentes de superposición</value>
+    <value>Ajustar la escala de fuentes de Plugin Overlay</value>
   </data>
   <data name="EchoglossianPathModal" xml:space="preserve">
     <value>¡Atención!</value>
@@ -147,10 +147,10 @@
     <value>El idioma seleccionado no es compatible con el backend de traducción disponible actualmente</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>El idioma seleccionado solo es compatible con las superposiciones de complementos debido a las limitaciones de la fuente nativa del juego</value>
+    <value>El idioma seleccionado solo es compatible con las Plugin Overlay debido a las limitaciones de la fuente nativa del juego</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Multiplicador de altura de superposición de traslación</value>
+    <value>Multiplicador de altura de Plugin Overlay de traslación</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Traducción de Battle Talk (líneas de diálogo de Enenies)</value>
@@ -184,7 +184,7 @@
     <value>Activar la traducción del texto del juego en tiempo real</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Ajuste las opciones relacionadas con la superposición de traducción:</value>
+    <value>Ajuste las opciones relacionadas con la Plugin Overlay de traducción:</value>
   </data>
   <data name="TranslationEngineSettingsNotRequired" xml:space="preserve">
     <value>Este motor de traducción no requiere ninguna configuración especial.</value>
@@ -217,7 +217,7 @@
     <value>¡Las traducciones están habilitadas!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Usar la superposición para mostrar las traducciones de notificaciones del sistema (WIP)</value>
+    <value>Usar la Plugin Overlay para mostrar las traducciones de notificaciones del sistema (WIP)</value>
   </data>
   <data name="ResetConfigsButton" xml:space="preserve">
     <value>Restablecer configuración</value>
@@ -619,10 +619,10 @@
     <value>Modo de visualización de detalles</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla las superficies ActionDetail y ItemDetail. Native UI escribe el texto detallado traducido en el complemento del juego, solo superposición mantiene intacto el complemento nativo y usa superposiciones Echoglossian, y nativo con superposición original escribe la traducción de forma nativa mientras muestra el original en nuestra superposición.</value>
+    <value>Este modo controla las superficies ActionDetail e ItemDetail. Native UI escribe el texto detallado traducido en el complemento del juego, Plugin Overlay translation only mantiene intacto el complemento nativo y usa Plugin Overlays, y Native UI translation + original Plugin Overlay escribe la traducción de forma nativa mientras muestra el original en nuestro Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Habilitar la traducción de detalles de acciones/elementos e información sobre herramientas compartida</value>
+    <value>Habilitar la traducción de detalles de acción/objeto y los Plugin Tooltips compartidos</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>No se pudieron recuperar los modelos. ¿Se está ejecutando Ollama localmente?</value>
@@ -634,34 +634,34 @@
     <value>ventanas de juego</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Estos colores se aplican a la información sobre herramientas flotante Echoglossian utilizada por las superficies de UI de búsqueda y DB-first.</value>
+    <value>Estos colores se aplican a los Plugin Tooltips usados por las superficies de misión y DB-first UI.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Apariencia de información sobre herramientas al pasar el cursor</value>
+    <value>Apariencia de Plugin Tooltip al pasar el cursor</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Color de fondo de la información sobre herramientas</value>
+    <value>Color de fondo de la Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Opacidad del fondo de la información sobre herramientas</value>
+    <value>Opacidad del fondo de la Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Color del texto de información sobre herramientas</value>
+    <value>Color del texto de Plugin Tooltip</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla Diario, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept y JournalResult. La información sobre herramientas del diario sigue este modo directamente; el cambio de información sobre herramientas global solo afecta a otras IU traducidas.</value>
+    <value>Este modo controla Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept y JournalResult. Los Plugin Tooltips de Journal siguen este modo directamente; el cambio global de Plugin Tooltip solo afecta a otras UI traducidas.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Modo de visualización de misiones de diario</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>El modo de reemplazo nativo está activo para este tipo de brindis. Los controles de estilo de superposición no se utilizan en este modo.</value>
+    <value>El modo de reemplazo nativo está activo para este tipo de brindis. Los controles de estilo de Plugin Overlay no se utilizan en este modo.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla cómo se presenta el texto traducido. Native UI escribe directamente en el complemento del juego, solo superposición deja intacto el complemento nativo y nativo con superposición original escribe la traducción de forma nativa mientras muestra el original en la superposición.</value>
+    <value>Este modo controla cómo se presenta el texto traducido. Native UI escribe directamente en el complemento del juego, solo Plugin Overlay deja intacto el complemento nativo y nativo con Plugin Overlay original escribe la traducción de forma nativa mientras muestra el original en la Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Native UI traducción + superposición original</value>
+    <value>Native UI traducción + Plugin Overlay original</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
     <value>Solo traducción superpuesta</value>
@@ -670,10 +670,10 @@
     <value>Mostrar barra de título superpuesta con el nombre del orador cuando esté disponible</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>El lenguaje de solo superposición está activo, por lo que todos los tipos de notificaciones se procesarán mediante superposiciones.</value>
+    <value>El lenguaje de solo Plugin Overlay está activo, por lo que todos los tipos de notificaciones se procesarán mediante Plugin Overlay.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>El idioma seleccionado no admite la fuente nativa del juego, por lo que esta superficie se limita a superposiciones Echoglossian e información sobre herramientas personalizada.</value>
+    <value>El idioma seleccionado no admite la fuente nativa del juego, por lo que esta superficie queda limitada a Plugin Overlays y Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -682,7 +682,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla cómo se presenta esta ventana de misión. Native UI escribe la traducción en el complemento, la información sobre herramientas solo mantiene intacto el complemento y la información sobre herramientas nativa con original escribe la traducción de forma nativa mientras muestra el original en la información sobre herramientas.</value>
+    <value>Este modo controla cómo se presenta esta ventana de misión. Native UI escribe la traducción en el complemento, Plugin Tooltip translation only mantiene intacto el complemento y Native UI translation + original Plugin Tooltips escribe la traducción de forma nativa mientras muestra el original en Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Modo de visualización de misiones</value>
@@ -691,10 +691,10 @@
     <value>Native UI traducción</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI traducción + información sobre herramientas original</value>
+    <value>Native UI traducción + Plugin Tooltip original</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Solo traducción de información sobre herramientas</value>
+    <value>Solo traducción de Plugin Tooltip</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Ventanas de misión</value>
@@ -721,10 +721,10 @@
     <value>La traducción está desactivada en este momento porque el idioma seleccionado requiere recursos de fuente adicionales. Abre la ventana de configuración para descargar o validar los archivos necesarios.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Cada tipo de brindis puede elegir de forma independiente entre reemplazo nativo y representación de superposición.</value>
+    <value>Cada tipo de brindis puede elegir de forma independiente entre reemplazo nativo y representación de Plugin Overlay.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Cuando un tipo de notificación utiliza el modo de superposición, también puede intercambiar los textos para que la superposición mantenga la línea original mientras que la notificación nativa muestra la traducción.</value>
+    <value>Cuando un tipo de notificación utiliza el modo de Plugin Overlay, también puede intercambiar los textos para que la Plugin Overlay mantenga la línea original mientras que la notificación nativa muestra la traducción.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Brindis de área</value>
@@ -733,7 +733,7 @@
     <value>Opacidad del fondo</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Controla qué tan opaco debe ser el fondo de superposición del brindis. Utilice 0 para un fondo totalmente transparente.</value>
+    <value>Controla qué tan opaco debe ser el fondo de Plugin Overlay del brindis. Utilice 0 para un fondo totalmente transparente.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Brindis por cambio de clase/trabajo</value>
@@ -796,7 +796,7 @@
     <value>Traducir JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Traducir Main Command</value>
+      <value>Traducir menú principal del juego</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Traducir MiniTalk</value>

--- a/Properties/Resources.eu.resx
+++ b/Properties/Resources.eu.resx
@@ -646,10 +646,10 @@
     <value>Xehetasun bistaratzeko modua</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Modu honek ActionDetail eta ItemDetail gainazalak kontrolatzen ditu. Native UI-k itzulitako xehetasun-testua idazten du jokoaren gehigarrian, gainjartzeak soilik jatorrizko gehigarria mantentzen du oso-osorik eta Echoglossian gainjartzeak erabiltzen ditu, eta jatorrizkoak-jatorrizko gainjarrizketak jatorrizkoan idazten du itzulpena gure gainjartzean jatorrizkoa erakusten duen bitartean.</value>
+    <value>Modu honek ActionDetail eta ItemDetail gainazalak kontrolatzen ditu. Native UI-k itzulitako xehetasun-testua jokoaren gehigarrian idazten du, Plugin Overlay translation only aukerak jatorrizko gehigarria oso-osorik mantentzen du eta Plugin Overlays erabiltzen ditu, eta Native UI translation + original Plugin Overlay aukerak itzulpena berez idazten du jatorrizkoa gure Plugin Overlay-n erakusten duen bitartean.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Gaitu ekintzen/elementuen xehetasunen itzulpena eta pasatzeko tresna-informazio partekatuak</value>
+    <value>Gaitu ekintza/elementu xehetasunen itzulpena eta partekatutako Plugin Tooltips</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Ezin izan dira modeloak eskuratu. Ollama lokalean exekutatzen al da?</value>
@@ -661,7 +661,7 @@
     <value>Joko leihoak</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Kolore hauek bilaketak eta DB-first UI gainazalek erabiltzen dituzten Echoglossian pasabiderako argibideei aplikatzen zaizkie.</value>
+    <value>Kolore hauek quest eta DB-first UI gainazalek erabiltzen dituzten Plugin Tooltips-ei aplikatzen zaizkie.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
     <value>Pasatu pasatzean tresna-informazioaren itxura</value>
@@ -676,7 +676,7 @@
     <value>Tresna-informazioa testuaren kolorea</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Modu honek Aldizkaria, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept eta JournalResult kontrolatzen ditu. Egunkaria pasatzeko tresna-informazioek zuzenean jarraitzen diote modu honi; tresna-informazio globalaren txandakatzaileak itzulitako beste interfaze bat baino ez du eragiten.</value>
+    <value>Modu honek Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept eta JournalResult kontrolatzen ditu. Journal Plugin Tooltips-ek modu hau zuzenean jarraitzen dute; Plugin Tooltip globalaren etengailuak beste UI itzulietan bakarrik eragiten du.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Aldizkaria bilatzea bistaratzeko modua</value>
@@ -700,7 +700,7 @@
     <value>Gainjartze-lengoaia soilik aktibo dago, beraz, tostada mota guztiak gainjarri bidez errendatuko dira.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>Hautatutako hizkuntzak ez du onartzen jatorrizko jokoaren letra-tipoa; beraz, azalera hau Echoglossian gainjarrietara eta tresna-aholku pertsonalizatuetara mugatuta dago.</value>
+    <value>Hautatutako hizkuntzak ez du jokoaren jatorrizko letra-tipoa onartzen; beraz, azalera hau Plugin Overlays eta Plugin Tooltips-etara mugatuta dago.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Modu honek bilaketa-leiho hau nola aurkezten den kontrolatzen du. Native UI-k itzulpena gehigarrian idazten du, tooltip-ak bakarrik mantentzen du gehigarria oso-osorik, eta native-with-original-tooltips itzulpena jatorrizkoan idazten du, jatorrizkoa tresna-aholkuetan erakusten duen bitartean.</value>
+    <value>Modu honek bilaketa-leiho hau nola aurkezten den kontrolatzen du. Native UI-k itzulpena gehigarrian idazten du, Plugin Tooltip translation only aukerak gehigarria oso-osorik mantentzen du, eta Native UI translation + original Plugin Tooltips aukerak itzulpena berez idazten du jatorrizkoa Plugin Tooltips-en erakusten duen bitartean.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Quest bistaratzeko modua</value>
@@ -718,7 +718,7 @@
     <value>Native UI itzulpena</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI itzulpena + jatorrizko tresna-aholkuak</value>
+    <value>Native UI itzulpena + jatorrizko Plugin Tooltip</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
     <value>Tresna-informazioen itzulpena soilik</value>
@@ -823,7 +823,7 @@
     <value>Itzuli JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Itzuli Main Command</value>
+      <value>Itzuli jokoaren menu nagusia</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Itzuli MiniTalk</value>

--- a/Properties/Resources.fr.resx
+++ b/Properties/Resources.fr.resx
@@ -71,7 +71,7 @@
     <value>Activer la traduction de texte de jeu en temps réel</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Couleur de police de superposition :</value>
+    <value>Couleur de police de Plugin Overlay :</value>
   </data>
   <data name="HelpMessage" xml:space="preserve">
     <value>Ouvre la fenêtre de configuration Echoglossian</value>
@@ -81,7 +81,7 @@
     <value>(?)</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Ajustez les options liées à la superposition de traduction :</value>
+    <value>Ajustez les options liées à la Plugin Overlay de traduction :</value>
   </data>
   <data name="LangIdentError" xml:space="preserve">
     <value>La langue n’a pas pu être identifiée avec un degré de certitude acceptable</value>
@@ -90,7 +90,7 @@
     <value>La langue sélectionnée n’est pas prise en charge par le backend de traduction actuellement disponible</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>La langue sélectionnée n’est prise en charge qu’à l’aide des superpositions de plugins en raison des limitations du jeu natif Font</value>
+    <value>La langue sélectionnée n’est prise en charge qu’à l’aide des Plugin Overlay de plugins en raison des limitations du jeu natif Font</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>Dans quelle langue traduire les boîtes de dialogue du jeu.</value>
@@ -111,25 +111,25 @@
     <value>La liste non exhaustive des problèmes et des TODO est disponible dans le lien ci-dessous:</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Veuillez ajuster la position si votre superposition n’est pas centrée par rapport à la zone de texte de l’interface utilisateur du jeu.</value>
+    <value>Veuillez ajuster la position si votre Plugin Overlay n’est pas centrée par rapport à la zone de texte de l’interface utilisateur du jeu.</value>
   </data>
   <data name="OverlayColorSelectName" xml:space="preserve">
     <value>OverlayColorSelect</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Cliquez pour choisir la couleur de police de superposition</value>
+    <value>Cliquez pour choisir la couleur de police de Plugin Overlay</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Ajuster l’échelle de police de superposition</value>
+    <value>Ajuster l’échelle de police de Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Taille de police de superposition</value>
+    <value>Taille de police de Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Sélectionnez la taille de police pour la superposition de texte</value>
+    <value>Sélectionnez la taille de police pour la Plugin Overlay de texte</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Multiplicateur de hauteur de superposition de translation</value>
+    <value>Multiplicateur de hauteur de Plugin Overlay de translation</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Battle talk (lignes de dialogue Enenies) traduction</value>
@@ -139,13 +139,13 @@
     <value>Réglage de la position</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Afficher la superposition de texte traduit au-dessus de la zone de texte de l’interface utilisateur du jeu au lieu de remplacer son texte par la traduction</value>
+    <value>Afficher la Plugin Overlay de texte traduit au-dessus de la zone de texte de l’interface utilisateur du jeu au lieu de remplacer son texte par la traduction</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajuster la largeur de superposition de traduction</value>
+    <value>Ajuster la largeur de Plugin Overlay de traduction</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplicateur de largeur de superposition de traduction</value>
+    <value>Multiplicateur de largeur de Plugin Overlay de traduction</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Chemin absolu vers le dossier Echoglossian (dans le dossier XIVLauncher -&gt; pluginConfigs)</value>
@@ -187,13 +187,13 @@
     <value>Paramètres de Google Traduction :</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Afficher le texte de dialogue d’origine dans superposition et traduit dans la boîte de dialogue de l’interface utilisateur du jeu</value>
+    <value>Afficher le texte de dialogue d’origine dans Plugin Overlay et traduit dans la boîte de dialogue de l’interface utilisateur du jeu</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajuster la largeur de superposition de translation toast</value>
+    <value>Ajuster la largeur de Plugin Overlay de translation toast</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplicateur de largeur de superposition toast</value>
+    <value>Multiplicateur de largeur de Plugin Overlay toast</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>Liste des TODO sur Github</value>
@@ -238,7 +238,7 @@
     <value>Traductions activées !</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Utiliser la superposition pour afficher les traductions toasts</value>
+    <value>Utiliser la Plugin Overlay pour afficher les traductions toasts</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>En attente de traduction...</value>
@@ -646,10 +646,10 @@
     <value>Mode d'affichage détaillé</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Ce mode contrôle les surfaces ActionDetail et ItemDetail. Native UI écrit le texte détaillé traduit dans le module complémentaire du jeu, la superposition uniquement conserve le module complémentaire natif intact et utilise les superpositions Echoglossian, et la superposition native avec l'original écrit la traduction de manière native tout en affichant l'original dans notre superposition.</value>
+    <value>Ce mode contrôle les surfaces ActionDetail et ItemDetail. Native UI écrit le texte de détail traduit dans l’addon du jeu, Plugin Overlay translation only laisse l’addon natif intact et utilise des Plugin Overlays, et Native UI translation + original Plugin Overlay écrit la traduction nativement tout en affichant l’original dans notre Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Activer la traduction des détails des actions/éléments et les info-bulles de survol partagées</value>
+    <value>Activer la traduction des détails d’action/objet et les Plugin Tooltips partagés</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Impossible de récupérer les modèles. Ollama s'exécute-t-il localement ?</value>
@@ -661,7 +661,7 @@
     <value>Fenêtres de jeu</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Ces couleurs s'appliquent aux info-bulles de survol Echoglossian utilisées par les surfaces d'interface utilisateur de quête et de base de données.</value>
+    <value>Ces couleurs s’appliquent aux Plugin Tooltips utilisées par les surfaces UI de quête et DB-first.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
     <value>Apparition de l'info-bulle de survol</value>
@@ -676,31 +676,31 @@
     <value>Couleur du texte de l'info-bulle</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Ce mode contrôle Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept et JournalResult. Les info-bulles de survol du journal suivent directement ce mode ; la bascule globale de l'info-bulle n'affecte que les autres interfaces utilisateur traduites.</value>
+    <value>Ce mode contrôle Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept et JournalResult. Les Plugin Tooltips du Journal suivent directement ce mode ; le basculement global de Plugin Tooltip n’affecte que les autres UI traduites.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Mode d'affichage des quêtes du journal</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>Le mode de remplacement natif est actif pour ce type de toast. Les contrôles de style de superposition ne sont pas utilisés dans ce mode.</value>
+    <value>Le mode de remplacement natif est actif pour ce type de toast. Les contrôles de style de Plugin Overlay ne sont pas utilisés dans ce mode.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Ce mode contrôle la façon dont le texte traduit est présenté. Native UI écrit directement dans le module complémentaire du jeu, la superposition uniquement laisse le module complémentaire natif intact et la superposition native avec l'original écrit la traduction de manière native tout en affichant l'original dans la superposition.</value>
+    <value>Ce mode contrôle la façon dont le texte traduit est présenté. Native UI écrit directement dans le module complémentaire du jeu, la Plugin Overlay uniquement laisse le module complémentaire natif intact et la Plugin Overlay native avec l'original écrit la traduction de manière native tout en affichant l'original dans la Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Traduction Native UI + superposition originale</value>
+    <value>Traduction Native UI + Plugin Overlay originale</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
     <value>Traduction superposée uniquement</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Afficher la barre de titre en superposition avec le nom de l'orateur lorsqu'elle est disponible</value>
+    <value>Afficher la barre de titre en Plugin Overlay avec le nom de l'orateur lorsqu'elle est disponible</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>Le langage de superposition uniquement est actif, donc tous les types de toast seront rendus via des superpositions.</value>
+    <value>Le langage de Plugin Overlay uniquement est actif, donc tous les types de toast seront rendus via des Plugin Overlay.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>La langue sélectionnée ne prend pas en charge la police native du jeu, cette surface est donc limitée aux superpositions Echoglossian et aux info-bulles personnalisées.</value>
+    <value>La langue sélectionnée ne prend pas en charge la police native du jeu, cette surface est donc limitée aux Plugin Overlays et aux Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Ce mode contrôle la façon dont cette fenêtre de quête est présentée. Native UI écrit la traduction dans le module complémentaire, l'info-bulle uniquement conserve le module complémentaire intact et les info-bulles natives avec l'original écrivent la traduction de manière native tout en affichant l'original dans les info-bulles.</value>
+    <value>Ce mode contrôle la façon dont cette fenêtre de quête est présentée. Native UI écrit la traduction dans l’addon, Plugin Tooltip translation only laisse l’addon intact, et Native UI translation + original Plugin Tooltips écrit la traduction nativement tout en affichant l’original dans les Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Mode d'affichage des quêtes</value>
@@ -748,10 +748,10 @@
     <value>La traduction est actuellement désactivée, car la langue sélectionnée nécessite des ressources de police supplémentaires. Ouvrez la fenêtre de configuration pour télécharger ou valider les fichiers requis.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Chaque type de toast peut choisir indépendamment entre le remplacement natif et le rendu par superposition.</value>
+    <value>Chaque type de toast peut choisir indépendamment entre le remplacement natif et le rendu par Plugin Overlay.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Lorsqu'un type de toast utilise le mode superposition, vous pouvez également échanger les textes afin que la superposition conserve la ligne d'origine tandis que le toast natif affiche la traduction.</value>
+    <value>Lorsqu'un type de toast utilise le mode Plugin Overlay, vous pouvez également échanger les textes afin que la Plugin Overlay conserve la ligne d'origine tandis que le toast natif affiche la traduction.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Toast de zone</value>
@@ -760,7 +760,7 @@
     <value>Opacité de l'arrière-plan</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Contrôle l'opacité de l'arrière-plan de superposition de toast. Utilisez 0 pour un arrière-plan entièrement transparent.</value>
+    <value>Contrôle l'opacité de l'arrière-plan de Plugin Overlay de toast. Utilisez 0 pour un arrière-plan entièrement transparent.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Toast de changement de classe/d'emploi</value>
@@ -823,7 +823,7 @@
     <value>Traduire JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Traduire Main Command</value>
+      <value>Traduire le menu principal du jeu</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Traduire MiniTalk</value>

--- a/Properties/Resources.it.resx
+++ b/Properties/Resources.it.resx
@@ -108,7 +108,7 @@
     <value>La lingua selezionata non è supportata dal backend di traduzione attualmente disponibile</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>La lingua selezionata è supportata solo utilizzando le sovrapposizioni del plug-in a causa delle limitazioni del carattere nativo del gioco</value>
+    <value>La lingua selezionata è supportata solo utilizzando le Plugin Overlay del plug-in a causa delle limitazioni del carattere nativo del gioco</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>In quale lingua tradurre le finestre di dialogo del gioco.</value>
@@ -646,10 +646,10 @@
     <value>Modalità di visualizzazione dei dettagli</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Questa modalità controlla le superfici ActionDetail e ItemDetail. Native UI scrive il testo dettagliato tradotto nel componente aggiuntivo del gioco, solo overlay mantiene intatto il componente aggiuntivo nativo e utilizza gli overlay Echoglossian e native-with-original-overlay scrive la traduzione in modo nativo mentre mostra l'originale nel nostro overlay.</value>
+    <value>Questa modalità controlla le superfici ActionDetail e ItemDetail. Native UI scrive il testo dettagliato tradotto nel componente aggiuntivo del gioco, Plugin Overlay translation only mantiene intatto il componente aggiuntivo nativo e usa Plugin Overlays, e Native UI translation + original Plugin Overlay scrive la traduzione in modo nativo mostrando l’originale nel nostro Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Abilita la traduzione dei dettagli di azioni/elementi e le descrizioni comandi condivise al passaggio del mouse</value>
+    <value>Abilita la traduzione dei dettagli di azioni/oggetti e i Plugin Tooltips condivisi</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Impossibile recuperare i modelli. Ollama è in esecuzione localmente?</value>
@@ -661,7 +661,7 @@
     <value>Finestre di gioco</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Questi colori si applicano alle descrizioni comandi al passaggio del mouse di Echoglossian utilizzate dalle missioni e dalle superfici dell'interfaccia utente DB-first.</value>
+    <value>Questi colori si applicano ai Plugin Tooltips usati dalle superfici UI quest e DB-first.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
     <value>Aspetto della descrizione comando al passaggio del mouse</value>
@@ -676,7 +676,7 @@
     <value>Colore del testo della descrizione comando</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Questa modalità controlla il diario, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept e JournalResult. I suggerimenti al passaggio del mouse sul diario seguono direttamente questa modalità; l'attivazione/disattivazione della descrizione comando globale influisce solo sull'altra interfaccia utente tradotta.</value>
+    <value>Questa modalità controlla Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept e JournalResult. I Plugin Tooltips del Journal seguono direttamente questa modalità; l’interruttore globale di Plugin Tooltip influisce solo su altre UI tradotte.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Modalità di visualizzazione delle missioni del diario</value>
@@ -685,7 +685,7 @@
     <value>La modalità di sostituzione nativa è attiva per questo tipo di toast. I controlli dello stile di sovrapposizione non vengono utilizzati in questa modalità.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Questa modalità controlla come viene presentato il testo tradotto. Native UI scrive direttamente nel componente aggiuntivo del gioco, solo overlay lascia intatto il componente aggiuntivo nativo e native-with-original-overlay scrive la traduzione in modo nativo mostrando l'originale nell'overlay.</value>
+    <value>Questa modalità controlla come viene presentato il testo tradotto. Native UI scrive direttamente nel componente aggiuntivo del gioco, solo Plugin Overlay lascia intatto il componente aggiuntivo nativo e Native UI translation + original Plugin Overlay scrive la traduzione in modo nativo mostrando l'originale nell'Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
     <value>Native UI traduzione + sovrapposizione originale</value>
@@ -697,10 +697,10 @@
     <value>Mostra la barra del titolo in sovrapposizione con il nome dell'oratore, se disponibile</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>La lingua di solo overlay è attiva, quindi tutti i tipi di toast verranno visualizzati tramite overlay.</value>
+    <value>La lingua di solo Plugin Overlay è attiva, quindi tutti i tipi di toast verranno visualizzati tramite Plugin Overlay.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>La lingua selezionata non supporta il carattere nativo del gioco, quindi questa superficie è limitata a sovrapposizioni Echoglossian e descrizioni comandi personalizzate.</value>
+    <value>La lingua selezionata non supporta il carattere nativo del gioco, quindi questa superficie è limitata a Plugin Overlays e Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Questa modalità controlla come viene presentata la finestra della missione. Native UI scrive la traduzione nel componente aggiuntivo, tooltip-only mantiene intatto il componente aggiuntivo e native-with-original-tooltips scrive la traduzione in modo nativo mostrando l'originale nei tooltip.</value>
+    <value>Questa modalità controlla come viene presentata questa finestra di missione. Native UI scrive la traduzione nel componente aggiuntivo, Plugin Tooltip translation only mantiene intatto il componente aggiuntivo e Native UI translation + original Plugin Tooltips scrive la traduzione in modo nativo mostrando l’originale nei Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Modalità di visualizzazione delle missioni</value>
@@ -718,10 +718,10 @@
     <value>Native UI traduzione</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI traduzione + tooltip originali</value>
+    <value>Native UI traduzione + Plugin Tooltip originali</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Solo traduzione delle descrizioni comandi</value>
+    <value>Solo traduzione delle Plugin Tooltip</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Finestre delle missioni</value>
@@ -751,7 +751,7 @@
     <value>Ogni tipo di toast può scegliere in modo indipendente tra la sostituzione nativa e il rendering in sovrapposizione.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Quando un tipo di toast utilizza la modalità overlay, puoi anche scambiare i testi in modo che l'overlay mantenga la riga originale mentre il toast nativo mostri la traduzione.</value>
+    <value>Quando un tipo di toast utilizza la modalità Plugin Overlay, puoi anche scambiare i testi in modo che l'Plugin Overlay mantenga la riga originale mentre il toast nativo mostri la traduzione.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Pane tostato della zona</value>
@@ -823,7 +823,7 @@
     <value>Traduci JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Traduci Main Command</value>
+      <value>Traduci il menu principale del gioco</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Traduci MiniTalk</value>

--- a/Properties/Resources.pt-BR.resx
+++ b/Properties/Resources.pt-BR.resx
@@ -30,16 +30,16 @@
     <value>Linguagem para traduzir para</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Ajuste a posição se a sobreposição não estiver centrada em relação à caixa de conversa da UI do jogo.</value>
+    <value>Ajuste a posição se a Plugin Overlay não estiver centrada em relação à caixa de texto da UI do jogo.</value>
   </data>
   <data name="OverlayPositionAdjustmentLabel" xml:space="preserve">
     <value>Ajuste de posição</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Exibir sobreposição com texto traduzido acima da caixa de diálogo da IU do jogo em vez de substituir seu texto pela tradução</value>
+    <value>Exibir o texto traduzido em uma Plugin Overlay acima da caixa de texto da UI do jogo em vez de substituir o texto original pela tradução</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplicador de largura da sobreposição de tradução de diálogo</value>
+    <value>Multiplicador de largura da Plugin Overlay</value>
   </data>
   <data name="PatronButtonLabel" xml:space="preserve">
     <value>Comprar um café para lokinmodar</value>
@@ -57,13 +57,13 @@
     <value>Aguardando tradução...</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Tamanho da fonte da sobreposição</value>
+    <value>Tamanho da fonte da Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Selecione o tamanho da fonte para a sobreposição de texto de diálogo</value>
+    <value>Selecione o tamanho da fonte para o texto da Plugin Overlay</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajuste a largura da sobreposição de tradução</value>
+    <value>Ajuste a largura da Plugin Overlay</value>
   </data>
   <data name="SendPixButton" xml:space="preserve">
     <value>Mande-me um PIX!</value>
@@ -93,16 +93,16 @@
     <value>Configurações de diálogos de batalha</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajuste a largura de sobreposição de tradução de Toasts</value>
+    <value>Ajuste a largura da Plugin Overlay de Toasts</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplicador de largura para Toasts</value>
+    <value>Multiplicador de largura da Plugin Overlay de Toasts</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Cor da fonte da sobreposição:</value>
+    <value>Cor da fonte da Plugin Overlay:</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Clique para escolher a cor da fonte da sobreposição</value>
+    <value>Clique para escolher a cor da fonte da Plugin Overlay</value>
   </data>
   <data name="TranslateAreaToastToggleText" xml:space="preserve">
     <value>Traduzir mensagens de nome de área</value>
@@ -129,10 +129,10 @@
     <value>Linguagem de janela de config:</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Mostrar texto de diálogo original no Overlay e o texto traduzido na caixa de diálogo da IU do jogo</value>
+    <value>Mostrar o texto original do diálogo na Plugin Overlay e o texto traduzido na caixa de diálogo da UI do jogo</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Ajuste a escala de fonte da Overlay</value>
+    <value>Ajuste a escala de fonte da Plugin Overlay</value>
   </data>
   <data name="EchoglossianPathModal" xml:space="preserve">
     <value>Atenção!</value>
@@ -147,10 +147,10 @@
     <value>O idioma selecionado não é suportado pelo backend de tradução disponível atualmente</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>O idioma selecionado só é suportado usando overlays devido a limitações da fonte nativa do jogo</value>
+    <value>O idioma selecionado só é suportado usando Plugin Overlays devido a limitações da fonte nativa do jogo</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Multiplicador de altura da overlay de diálogo</value>
+    <value>Multiplicador de altura da Plugin Overlay</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Tradução de diálogos de batalha</value>
@@ -184,7 +184,7 @@
     <value>Ativar tradução em tempo real do texto do jogo</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Ajuste as opções relacionadas à overlay de tradução:</value>
+    <value>Ajuste as opções relacionadas à Plugin Overlay:</value>
   </data>
   <data name="TranslationEngineSettingsNotRequired" xml:space="preserve">
     <value>Este mecanismo de tradução não requer configurações especiais.</value>
@@ -217,7 +217,7 @@
     <value>Traduções estão habilitadas!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Use sobreposição para mostrar traduções de toasts (WIP)</value>
+    <value>Usar Plugin Overlay para mostrar traduções de Toasts (WIP)</value>
   </data>
   <data name="ResetConfigsButton" xml:space="preserve">
     <value>Resetar Configurações</value>
@@ -586,10 +586,10 @@
     <value>Modo de exibição de detalhes</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla as superfícies ActionDetail e ItemDetail. Native UI grava o texto detalhado traduzido no complemento do jogo, apenas a sobreposição mantém o complemento nativo intacto e usa sobreposições Echoglossian, e sobreposição nativa com original grava a tradução nativamente enquanto mostra o original em nossa sobreposição.</value>
+    <value>Este modo controla as superfícies ActionDetail e ItemDetail. Native UI grava o texto detalhado traduzido no complemento do jogo, o modo somente Plugin Overlay mantém o complemento nativo intacto e usa Plugin Overlays, e Tradução de Native UI + Plugin Overlay original grava a tradução nativamente enquanto mostra o original na nossa Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Habilitar tradução de detalhes de ação/item e dicas de ferramentas instantâneas compartilhadas</value>
+    <value>Habilitar tradução de detalhes de ação/item e Plugin Tooltips compartilhadas</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Não foi possível buscar modelos. Ollama está sendo executado localmente?</value>
@@ -601,46 +601,46 @@
     <value>Janelas de jogo</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Essas cores se aplicam às dicas de ferramentas instantâneas Echoglossian usadas pela missão e pelas superfícies de UI do banco de dados.</value>
+    <value>Essas cores se aplicam às Plugin Tooltips usadas pelas superfícies de quest e DB-first.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Aparência da dica de ferramenta ao passar o mouse</value>
+    <value>Aparência das Plugin Tooltips</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Cor de fundo da dica de ferramenta</value>
+    <value>Cor de fundo da Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Opacidade do plano de fundo da dica de ferramenta</value>
+    <value>Opacidade do fundo da Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Cor do texto da dica</value>
+    <value>Cor do texto da Plugin Tooltip</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla Diário, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept e JournalResult. As dicas de ferramentas de foco do diário seguem esse modo diretamente; a alternância global da dica de ferramenta afeta apenas outras UI traduzidas.</value>
+    <value>Este modo controla Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept e JournalResult. As Plugin Tooltips do Journal seguem esse modo diretamente; o toggle global de Plugin Tooltip afeta apenas outras UIs traduzidas.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Modo de exibição da missão do diário</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>O modo de substituição nativo está ativo para este tipo de notificação. Os controles de estilo de sobreposição não são usados ​​neste modo.</value>
+    <value>O modo de substituição nativa está ativo para este tipo de toast. Os controles de estilo da Plugin Overlay não são usados nesse modo.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla como o texto traduzido é apresentado. Native UI grava diretamente no complemento do jogo, apenas a sobreposição deixa o complemento nativo intacto e a sobreposição nativa com original grava a tradução nativamente enquanto mostra o original na sobreposição.</value>
+    <value>Este modo controla como o texto traduzido é apresentado. Native UI grava diretamente no complemento do jogo, o modo somente Plugin Overlay deixa o complemento nativo intacto, e Tradução de Native UI + Plugin Overlay original grava a tradução nativamente enquanto mostra o original na Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Tradução Native UI + sobreposição original</value>
+    <value>Tradução de Native UI + Plugin Overlay original</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
-    <value>Somente tradução de sobreposição</value>
+    <value>Somente tradução via Plugin Overlay</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Mostrar barra de título sobreposta com o nome do palestrante, quando disponível</value>
+    <value>Mostrar a barra de título da Plugin Overlay com o nome do falante, quando disponível</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>O idioma somente de sobreposição está ativo, portanto, todos os tipos de brinde serão renderizados por meio de sobreposições.</value>
+    <value>O suporte somente por Plugin Overlays está ativo, então todos os tipos de toast serão renderizados por meio de Plugin Overlays.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>O idioma selecionado não suporta a fonte nativa do jogo, portanto esta superfície é limitada a sobreposições Echoglossian e dicas de ferramentas personalizadas.</value>
+    <value>O idioma selecionado não suporta a fonte nativa do jogo, então esta superfície fica limitada a Plugin Overlays e Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -649,7 +649,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla como esta janela de missão é apresentada. Native UI grava a tradução no complemento, apenas dicas de ferramentas mantém o complemento intacto e dicas de ferramentas nativas com originais gravam a tradução nativamente enquanto mostram o original nas dicas de ferramentas.</value>
+    <value>Este modo controla como esta janela de missão é apresentada. Native UI grava a tradução no complemento, o modo somente Plugin Tooltips mantém o complemento intacto, e Tradução de Native UI + Plugin Tooltips originais grava a tradução nativamente enquanto mostra o original nas Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Modo de exibição de missão</value>
@@ -658,10 +658,10 @@
     <value>Tradução de Native UI</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Tradução de Native UI + dicas originais</value>
+    <value>Tradução de Native UI + Plugin Tooltips originais</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Somente tradução de dicas</value>
+    <value>Somente tradução via Plugin Tooltips</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Janelas de missão</value>
@@ -688,10 +688,10 @@
     <value>A tradução está desativada no momento porque o idioma selecionado exige assets extras de fonte. Abra a janela de configuração para baixar ou validar os arquivos necessários.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Cada tipo de sistema pode escolher independentemente entre substituição nativa e renderização de sobreposição.</value>
+    <value>Cada tipo de toast pode escolher independentemente entre substituição nativa e renderização em Plugin Overlay.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Quando um tipo de brinde usa o modo de sobreposição, você também pode trocar os textos para que a sobreposição mantenha a linha original enquanto o brinde nativo mostra a tradução.</value>
+    <value>Quando um tipo de toast usa o modo Plugin Overlay, você também pode trocar os textos para que a Plugin Overlay mantenha a linha original enquanto o toast nativo mostra a tradução.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Brinde de Área</value>
@@ -700,7 +700,7 @@
     <value>Opacidade de fundo</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Controla o quão opaco deve ser o plano de fundo da sobreposição do sistema. Use 0 para um fundo totalmente transparente.</value>
+    <value>Controla a opacidade do fundo da Plugin Overlay de toast. Use 0 para um fundo totalmente transparente.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Brinde de mudança de classe / emprego</value>
@@ -763,7 +763,7 @@
     <value>Traduzir JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Traduzir Main Command</value>
+      <value>Traduzir Menu Principal do Jogo</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Traduzir MiniTalk</value>

--- a/Properties/Resources.pt.resx
+++ b/Properties/Resources.pt.resx
@@ -89,7 +89,7 @@
     <value>Ative a tradução em tempo real do texto do jogo</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Cor da fonte de sobreposição:</value>
+    <value>Cor da fonte da Plugin Overlay:</value>
   </data>
   <data name="HelpMessage" xml:space="preserve">
     <value>Abre a janela de configuração do Echoglossian</value>
@@ -99,7 +99,7 @@
     <value>(?)</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Ajuste as opções relacionadas à sobreposição de translação:</value>
+    <value>Ajuste as opções relacionadas à Plugin Overlay:</value>
   </data>
   <data name="LangIdentError" xml:space="preserve">
     <value>A língua não pôde ser identificada com um grau aceitável de certeza</value>
@@ -108,7 +108,7 @@
     <value>O idioma selecionado não é suportado pelo back-end de tradução disponível no momento</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>O idioma selecionado só é suportado usando as sobreposições de plug-in devido a limitações da fonte nativa do jogo</value>
+    <value>O idioma selecionado só é suportado usando Plugin Overlays devido a limitações da fonte nativa do jogo</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>Para qual idioma traduzir as caixas de diálogo do jogo.</value>
@@ -129,25 +129,25 @@
     <value>A lista não exaustiva de problemas e TODOs está disponível no link abaixo:</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Ajuste a posição se sua sobreposição não estiver centralizada em relação à caixa de texto da interface do jogo.</value>
+    <value>Ajuste a posição se a Plugin Overlay não estiver centrada em relação à caixa de texto da interface do jogo.</value>
   </data>
   <data name="OverlayColorSelectName" xml:space="preserve">
     <value>SobreposiçãoCorSelecionar</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Clique para escolher a cor da fonte de sobreposição</value>
+    <value>Clique para escolher a cor da fonte da Plugin Overlay</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Ajustar a escala de fonte de sobreposição</value>
+    <value>Ajustar a escala de fonte da Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Tamanho da fonte de sobreposição</value>
+    <value>Tamanho da fonte da Plugin Overlay</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Selecione o tamanho da fonte para a sobreposição de texto</value>
+    <value>Selecione o tamanho da fonte para o texto da Plugin Overlay</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Multiplicador de altura de sobreposição de translação</value>
+    <value>Multiplicador de altura da Plugin Overlay</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Tradução de Battle talk (linhas de diálogo Enenies)</value>
@@ -157,13 +157,13 @@
     <value>Ajuste de posição</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Exibir sobreposição de texto traduzido acima da caixa de texto da interface do usuário do jogo em vez de substituir seu texto pela tradução</value>
+    <value>Exibir o texto traduzido em uma Plugin Overlay acima da caixa de texto da interface do jogo em vez de substituir o texto original pela tradução</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajustar a largura da sobreposição de translação</value>
+    <value>Ajustar a largura da Plugin Overlay</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplicador de largura de sobreposição de translação</value>
+    <value>Multiplicador de largura da Plugin Overlay</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Caminho absoluto para a pasta Echoglossian (dentro da pasta XIVLauncher -&gt; pluginConfigs)</value>
@@ -211,13 +211,13 @@
     <value>As configurações ecoglossianas foram redefinidas para o padrão com sucesso!</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Mostrar texto do diálogo original em Sobreposição e traduzido na caixa de diálogo da interface do usuário do jogo</value>
+    <value>Mostrar o texto original do diálogo na Plugin Overlay e o texto traduzido na caixa de diálogo da interface do jogo</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Ajustar a largura da sobreposição da tradução da notificação do sistema</value>
+    <value>Ajustar a largura da Plugin Overlay de notificações do sistema</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Multiplicador de largura de sobreposição de notificação do sistema</value>
+    <value>Multiplicador de largura da Plugin Overlay de notificações do sistema</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>Lista de TODOs no Github</value>
@@ -262,7 +262,7 @@
     <value>As traduções estão habilitadas!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Usar sobreposição para mostrar traduções do sistema (WIP)</value>
+    <value>Usar Plugin Overlay para mostrar traduções de notificações do sistema (WIP)</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>Aguardando tradução...</value>
@@ -646,10 +646,10 @@
     <value>Modo de exibição de detalhes</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla as superfícies ActionDetail e ItemDetail. Native UI grava o texto detalhado traduzido no complemento do jogo, apenas a sobreposição mantém o complemento nativo intacto e usa sobreposições Echoglossian, e sobreposição nativa com original grava a tradução nativamente enquanto mostra o original em nossa sobreposição.</value>
+    <value>Este modo controla as superfícies ActionDetail e ItemDetail. Native UI grava o texto detalhado traduzido no complemento do jogo, o modo somente Plugin Overlay mantém o complemento nativo intacto e usa Plugin Overlays, e Tradução de Native UI + Plugin Overlay original grava a tradução nativamente enquanto mostra o original na nossa Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Habilitar tradução de detalhes de ação/item e dicas de ferramentas instantâneas compartilhadas</value>
+    <value>Habilitar tradução de detalhes de ação/item e Plugin Tooltips compartilhadas</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Não foi possível buscar modelos. Ollama está sendo executado localmente?</value>
@@ -661,46 +661,46 @@
     <value>Janelas de jogo</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Essas cores se aplicam às dicas de ferramentas instantâneas Echoglossian usadas pela missão e pelas superfícies de UI do banco de dados.</value>
+    <value>Essas cores se aplicam às Plugin Tooltips usadas pelas superfícies de missão e DB-first.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Aparência da dica de ferramenta ao passar o mouse</value>
+    <value>Aparência das Plugin Tooltips</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Cor de fundo da dica de ferramenta</value>
+    <value>Cor de fundo da Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Opacidade do plano de fundo da dica de ferramenta</value>
+    <value>Opacidade do fundo da Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Cor do texto da dica</value>
+    <value>Cor do texto da Plugin Tooltip</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla Diário, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept e JournalResult. As dicas de ferramentas de foco do diário seguem esse modo diretamente; a alternância global da dica de ferramenta afeta apenas outras UI traduzidas.</value>
+    <value>Este modo controla Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept e JournalResult. As Plugin Tooltips do Journal seguem esse modo diretamente; a alternância global de Plugin Tooltip afeta apenas outras UIs traduzidas.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Modo de exibição da missão do diário</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>O modo de substituição nativo está ativo para este tipo de notificação. Os controles de estilo de sobreposição não são usados ​​neste modo.</value>
+    <value>O modo de substituição nativa está ativo para este tipo de notificação do sistema. Os controles de estilo da Plugin Overlay não são usados nesse modo.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla como o texto traduzido é apresentado. Native UI grava diretamente no complemento do jogo, apenas a sobreposição deixa o complemento nativo intacto e a sobreposição nativa com original grava a tradução nativamente enquanto mostra o original na sobreposição.</value>
+    <value>Este modo controla como o texto traduzido é apresentado. Native UI grava diretamente no complemento do jogo, o modo somente Plugin Overlay deixa o complemento nativo intacto, e Tradução de Native UI + Plugin Overlay original grava a tradução nativamente enquanto mostra o original na Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Tradução Native UI + sobreposição original</value>
+    <value>Tradução de Native UI + Plugin Overlay original</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
-    <value>Somente tradução de sobreposição</value>
+    <value>Somente tradução via Plugin Overlay</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Mostrar barra de título sobreposta com o nome do palestrante, quando disponível</value>
+    <value>Mostrar a barra de título da Plugin Overlay com o nome do orador, quando disponível</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>O idioma somente de sobreposição está ativo, portanto, todos os tipos de brinde serão renderizados por meio de sobreposições.</value>
+    <value>O suporte somente por Plugin Overlays está ativo, então todos os tipos de notificações do sistema serão renderizados por meio de Plugin Overlays.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>O idioma selecionado não suporta a fonte nativa do jogo, portanto esta superfície é limitada a sobreposições Echoglossian e dicas de ferramentas personalizadas.</value>
+    <value>O idioma selecionado não suporta a fonte nativa do jogo, então esta superfície fica limitada a Plugin Overlays e Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Este modo controla como esta janela de missão é apresentada. Native UI grava a tradução no complemento, apenas dicas de ferramentas mantém o complemento intacto e dicas de ferramentas nativas com originais gravam a tradução nativamente enquanto mostram o original nas dicas de ferramentas.</value>
+    <value>Este modo controla como esta janela de missão é apresentada. Native UI grava a tradução no complemento, o modo somente Plugin Tooltips mantém o complemento intacto, e Tradução de Native UI + Plugin Tooltips originais grava a tradução nativamente enquanto mostra o original nas Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Modo de exibição de missão</value>
@@ -718,10 +718,10 @@
     <value>Tradução de Native UI</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Tradução de Native UI + dicas originais</value>
+    <value>Tradução de Native UI + Plugin Tooltips originais</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Somente tradução de dicas</value>
+    <value>Somente tradução via Plugin Tooltips</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Janelas de missão</value>
@@ -748,10 +748,10 @@
     <value>A tradução está atualmente desativada porque o idioma selecionado requer recursos de fonte adicionais. Abra a janela de configuração para transferir ou validar os ficheiros necessários.</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Cada tipo de sistema pode escolher independentemente entre substituição nativa e renderização de sobreposição.</value>
+    <value>Cada tipo de notificação do sistema pode escolher independentemente entre substituição nativa e renderização em Plugin Overlay.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Quando um tipo de brinde usa o modo de sobreposição, você também pode trocar os textos para que a sobreposição mantenha a linha original enquanto o brinde nativo mostra a tradução.</value>
+    <value>Quando um tipo de notificação do sistema usa o modo Plugin Overlay, você também pode trocar os textos para que a Plugin Overlay mantenha a linha original enquanto a notificação nativa mostra a tradução.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Brinde de Área</value>
@@ -760,7 +760,7 @@
     <value>Opacidade de fundo</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Controla o quão opaco deve ser o plano de fundo da sobreposição do sistema. Use 0 para um fundo totalmente transparente.</value>
+    <value>Controla a opacidade do fundo da Plugin Overlay da notificação do sistema. Use 0 para um fundo totalmente transparente.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Brinde de mudança de classe / emprego</value>
@@ -823,7 +823,7 @@
     <value>Traduzir JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Traduzir Main Command</value>
+      <value>Traduzir Menu Principal do Jogo</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Traduzir MiniTalk</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -207,7 +207,7 @@
     <value>Activate game text realtime translation</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Overlay font color:</value>
+    <value>Plugin Overlay font color:</value>
   </data>
   <data name="HelpMessage" xml:space="preserve">
     <value>Opens Echoglossian config window</value>
@@ -217,7 +217,7 @@
     <value>(?)</value>
   </data>
   <data name="ImguiAdjustmentsLabel" xml:space="preserve">
-    <value>Adjust the options related to the translation overlay:</value>
+    <value>Adjust the options related to the Plugin Overlay:</value>
   </data>
   <data name="LangIdentError" xml:space="preserve">
     <value>The language could not be identified with an acceptable degree of certainty</value>
@@ -226,7 +226,7 @@
     <value>The selected language is not supported by the currently available translation backend</value>
   </data>
   <data name="LanguageOnlySupportedUsingOverlay" xml:space="preserve">
-    <value>The selected language is only supported using the plugin overlays due to limitations of the native game Font</value>
+    <value>The selected language is only supported using Plugin Overlays due to limitations of the native game font</value>
   </data>
   <data name="LanguageSelectionTooltip" xml:space="preserve">
     <value>Which language to translate the in-game dialogue boxes to.</value>
@@ -247,25 +247,25 @@
     <value>The non-exhaustive list of issues and TODOs is available in the link below:</value>
   </data>
   <data name="OverlayAdjustmentOrientations" xml:space="preserve">
-    <value>Please adjust position if your overlay is not centered relative to the game's UI text box.</value>
+    <value>Please adjust the position if your Plugin Overlay is not centered relative to the game's UI text box.</value>
   </data>
   <data name="OverlayColorSelectName" xml:space="preserve">
     <value>OverlayColorSelect</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Click to choose the overlay font color</value>
+    <value>Click to choose the Plugin Overlay font color</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
-    <value>Adjust the Overlay font scale</value>
+    <value>Adjust the Plugin Overlay font scale</value>
   </data>
   <data name="OverlayFontSizeLabel" xml:space="preserve">
-    <value>Overlay Font Size</value>
+    <value>Plugin Overlay font size</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Select the font size for the text overlay</value>
+    <value>Select the font size for the Plugin Overlay text</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Translation Overlay Height multiplier</value>
+    <value>Plugin Overlay height multiplier</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Battle talk (Enenies dialogue lines) translation</value>
@@ -275,16 +275,16 @@
     <value>Position adjustment</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Display translated text overlay above game UI text box instead of replacing its text with the translation</value>
+    <value>Display translated text in a Plugin Overlay above the game UI text box instead of replacing its text with the translation</value>
   </data>
   <data name="OverlayForceShowTitleToggleLabel" xml:space="preserve">
-    <value>Show overlay title bar with speaker name when available</value>
+    <value>Show a Plugin Overlay title bar with speaker name when available</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Adjust translation overlay width</value>
+    <value>Adjust Plugin Overlay width</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Translation Overlay Width multiplier</value>
+    <value>Plugin Overlay width multiplier</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Absolute path to Echoglossian folder (inside XIVLauncher -&gt; pluginConfigs folder)</value>
@@ -332,13 +332,13 @@
     <value>Echoglossian settings reset to default successfully!</value>
   </data>
   <data name="SwapTranslationTextToggle" xml:space="preserve">
-    <value>Show Original dialogue text in Overlay and Translated in the Game UI dialogue box</value>
+    <value>Show original dialogue text in a Plugin Overlay and translated text in the game UI dialogue box</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Adjust toast translation overlay width</value>
+    <value>Adjust toast Plugin Overlay width</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Toast Overlay Width multiplier</value>
+    <value>Toast Plugin Overlay width multiplier</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>TODOs List on Github</value>
@@ -383,7 +383,7 @@
     <value>Translations are Enabled!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Use overlay to show Toasts translations (WIP)</value>
+    <value>Use a Plugin Overlay to show toast translations (WIP)</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>Awaiting translation...</value>
@@ -848,34 +848,34 @@
     <value>Native UI translation</value>
   </data>
   <data name="JournalQuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Tooltip translation only</value>
+    <value>Plugin Tooltip translation only</value>
   </data>
   <data name="JournalQuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI translation + original tooltips</value>
+    <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Journal quest display mode</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal hover tooltips follow this mode directly; the global tooltip toggle only affects other translated UI.</value>
+    <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
   </data>
   <data name="JournalGlobalHoverTooltipsLabel" xml:space="preserve">
-    <value>Enable global hover tooltips for other translated UI</value>
+    <value>Enable global Plugin Tooltips for other translated UI</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslation" xml:space="preserve">
     <value>Native UI translation</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Tooltip translation only</value>
+    <value>Plugin Tooltip translation only</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI translation + original tooltips</value>
+    <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Quest display mode</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, tooltip-only keeps the addon intact, and native-with-original-tooltips writes translation natively while showing the original in tooltips.</value>
+    <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
   </data>
   <data name="TranslateJournalAcceptToggle" xml:space="preserve">
     <value>Translate JournalAccept</value>
@@ -926,19 +926,19 @@
     <value>Quest</value>
   </data>
   <data name="ToastModeDescription" xml:space="preserve">
-    <value>Each toast type can choose independently between native replacement and overlay rendering.</value>
+    <value>Each toast type can choose independently between native replacement and Plugin Overlay rendering.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>When a toast type uses overlay mode, you can also swap the texts so the overlay keeps the original line while the native toast shows the translation.</value>
+    <value>When a toast type uses Plugin Overlay mode, you can also swap the texts so the Plugin Overlay keeps the original line while the native toast shows the translation.</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>Overlay-only language is active, so all toast types will render through overlays.</value>
+    <value>Plugin Overlay-only language support is active, so all toast types will render through Plugin Overlays.</value>
   </data>
   <data name="OverlayOnlyLanguageActiveThisToastTypeWillRenderThroughAnOverlay" xml:space="preserve">
-    <value>Overlay-only language is active, so this toast type will render through an overlay.</value>
+    <value>Plugin Overlay-only language support is active, so this toast type will render through a Plugin Overlay.</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>Native replacement mode is active for this toast type. Overlay style controls are not used in this mode.</value>
+    <value>Native replacement mode is active for this toast type. Plugin Overlay style controls are not used in this mode.</value>
   </data>
   <data name="ToastOverlayScreenInfoWideTextSectionTitle" xml:space="preserve">
     <value>Screen Info (_WideText)</value>
@@ -962,7 +962,7 @@
     <value>Enable this toast type</value>
   </data>
   <data name="ToastOverlayUseOverlayForThisToastTypeLabel" xml:space="preserve">
-    <value>Use overlay for this toast type</value>
+    <value>Use a Plugin Overlay for this toast type</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Translate MiniTalk</value>
@@ -974,19 +974,19 @@
     <value>Background opacity</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Controls how opaque the toast overlay background should be. Use 0 for a fully transparent background.</value>
+    <value>Controls how opaque the toast Plugin Overlay background should be. Use 0 for a fully transparent background.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>This mode controls how the translated text is presented. Native UI writes directly into the game addon, overlay-only leaves the native addon untouched, and native-with-original-overlay writes translation natively while showing the original in the overlay.</value>
+    <value>This mode controls how the translated text is presented. Native UI writes directly into the game addon, Plugin Overlay translation only leaves the native addon untouched, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in the Plugin Overlay.</value>
   </data>
   <data name="OverlayDisplayModeOverlayTranslationOnly" xml:space="preserve">
-    <value>Overlay translation only</value>
+    <value>Plugin Overlay translation only</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
-    <value>Native UI translation + original overlay</value>
+    <value>Native UI translation + original Plugin Overlay</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>The selected language does not support the native game font, so this surface is limited to Echoglossian overlays and custom tooltips.</value>
+    <value>The selected language does not support the native game font, so this surface is limited to Plugin Overlays and Plugin Tooltips.</value>
   </data>
   <data name="ActionAndItemTooltipsSectionLabel" xml:space="preserve">
     <value>Action and item details</value>
@@ -995,25 +995,25 @@
     <value>Detail display mode</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, overlay-only keeps the native addon intact and uses Echoglossian overlays, and native-with-original-overlay writes translation natively while showing the original in our overlay.</value>
+    <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Hover tooltip appearance</value>
+    <value>Plugin Tooltip appearance</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Tooltip text color</value>
+    <value>Plugin Tooltip text color</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Tooltip background color</value>
+    <value>Plugin Tooltip background color</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Tooltip background opacity</value>
+    <value>Plugin Tooltip background opacity</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>These colors apply to Echoglossian hover tooltips used by quest and DB-first UI surfaces.</value>
+    <value>These colors apply to Plugin Tooltips used by quest and DB-first UI surfaces.</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Translate Main Command</value>
+      <value>Translate Game Main Menu</value>
   </data>
   <data name="TranslateActionMenuWindow" xml:space="preserve">
     <value>Translate ActionMenu Window</value>
@@ -1073,7 +1073,7 @@
     <value>Could not fetch models. Is Ollama running locally?</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Enable action/item detail translation and shared hover tooltips</value>
+    <value>Enable action/item detail translation and shared Plugin Tooltips</value>
   </data>
   <data name="NoModelsAvailable" xml:space="preserve">
     <value>No models available.</value>

--- a/Properties/Resources.ru.resx
+++ b/Properties/Resources.ru.resx
@@ -89,7 +89,7 @@
     <value>Активируйте перевод игрового текста в реальном времени</value>
   </data>
   <data name="FontColorSelectLabel" xml:space="preserve">
-    <value>Цвет шрифта наложения:</value>
+    <value>Цвет шрифта Plugin Overlay:</value>
   </data>
   <data name="HelpMessage" xml:space="preserve">
     <value>Открывает окно конфигурации Echoglossian</value>
@@ -135,7 +135,7 @@
     <value>OverlayColorSelect (НаложениеColorSelect)</value>
   </data>
   <data name="OverlayFontColorOrientations" xml:space="preserve">
-    <value>Нажмите, чтобы выбрать цвет шрифта наложения</value>
+    <value>Нажмите, чтобы выбрать цвет шрифта Plugin Overlay</value>
   </data>
   <data name="OverlayFontScaleLabel" xml:space="preserve">
     <value>Настройка масштаба шрифта Наложение</value>
@@ -144,10 +144,10 @@
     <value>Размер наложенного шрифта</value>
   </data>
   <data name="OverlayFontSizeOrientations" xml:space="preserve">
-    <value>Выберите размер шрифта для наложения текста</value>
+    <value>Выберите размер шрифта для Plugin Overlay текста</value>
   </data>
   <data name="OverlayHeightScrollLabel" xml:space="preserve">
-    <value>Множитель высоты наложения перевода</value>
+    <value>Множитель высоты Plugin Overlay перевода</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
     <value>Перевод разговора о битве (диалоговые строки Энениса)</value>
@@ -157,13 +157,13 @@
     <value>Регулировка положения</value>
   </data>
   <data name="OverlayToggleLabel" xml:space="preserve">
-    <value>Отображение наложения переведенного текста над текстовым полем игрового интерфейса вместо замены его текста переводом</value>
+    <value>Отображение Plugin Overlay переведенного текста над текстовым полем игрового интерфейса вместо замены его текста переводом</value>
   </data>
   <data name="OverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Настройка ширины наложения перевода</value>
+    <value>Настройка ширины Plugin Overlay перевода</value>
   </data>
   <data name="OverlayWidthScrollLabel" xml:space="preserve">
-    <value>Множитель ширины наложения перевода</value>
+    <value>Множитель ширины Plugin Overlay перевода</value>
   </data>
   <data name="PathInputInstructions" xml:space="preserve">
     <value>Абсолютный путь к папке Echoglossian (внутри XIVLauncher -&gt; папка pluginConfigs)</value>
@@ -214,10 +214,10 @@
     <value>Показать исходный текст диалога в оверлее и переведенный в диалоговом окне пользовательского интерфейса игры</value>
   </data>
   <data name="ToastOverlayWidthMultiplierOrientations" xml:space="preserve">
-    <value>Настройка ширины наложения перевода всплывающих уведомлений</value>
+    <value>Настройка ширины Plugin Overlay перевода всплывающих уведомлений</value>
   </data>
   <data name="ToastOverlayWidthScrollLabel" xml:space="preserve">
-    <value>Множитель ширины наложения тоста</value>
+    <value>Множитель ширины Plugin Overlay тоста</value>
   </data>
   <data name="TodoUrl" xml:space="preserve">
     <value>Список TODO на Github</value>
@@ -262,7 +262,7 @@
     <value>Переводы включены!</value>
   </data>
   <data name="UseImGuiForToastsToggle" xml:space="preserve">
-    <value>Использование наложения для отображения переводов всплывающих уведомлений (WIP)</value>
+    <value>Использование Plugin Overlay для отображения переводов всплывающих уведомлений (WIP)</value>
   </data>
   <data name="WaitingForTranslation" xml:space="preserve">
     <value>В ожидании перевода...</value>
@@ -646,10 +646,10 @@
     <value>Подробный режим отображения</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
-    <value>Этот режим управляет поверхностями ActionDetail и ItemDetail. Native UI записывает переведенный подробный текст в дополнение к игре, overlay-only сохраняет родное дополнение нетронутым и использует оверлеи Echoglossian, а Native-with-original-overlay записывает перевод изначально, показывая оригинал в нашем наложении.</value>
+    <value>Этот режим управляет поверхностями ActionDetail и ItemDetail. Native UI записывает переведённый подробный текст в дополнение к игре, Plugin Overlay translation only сохраняет родное дополнение нетронутым и использует Plugin Overlays, а Native UI translation + original Plugin Overlay записывает перевод нативно, показывая оригинал в нашем Plugin Overlay.</value>
   </data>
   <data name="ActionAndItemTooltipsToggleLabel" xml:space="preserve">
-    <value>Включить перевод сведений о действии/элементе и общие подсказки при наведении</value>
+    <value>Включить перевод сведений о действии/элементе и общие Plugin Tooltips</value>
   </data>
   <data name="CouldNotFetchOllamaModels" xml:space="preserve">
     <value>Не удалось получить модели. Ollama работает локально?</value>
@@ -661,31 +661,31 @@
     <value>Игровые окна</value>
   </data>
   <data name="HoverTooltipAppearanceDescription" xml:space="preserve">
-    <value>Эти цвета применяются к всплывающим подсказкам Echoglossian, используемым в квестах и ​​поверхностях пользовательского интерфейса DB-first.</value>
+    <value>Эти цвета применяются к Plugin Tooltips, используемым в квестах и поверхностях пользовательского интерфейса DB-first.</value>
   </data>
   <data name="HoverTooltipAppearanceSectionLabel" xml:space="preserve">
-    <value>Внешний вид всплывающей подсказки при наведении</value>
+    <value>Внешний вид всплывающей Plugin Tooltip при наведении</value>
   </data>
   <data name="HoverTooltipBackgroundColorLabel" xml:space="preserve">
-    <value>Цвет фона подсказки</value>
+    <value>Цвет фона Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipBackgroundOpacityLabel" xml:space="preserve">
-    <value>Непрозрачность фона подсказки</value>
+    <value>Непрозрачность фона Plugin Tooltip</value>
   </data>
   <data name="HoverTooltipTextColorLabel" xml:space="preserve">
-    <value>Цвет текста подсказки</value>
+    <value>Цвет текста Plugin Tooltip</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
-    <value>Этот режим управляет журналом, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept и JournalResult. Подсказки при наведении на журнал напрямую следуют этому режиму; глобальный переключатель всплывающей подсказки влияет только на другой переведенный пользовательский интерфейс.</value>
+    <value>Этот режим управляет Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept и JournalResult. Plugin Tooltips Journal напрямую следуют этому режиму; global переключатель Plugin Tooltip влияет только на другой переведённый UI.</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
     <value>Режим отображения квестов журнала</value>
   </data>
   <data name="NativeReplacementModeIsActiveForThisToastTypeOverlayStyleControlsAreNotUsedInThisMode" xml:space="preserve">
-    <value>Для этого типа всплывающего уведомления активен режим собственной замены. В этом режиме элементы управления стилем наложения не используются.</value>
+    <value>Для этого типа всплывающего уведомления активен режим собственной замены. В этом режиме элементы управления стилем Plugin Overlay не используются.</value>
   </data>
   <data name="OverlayDisplayModeDescription" xml:space="preserve">
-    <value>Этот режим контролирует представление переведенного текста. Native UI записывает перевод непосредственно в аддон игры, Overlay-only оставляет родной аддон нетронутым, а Native-with-original-overlay записывает перевод изначально, показывая оригинал в наложении.</value>
+    <value>Этот режим контролирует представление переведенного текста. Native UI записывает перевод непосредственно в аддон игры, Plugin Overlay translation only оставляет родной аддон нетронутым, а Native UI translation + original Plugin Overlay записывает перевод изначально, показывая оригинал в наложении.</value>
   </data>
   <data name="OverlayDisplayModeNativeUiTranslationWithOriginalOverlay" xml:space="preserve">
     <value>Native UI перевод + оригинальное наложение</value>
@@ -697,10 +697,10 @@
     <value>Показывать наложенную строку заголовка с именем докладчика, если она доступна</value>
   </data>
   <data name="OverlayOnlyLanguageActiveAllToastTypesWillRenderThroughOverlays" xml:space="preserve">
-    <value>Язык только наложений активен, поэтому все типы всплывающих уведомлений будут отображаться через наложения.</value>
+    <value>Язык только наложений активен, поэтому все типы всплывающих уведомлений будут отображаться через Plugin Overlay.</value>
   </data>
   <data name="OverlayOnlyLanguageModeDescription" xml:space="preserve">
-    <value>Выбранный язык не поддерживает собственный шрифт игры, поэтому эта поверхность ограничена наложениями Echoglossian и пользовательскими подсказками.</value>
+    <value>Выбранный язык не поддерживает собственный шрифт игры, поэтому эта поверхность ограничена Plugin Overlays и Plugin Tooltips.</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -709,7 +709,7 @@
     <value>MiniTalk</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
-    <value>Этот режим управляет отображением этого окна квеста. Native UI записывает перевод в дополнение, Tooltip-only сохраняет дополнение нетронутым, а Native-with-Original-ToolTips записывает перевод изначально, отображая оригинал во всплывающих подсказках.</value>
+    <value>Этот режим управляет отображением этого окна квеста. Native UI записывает перевод в дополнение, Plugin Tooltip translation only сохраняет дополнение нетронутым, а Native UI translation + original Plugin Tooltips записывает перевод нативно, показывая оригинал в Plugin Tooltips.</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
     <value>Режим отображения квеста</value>
@@ -718,10 +718,10 @@
     <value>Native UI перевод</value>
   </data>
   <data name="QuestDisplayModeNativeUiTranslationWithOriginalTooltips" xml:space="preserve">
-    <value>Native UI перевод + оригинальные подсказки</value>
+    <value>Native UI перевод + оригинальные Plugin Tooltip</value>
   </data>
   <data name="QuestDisplayModeTooltipTranslationOnly" xml:space="preserve">
-    <value>Только перевод подсказки</value>
+    <value>Только перевод Plugin Tooltip</value>
   </data>
   <data name="QuestWindowsTabTitle" xml:space="preserve">
     <value>Окна квестов</value>
@@ -751,7 +751,7 @@
     <value>Каждый тип всплывающего уведомления может независимо выбирать между собственной заменой и наложением рендеринга.</value>
   </data>
   <data name="ToastModeSwapDescription" xml:space="preserve">
-    <value>Если тип всплывающего уведомления использует режим наложения, вы также можете поменять местами тексты, чтобы наложение сохраняло исходную строку, а собственное всплывающее уведомление отображало перевод.</value>
+    <value>Если тип всплывающего уведомления использует режим Plugin Overlay, вы также можете поменять местами тексты, чтобы наложение сохраняло исходную строку, а собственное всплывающее уведомление отображало перевод.</value>
   </data>
   <data name="ToastOverlayAreaSectionTitle" xml:space="preserve">
     <value>Тост за площадь</value>
@@ -760,7 +760,7 @@
     <value>Непрозрачность фона</value>
   </data>
   <data name="ToastOverlayBackgroundOpacityTooltip" xml:space="preserve">
-    <value>Управляет тем, насколько непрозрачным должен быть фон наложения всплывающего уведомления. Используйте 0 для полностью прозрачного фона.</value>
+    <value>Управляет тем, насколько непрозрачным должен быть фон Plugin Overlay всплывающего уведомления. Используйте 0 для полностью прозрачного фона.</value>
   </data>
   <data name="ToastOverlayClassJobChangeSectionTitle" xml:space="preserve">
     <value>Тост о смене класса/работы</value>
@@ -823,7 +823,7 @@
     <value>Перевести JournalResult</value>
   </data>
   <data name="TranslateMainCommandWindow" xml:space="preserve">
-    <value>Перевести Main Command</value>
+      <value>Переводить главное меню игры</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
     <value>Перевести MiniTalk</value>


### PR DESCRIPTION
## Summary
- unify `_MainCommand` and `AddonContextMenuTitle` under a single `Game Main Menu` toggle and display mode
- keep `ActionMenu` independent and leave its behavior unchanged
- standardize plugin-generated terminology across localized resources to `Plugin Overlay(s)` and `Plugin Tooltip(s)`
- add config normalization coverage for the unified game main menu settings

## Validation
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build Echoglossian.csproj -c Release --no-restore`
