### PR TITLE
fix(#198): stabilize addon handler refresh and add release workflow skill

### DIFF
--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -32,7 +32,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Company>lokinmodar</Company>
     <Description>Final Fantasy XIV game text translator</Description>
-    <Copyright>lokinmodar - 2021-2025</Copyright>
+    <Copyright>lokinmodar - 2021-2026</Copyright>
     <PackageProjectUrl>https://github.com/lokinmodar/Echoglossian/</PackageProjectUrl>
     <Nullable>enable</Nullable>
     <ApplicationIcon>minfilia.ico</ApplicationIcon>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2047,6 +2047,11 @@
                 payloads.
             </summary>
             <summary>
+                Handles the quest probe command used to inspect the complete quest data
+                shape from Lumina, the live quest progress resolver, and the current
+                QuestPlate database rows.
+            </summary>
+            <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
                 <see cref="E:Dalamud.Plugin.Services.IToastGui.QuestToast" /> instead of the addon-handler
                 registrar.
@@ -2557,6 +2562,11 @@
             Holds the database editor window instance.
             </summary>
         </member>
+        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
+            <summary>
+            Holds the currently active addon structure probe watch, if any.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -2669,6 +2679,11 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
+            <summary>
+                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -4018,6 +4033,21 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
+            <summary>
+            Dumps a recursive probe of the requested addon to the log so we can
+            inspect its live node tree, component roots, and likely overlay anchors.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
+            <summary>
+            Parses the addon probe command arguments into an addon name and optional index.
+            </summary>
+            <param name="args">The raw command arguments.</param>
+            <returns>The addon name and index to probe.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -4286,6 +4316,102 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
+            <summary>
+                Handles the quest probe command.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
+            <summary>
+                Tries to resolve the quest probe target from either a quest id or a
+                quest name.
+            </summary>
+            <param name="input">The command argument.</param>
+            <param name="questIdText">The resolved quest id as text.</param>
+            <param name="questName">The resolved quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>True when the quest could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the quest data structure for inspection.
+            </summary>
+            <param name="questIdText">The quest id as text.</param>
+            <param name="questName">The quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the raw Lumina quest row properties.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs all rows from the quest text sheet, not just the live todo
+                entries, so we can inspect the full structure of the quest sheet.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
+            <summary>
+                Logs the QuestPlate rows currently stored for the quest.
+            </summary>
+            <param name="questIdText">The quest id text.</param>
+            <param name="questName">The quest name.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Logs the resolved live quest progression snapshot.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves a human-readable quest name from a quest row.
+            </summary>
+            <param name="questRow">The quest row.</param>
+            <returns>The resolved quest name, if available.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
+            <summary>
+                Converts quest text to a readable string for probe output.
+            </summary>
+            <param name="text">The quest text.</param>
+            <returns>The evaluated text string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
+            <summary>
+                Formats a probe value for log output.
+            </summary>
+            <param name="value">The value to format.</param>
+            <returns>A human-readable value string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Builds the raw quest sheet name used by the game files.
+            </summary>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>The quest text sheet name, if it can be derived.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest row id as text through reflection so the probe
+                stays compatible with generated sheet shapes.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest row id as text, or an empty string if unavailable.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest sheet identifier used to mount the quest text
+                sheet path.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -6716,152 +6842,7 @@
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.#ctor">
             <summary>
-             Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage"/> class.
-             </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalSecondaryText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalSecondaryText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslatedText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslatedText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslatedSecondaryText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslatedSecondaryText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslationLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslationLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslationEngine">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslationEngine(System.Int32)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetEntityKey">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetEntityKey(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetGameVersion">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetGameVersion(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText">
-            <summary>
-                Represents one canonical DB-first BgcArmyAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText.BgcArmyActionId">
-            <summary>
-                Gets or sets the BgcArmyAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.BuddyActionText">
-            <summary>
-                Represents one canonical DB-first BuddyAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.BuddyActionText.BuddyActionId">
-            <summary>
-                Gets or sets the BuddyAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BuddyActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.CompanyActionText">
-            <summary>
-                Represents one canonical DB-first CompanyAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.CompanyActionText.CompanyActionId">
-            <summary>
-                Gets or sets the CompanyAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.CompanyActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.CraftActionText">
-            <summary>
-                Represents one canonical DB-first CraftAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.CraftActionText.CraftActionId">
-            <summary>
-                Gets or sets the CraftAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.CraftActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText">
-            <summary>
-                Represents one canonical DB-first DeepDungeonItem payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.DeepDungeonItemId">
-            <summary>
-                Gets or sets the DeepDungeonItem row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText">
-            <summary>
-                Represents one canonical DB-first EurekaMagiaAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText.EurekaMagiaActionId">
-            <summary>
-                Gets or sets the EurekaMagiaAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.EventActionText">
-            <summary>
-                Represents one canonical DB-first EventAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.EventActionText.EventActionId">
-            <summary>
-                Gets or sets the EventAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.EventActionText.ToString">
+             Initializes a new instance of the <see cref="Tels.EventActionText.ToString">
             <inheritdoc />
         </member>
         <member name="T:Echoglossian.EFCoreSqlite.Models.EventItemText">
@@ -9723,6 +9704,103 @@
             <param name="engine">The translation engine identifier.</param>
             <param name="gameVersion">The current game version.</param>
             <param name="fallbackLookup">The persisted fallback lookup.</param>
+            <param name="translatedText">The resolved translated text.</param>
+            <returns>
+                <see langword="true" /> when a translated text was resolved;
+                otherwise <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.TryResolveLevelAwareOriginalText(System.String,System.String,System.Int32,System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.String@)">
+            <summary>
+                Tries to resolve one canonical original text by reversing only the
+                visible action name when the translated text ends with a trailing
+                level token.
+            </summary>
+            <param name="visibleText">The visible translated text.</param>
+            <param name="targetLanguage">The target translation language.</param>
+            <param name="engine">The translation engine identifier.</param>
+            <param name="gameVersion">The current game version.</param>
+            <param name="fallbackLookup">The persisted reverse lookup.</param>
+            <param name="originalText">The resolved canonical original text.</param>
+            <returns>
+                <see langword="true" /> when an original text was resolved;
+                otherwise <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.ResolveTranslatedBaseText(System.String,System.String,System.Int32,System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.String})">
+            <summary>
+                Resolves one translated text without applying any level-token
+                decomposition.
+            </summary>
+            <param name="originalText">The original text.</param>
+            <param name="targetLanguage">The target translation language.</param>
+            <param name="engine">The translation engine identifier.</param>
+            <param name="gameVersion">The current game version.</param>
+            <param name="fallbackLookup">The persisted fallback lookup.</param>
+            <returns>The resolved translated text, or the original text.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.ResolveOriginalBaseText(System.String,System.String,System.Int32,System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.String})">
+            <summary>
+                Resolves one canonical original text without applying any
+                level-token decomposition.
+            </summary>
+            <param name="visibleText">The translated text.</param>
+            <param name="targetLanguage">The target translation language.</param>
+            <param name="engine">The translation engine identifier.</param>
+            <param name="gameVersion">The current game version.</param>
+            <param name="fallbackLookup">The persisted reverse lookup.</param>
+            <returns>The resolved original text, or the visible text.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.TryParseTrailingLevelToken(System.String,System.String@,System.String@,System.String@,System.String@)">
+            <summary>
+                Tries to parse one text into a visible prefix, separator, and
+                trailing level token.
+            </summary>
+            <param name="text">The text to parse.</param>
+            <param name="prefix">The visible text before the level token.</param>
+            <param name="separator">The separator before the level token.</param>
+            <param name="levelLabel">The level label prefix.</param>
+            <param name="levelNumber">The trailing level number.</param>
+            <returns>
+                <see langword="true" /> when the text contains one trailing level
+                token; otherwise <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.NormalizeTranslatedLevelToken(System.String,System.String,System.String)">
+            <summary>
+                Normalizes one translated level token for the target language.
+            </summary>
+            <param name="levelLabel">The source level label.</param>
+            <param name="levelNumber">The trailing level number.</param>
+            <param name="targetLanguage">The target translation language.</param>
+            <returns>The normalized translated level token.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.NormalizeOriginalLevelToken(System.String,System.String)">
+            <summary>
+                Normalizes one translated level token back to the canonical English
+                source token.
+            </summary>
+            <param name="levelLabel">The visible translated level label.</param>
+            <param name="levelNumber">The trailing level number.</param>
+            <returns>The canonical English level token.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.NormalizeResolvedLevelSeparator(System.String)">
+            <summary>
+                Normalizes one resolved level separator so malformed payloads that
+                collapsed the separator can still be rewritten into readable text.
+            </summary>
+            <param name="separator">The captured separator.</param>
+            <returns>The separator to use in one rebuilt level-aware label.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.ActionMenu.ActionMenuWindowHandler.MergeTranslatedIntMap(System.Collections.Generic.SortedDictionary{System.Int32,System.String},System.Collections.Generic.SortedDictionary{System.Int32,System.String},System.String,System.Int32,System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.String})">
+            <summary>
+                Merges one integer-keyed translated payload map with canonical
+                translations derived from repo-local sources.
+            </summary>
+            <param name="originalValues">The original values.</param>
+            <param name="resolvedTranslatedValues">The resolved translated values.</param>
+            <param name="targetLanguage">The target translation language.</param>
+            <para fallback lookup.</param>
             <param name="translatedText">The resolved translated text.</param>
             <returns>
                 <see langword="true" /> when a translated text was resolved;
@@ -14453,120 +14531,7 @@
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryLoadStoredTranslation(System.String,System.String@,System.String@)">
             <summary>
-                Attempts to load a stored MiniTalk translation from the database.
-            </summary>
-            <param name="originalText">The source MiniTalk text.</param>
-            <param name="translatedText">Receives the translated text.</param>
-            <param name="replacementText">Receives the normalized replacement text.</param>
-            <returns>
-                <see langword="true" /> when a stored translation exists;
-                otherwise, <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryGetCurrentResolvedTranslation(System.IntPtr,System.String@,System.String@,System.String@)">
-            <summary>
-                Returns the active resolved translation currently held by the handler
-                state.
-            </summary>
-            <param name="originalText">Receives the active original text.</param>
-            <param name="translatedText">Receives the translated text.</param>
-            <param name="replacementText">Receives the normalized replacement text.</param>
-            <returns>
-                <see langword="true" /> when the handler already has a translated line;
-                otherwise, <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryQueueTranslation(System.IntPtr,System.String,System.Int32@)">
-            <summary>
-                Starts a new translation request when the visible source line changes or
-                when the current line still has no cached translation.
-            </summary>
-            <param name="originalText">The source MiniTalk text.</param>
-            <param name="requestId">Receives the active request identifier.</param>
-            <returns>
-                <see langword="true" /> when a new translation task should be queued;
-                otherwise, <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.SetResolvedState(System.IntPtr,System.String,System.String,System.String)">
-            <summary>
-                Sets the resolved in-memory state for the current MiniTalk line.
-            </summary>
-            <param name="originalText">The original MiniTalk text.</param>
-            <param name="translatedText">The translated MiniTalk text.</param>
-            <param name="replacementText">The translated text normalized for native replacement.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.PublishOverlay(System.IntPtr,System.String,System.String,System.String)">
-            <summary>
-                Publishes translated MiniTalk content to the configured overlay when
-                overlay mode is enabled.
-            </summary>
-            <param name="originalText">The original MiniTalk text.</param>
-            <param name="translatedText">The translated MiniTalk text.</param>
-            <param name="trigger">The log trigger label associated with the call.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ShouldUseOverlay">
-            <summary>
-                Determines whether this MiniTalk request should render through the
-                overlay path.
-            </summary>
-            <returns>
-                <see langword="true" /> when the overlay path is active; otherwise,
-                <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ShouldApplyNativeText">
-            <summary>
-                Determines whether the MiniTalk addon should receive translated text
-                directly in the game UI.
-            </summary>
-            <returns>
-                <see langword="true" /> when the addon should be replaced natively;
-                otherwise, <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ShouldSwapTexts">
-            <summary>
-                Determines whether the overlay should currently show the original text
-                while the native addon receives the translation.
-            </summary>
-            <returns>
-                <see langword="true" /> when overlay swap mode is active; otherwise,
-                <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.BuildLookupMessage(System.String)">
-            <summary>
-                Builds a lookup entity matching the MiniTalk database schema.
-            </summary>
-            <param name="originalText">The original MiniTalk text.</param>
-            <returns>A formatted <see cref="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage" /> suitable for DB lookup.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.NormalizeForReplacement(System.String)">
-            <summary>
-                Normalizes translated MiniTalk text before native replacement when the
-                active config requests diacritic stripping.
-            </summary>
-            <param name="text">The translated MiniTalk text to normalize.</param>
-            <returns>The text that should be written back into the native addon.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ReadTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
-            <summary>
-                Reads the current string value from a MiniTalk text node.
-            </summary>
-            <param name="textNode">The text node to inspect.</param>
-            <returns>The visible node text, or an empty string when unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TextMatches(System.String,System.String)">
-            <summary>
-                Compares two rendered text values after normalizing spacing and the
-                optional diacritic removal rules used for native replacement.
-            </summary>
-            <param name="left">The first text value.</param>
-            <param name="right">The second text value.</param>
-            <returns><see langword="true" /> when the texts should be considered equal.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.NormalizeForComparison(System.String)">
+            .NativeUI.AddonHandlers.SingleText.MiniTalkHandler.NormalizeForComparison(System.String)">
             <summary>
                 Normalizes text for comparison against native node values.
             </summary>
@@ -16663,6 +16628,133 @@
             </param>
             <param name="addonLifecycle">The lifecycle manager for the addons.</param>
         </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar.GetStableEventHandlers(Echoglossian.NativeUI.Handlers.IAddonTranslationHandler)">
+            <summary>
+                Returns one stable event-handler map for the lifetime of the supplied
+                addon handler instance so       </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.ClassJobCategoryId">
+            <summary>
+                Gets or sets the class-job-category row identifier.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.Name">
+            <summary>
+                Gets or sets the original action name.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.Description">
+            <summary>
+                Gets or sets the original action description.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.TranslatedName">
+            <summary>
+                Gets or sets the translated action name.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.TranslatedDescription">
+            <summary>
+                Gets or sets the translated action description.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.HasCompleteTranslation">
+            <summary>
+                Gets whether the canonical payload has every translated field required for UI usage.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.Serialize">
+            <summary>
+                Serializes the payload using a stable JSON shape.
+            </summary>
+            <returns>The serialized payload.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.ComputeSourceContentHash">
+            <summary>
+                Computes a stable source-content hash using only original source semantics.
+            </summary>
+            <returns>The stable source hash.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.BuildOriginalTooltipText">
+            <summary>
+                Builds the fully assembled original tooltip text.
+            </summary>
+            <returns>The original tooltip text.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.BuildTranslatedTooltipText">
+            <summary>
+                Builds the fully assembled translated tooltip text when complete.
+            </summary>
+            <returns>The translated tooltip text, or <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.Deserialize(System.String)">
+            <summary>
+                Deserializes a canonical action-tooltip payload.
+            </summary>
+            <param name="serializedPayload">The serialized payload.</param>
+            <returns>The deserialized payload, or <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.ActionTooltipCanonicalPayload.BuildTooltipText(System.String,System.String)">
+            <summary>
+                Builds one tooltip text block from title and body.
+            </summary>
+            <param name="title">The title line.</param>
+            <param name="body">The body text.</param>
+            <returns>The combined tooltip text.</returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar">
+            <summary>
+                Utility for registering and unregistering addon translation handlers.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar.Register(System.String,Echoglossian.NativeUI.Handlers.IAddonTranslationHandler,Dalamud.Plugin.Services.IAddonLifecycle)">
+            <summary>
+                Registers an addon translation handler with the specified addon lifecycle.
+            </summary>
+            <param name="addonName">The name of the addon to register the handler for.</param>
+            <param name="handler">The handler responsible for addon translation.</param>
+            <param name="addonLifecycle">The lifecycle manager for the addon.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar.RegisterMany(System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,Echoglossian.NativeUI.Handlers.IAddonTranslationHandler}},Dalamud.Plugin.Services.IAddonLifecycle)">
+            <summary>
+                Registers multiple addon translation handlers with the specified addon
+                lifecycle.
+            </summary>
+            <param name="handlers">
+                A collection of addon names and their corresponding
+                handlers.
+            </param>
+            <param name="addonLifecycle">The lifecycle manager for the addons.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar.Unregister(System.String,Echoglossian.NativeUI.Handlers.IAddonTranslationHandler,Dalamud.Plugin.Services.IAddonLifecycle)">
+            <summary>
+                Unregisters an addon translation handler from the specified addon
+                lifecycle.
+            </summary>
+            <param name="addonName">The name of the addon to unregister the handler for.</param>
+            <param name="handler">The handler responsible for addon translation.</param>
+            <param name="addonLifecycle">The lifecycle manager for the addon.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar.UnregisterMany(System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,Echoglossian.NativeUI.Handlers.IAddonTranslationHandler}},Dalamud.Plugin.Services.IAddonLifecycle)">
+            <summary>
+                Unregisters multiple addon translation handlers from the specified addon
+                lifecycle.
+            </summary>
+            <param name="handlers">
+                A collection of addon names and their corresponding
+                handlers.
+            </param>
+            <param name="addonLifecycle">The lifecycle manager for the addons.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonHandlerRegistrar.GetStableEventHandlers(Echoglossian.NativeUI.Handlers.IAddonTranslationHandler)">
+            <summary>
+                Returns one stable event-handler map for the lifetime of the supplied
+                addon handler instance so register and unregister use the same
+                delegate instances.
+            </summary>
+            <param name="handler">The addon handler instance.</param>
+            <returns>The stable event-handler map for that handler instance.</returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonLifecycleExtensions">
             <summary>
             Provides extension methods for registering and removing logging listeners for key lifecycle events of add-ons
@@ -16675,91 +16767,7 @@
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.AddonLifecycleExtensions.LogAddon(Dalamud.Plugin.Services.IAddonLifecycle,System.String,System.Collections.Generic.IReadOnlyCollection{Dalamud.Game.Addon.Lifecycle.AddonEvent})">
             <summary>
-            Registers a logger as a listener for key lifecycle events of the specified addon.
-            </summary>
-            <remarks>This method attaches a logger to several important lifecycle events, enabling logging for
-            setup, refresh, event reception, requested updates, and finalization phases of the addon. This can assist in
-            monitoring and debugging addon behavior throughout its lifecycle.</remarks>
-            <param name="addonLifecycle">The addon lifecycle manager used to register event listeners.</param>
-            <param name="addonName">The name of the addon for which lifecycle event listeners are registered.</param>
-            <param name="events">Optional lifecycle event set to log. Defaults to the full event set.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonLifecycleExtensions.Logger(Dalamud.Game.Addon.Lifecycle.AddonEvent,Dalamud.Game.Addon.Lifecycle.AddonArgTypes.AddonArgs)">
-            <summary>
-            Writes a debug log entry for the specified add-on event and its associated arguments.
-            </summary>
-            <param name="type">The event type that triggered the logging operation.</param>
-            <param name="args">The arguments containing details about the add-on, including its name and context.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonLifecycleExtensions.UnLogAddon(Dalamud.Plugin.Services.IAddonLifecycle,System.String,System.Collections.Generic.IReadOnlyCollection{Dalamud.Game.Addon.Lifecycle.AddonEvent})">
-            <summary>
-            Removes logging event listeners for the specified add-on from the provided add-on lifecycle instance.
-            </summary>
-            <remarks>This method unregisters logging listeners for several key lifecycle events, ensuring that log
-            output related to the specified add-on is no longer generated. Use this method when you want to stop logging
-            activity for an add-on without affecting its other event listeners.</remarks>
-            <param name="addonLifecycle">The add-on lifecycle instance from which logging event listeners will be removed. Cannot be null.</param>
-            <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
-            <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
-        </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
-            <summary>
-            Provides a generic recursive addon probe for live UI inspection.
-            </summary>
-            <remarks>
-            The traversal pattern is intentionally generic and was inspired by the
-            recursive addon walk used in SimpleTweaksPlugin's UIDebug helper and the
-            addon inspection approach used by HaselDebug. The goal here is to keep the
-            probe passive, reusable, and focused on structural logging rather than a
-            dedicated UI panel.
-            </remarks>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonStructureProbe.ProbeAddon(Dalamud.Plugin.Services.IGameGui,Dalamud.Plugin.Services.IPluginLog,System.String,System.Int32,System.Int32,System.Int32)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log.
-            </summary>
-            <param name="gameGui">The game GUI service used to resolve the addon.</param>
-            <param name="pluginLog">The plugin log used to emit the probe output.</param>
-            <param name="addonName">The addon name to inspect.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="maxDepth">Maximum recursion depth for the probe.</param>
-            <param name="maxNodes">Maximum number of visited nodes before aborting.</param>
-            <returns><see langword="true" /> if the addon was found and probed; otherwise <see langword="false" />.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonStructureProbe.ProbeAddon(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,Dalamud.Plugin.Services.IPluginLog,System.String,System.Int32,System.String,System.Int32,System.Int32)">
-            <summary>
-            Dumps a recursive probe for an already-resolved addon pointer.
-            </summary>
-            <param name="addon">The resolved addon pointer to inspect.</param>
-            <param name="pluginLog">The plugin log used to emit the probe output.</param>
-            <param name="addonName">The addon name to inspect.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="trigger">Optional trigger label used in the logs.</param>
-            <param name="maxDepth">Maximum recursion depth for the probe.</param>
-            <param name="maxNodes">Maximum number of visited nodes before aborting.</param>
-            <returns><see langword="true" /> if the addon pointer was valid and probed; otherwise <see langword="false" />.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonStructureProbe.TryResolveAddonPointer(Dalamud.Plugin.Services.IGameGui,System.String,System.Int32,FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*@)">
-            <summary>
-            Attempts to resolve an addon pointer by name and optional index.
-            </summary>
-            <param name="gameGui">The game GUI service used for the initial lookup.</param>
-            <param name="addonName">The addon name to resolve.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="addon">The resolved addon pointer, when found.</param>
-            <returns><see langword="true" /> when the addon was resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonStructureProbe.StartWatch(Dalamud.Plugin.Services.IGameGui,Dalamud.Plugin.Services.IPluginLog,System.String,System.Int32,System.Nullable{System.TimeSpan})">
-            <summary>
-            Starts a one-minute addon watch that polls for the addon and captures a
-            complete structural dump as soon as the addon becomes live.
-            </summary>
-            <param name="gameGui">The game GUI service used to resolve the addon.</param>
-            <param name="pluginLog">The plugin log used to emit the probe output.</param>
-            <param name="addonName">The addon name to watch.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="duration">How long the watch should stay active.</param>
-            <returns>The active watch instance.</returns>
+            Registers a logger as a listener for kewatch instance.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.AddonStructureProbe.TryGetLatestSnapshot(System.String,System.Int32,Echoglossian.NativeUI.Helpers.AddonStructureProbe.AddonStructureProbeSnapshot@)">
             <summary>
@@ -20773,6 +20781,131 @@
               Looks up a localized string similar to This mode controls how this quest window is presented. Native UI writes the translation into the addon, tooltip-only keeps the addon intact, and native-with-original-tooltips writes translation natively while showing the original in tooltips..
             </summary>
         </member>
+        <member name="P:Echoglosshoglossian.Properties.Resources.TranslateToastToggle">
+            <summary>
+              Looks up a localized string similar to Translate Toast Messages.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslateToastToggleText">
+            <summary>
+              Looks up a localized string similar to Translate in-game Toast Messages.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslateYesNoScreenLabel">
+            <summary>
+              Looks up a localized string similar to Translate Yes/No Screen.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslationDisabled">
+            <summary>
+              Looks up a localized string similar to Translations are Disabled!.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslationEnabled">
+            <summary>
+              Looks up a localized string similar to Translations are Enabled!.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslationEngineChoose">
+            <summary>
+              Looks up a localized string similar to Choose the translation engine.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslationEngineSettingsNotRequired">
+            <summary>
+              Looks up a localized string similar to This translation engine does not require any special settings..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslationError">
+            <summary>
+              Looks up a localized string similar to Translation Error:.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslationsEnabled">
+            <summary>
+              Looks up a localized string similar to Translations are Enabled!.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.UnableToLoadEntityForEditing">
+            <summary>
+              Looks up a localized string similar to Unable to load entity for editing..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.UseAuthentication">
+            <summary>
+              Looks up a localized string similar to Use Authentication.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.UseImGuiForToastsToggle">
+            <summary>
+              Looks up a localized string similar to Use overlay to show Toasts translations (WIP).
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeHelpMessage">
+            <summary>
+              Looks up a localized string similar to Awaiting translation....
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.QuestProbeHelpMessage">
+            <summary>
+              Looks up a localized string similar to Dumps a full quest data probe to the log. Usage: /egloquestprobe &lt;quest name or quest id&gt;.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AcceptedQuestPrefetchStartedNotification">
+            <summary>
+              Looks up a localized string similar to Background quest pre-translation started for {0} accepted quests..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AcceptedQuestPrefetchCompletedNotification">
+            <summary>
+              Looks up a localized string similar to Background quest pre-translation finished for {0} accepted quests..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToDoListAwaitingQuestDataNotification">
+            <summary>
+              Looks up a localized string similar to ToDoList is waiting for stored quest data for {0} visible quests. The addon will stay untouched until all quest data is ready..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ScenarioTreeAwaitingQuestDataNotification">
+            <summary>
+              Looks up a localized string similar to ScenarioTree is waiting for stored quest data for {0} visible quests. The addon will stay untouched until all quest data is ready..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ShowQuestProgressNotificationsDescription">
+            <summary>
+              Looks up a localized string similar to Shows informational notifications when background quest pre-translation starts or when quest windows are still waiting for stored quest data. Disabled by default to avoid noisy popups during normal gameplay..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ShowQuestProgressNotificationsToggle">
+            <summary>
+              Looks up a localized string similar to Show quest background notifications.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.QuestDisplayModeNativeUiTranslation">
+            <summary>
+              Looks up a localized string similar to Native UI translation.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.QuestDisplayModeTooltipTranslationOnly">
+            <summary>
+              Looks up a localized string similar to Tooltip translation only.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.QuestDisplayModeNativeUiTranslationWithOriginalTooltips">
+            <summary>
+              Looks up a localized string similar to Native UI translation + original tooltips.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.QuestDisplayModeLabel">
+            <summary>
+              Looks up a localized string similar to Quest display mode.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.QuestDisplayModeDescription">
+            <summary>
+              Looks up a localized string similar to This mode controls how this quest window is presented. Native UI writes the translation into the addon, tooltip-only keeps the addon intact, and native-with-original-tooltips writes translation natively while showing the original in tooltips..
+            </summary>
+        </member>
         <member name="P:Echoglossian.Properties.Resources.TranslateJournalAcceptToggle">
             <summary>
               Looks up a localized string similar to Translate JournalAccept.
@@ -20960,165 +21093,7 @@
         </member>
         <member name="P:Echoglossian.Properties.Resources.ToastOverlayBackgroundOpacityLabel">
             <summary>
-              Looks up a localized string similar to Background opacity.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.ToastOverlayBackgroundOpacityTooltip">
-            <summary>
-              Looks up a localized string similar to Controls how opaque the toast overlay background should be. Use 0 for a fully transparent background..
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.WhatToTranslateText">
-            <summary>
-              Looks up a localized string similar to Select what kind of text you want to be translated in the corresponding tab below!.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.WhichToastsToTranslate">
-            <summary>
-              Looks up a localized string similar to Select which kind of in-game message toasts to translate.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.YandexCloudApiKey">
-            <summary>
-              Looks up a localized string similar to YandexCloud Api Key.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.YandexCloudFolderId">
-            <summary>
-              Looks up a localized string similar to Folder ID.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.YesReset">
-            <summary>
-              Looks up a localized string similar to Yes, reset.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.ActionAndItemTooltipsSectionLabel">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.ActionAndItemTooltipsDisplayModeLabel">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.ActionAndItemTooltipsDisplayModeDescription">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.HoverTooltipAppearanceSectionLabel">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.HoverTooltipAppearanceDescription">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.HoverTooltipTextColorLabel">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.HoverTooltipBackgroundColorLabel">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.HoverTooltipBackgroundOpacityLabel">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.TranslateMainCommandWindow">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.TranslateActionMenuWindow">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.TranslateHudWindows">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.TranslateOperationGuideWindow">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.TranslateAddonContextMenuTitleWindow">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayDisplayModeDescription">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayDisplayModeOverlayTranslationOnly">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayDisplayModeNativeUiTranslationWithOriginalOverlay">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayOnlyLanguageModeDescription">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleTalkTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleBattleTalkTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleTalkSubtitleTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleMiniTalkTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleCutSceneSelectStringTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleTextGimmickHintTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleWideTextToastTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleErrorToastTranslation">
-            <summary>
-              Looks up a localized string.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Properties.Resources.OverlayWindowTitleAreaToastTranslation">
+              Looks up a localized string similar to glossian.Properties.Resources.OverlayWindowTitleAreaToastTranslation">
             <summary>
               Looks up a localized string.
             </summary>
@@ -21769,68 +21744,74 @@
             <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
             <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
             <returns>
-                A task that represents the asynchronous operation. The task result
-                contains the translated text as a string.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.Translators.TranslationService.AcceptTranslatedResultOrFallback(System.String,System.String,System.String,System.String,System.String,System.String)">
-            <summary>
-            Accepts a translated result only when it is safe to treat as a real
-            translation; otherwise records the failure and falls back to the
-            sanitized source text.
+                A task that representy.
             </summary>
-            <param name="translatedText">The translated text candidate.</param>
-            <param name="parsedText">The parsed source text sent to the translator.</param>
-            <param name="sanitizedText">The sanitized source text shown on fallback.</param>
-            <param name="normalizedSourceLanguage">The normalized source language code.</param>
-            <param name="normalizedTargetLanguage">The normalized target language code.</param>
-            <param name="resolvedOriginContext">The resolved origin context for diagnostics.</param>
-            <returns>
-            The accepted translated text, or <paramref name="sanitizedText" /> when
-            the result is empty or synthetic.
-            </returns>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <param name="cacheKey">The normalized cache key for this request.</param>
+            <returns>The translated text or an error placeholder.</returns>
         </member>
-        <member name="M:Echoglossian.Translators.TranslationService.ShouldBypassTranslationDueToMissingLanguageAssets">
+        <member name="M:Echoglossian.Translators.OllamaTranslator.TranslateCoreAsync(System.String,System.String,System.String,System.String)">
             <summary>
-            Determines whether the current selected language depends on missing
-            downloaded font assets and should therefore bypass translation work until
-            those assets are available.
+                Performs the actual Ollama translation request for one cache key.
             </summary>
-            <returns>
-            <c>true</c> when translation should be bypassed because required language
-            assets are missing; otherwise, <c>false</c>.
-            </returns>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <param name="cacheKey">The normalized cache key for this request.</param>
+            <returns>The translated text or an error placeholder.</returns>
         </member>
-        <member name="M:Echoglossian.Translators.TranslationService.CheckTextToTranslate(System.String)">
+        <member name="M:Echoglossian.Translators.OpenRouterTranslator.TranslateCoreAsync(System.String,System.String,System.String,System.String)">
             <summary>
-            Determines whether the specified text should be translated and returns a sanitized version of the text.
+                Performs the actual OpenRouter translation request for one cache key.
             </summary>
-            <param name="text">The text to be checked and potentially sanitized for translation.</param>
-            <returns>A tuple containing the sanitized text and a boolean indicating whether the text should be translated. The
-            sanitized text is an empty string if the input text is null or empty, or if the sanitized result is equivalent to
-            specific non-translatable patterns. The boolean is <see langword="true"/> if the text should be translated;
-            otherwise, <see langword="false"/>.</returns>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <param name="cacheKey">The normalized cache key for this request.</param>
+            <returns>The translated text or an error placeholder.</returns>
         </member>
-        <member name="M:Echoglossian.Translators.TranslationService.IsKnownFailedTranslation(System.String,System.String,System.String)">
+        <member name="T:Echoglossian.Translators.TranslationFailureKey">
             <summary>
-                Determines whether the given exact translation request is already
-                known to fail for the current engine and language pair.
+                Builds stable keys for exact translation-failure tracking.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationFailureKey.ComputeSourceTextHash(System.String)">
+            <summary>
+                Computes a short stable hash for one exact source text.
             </summary>
             <param name="sourceText">The exact sanitized source text.</param>
-            <param name="sourceLanguage">The normalized source language code.</param>
-            <param name="targetLanguage">The normalized target language code.</param>
-            <returns>
-                <see langword="true" /> when the request should be skipped because it
-                is already cached as a known failure; otherwise <see langword="false" />.
-            </returns>
+            <returns>The stable lowercase hash.</returns>
         </member>
-        <member name="M:Echoglossian.Translators.TranslationService.RecordFailedTranslation(System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:Echoglossian.Translators.TranslationFailureKey.BuildLookupKey(System.String,System.String,System.String,System.Int32)">
             <summary>
-                Records one exact translation request as a known failure for the
-                current engine and language pair.
+                Builds the in-memory lookup key for one source/target language pair
+                and translation engine.
             </summary>
-            <param name="sourceText">The exact sanitized source text.</param>
-            <param name="sourceLanguage">The normalized source language code.</param>
+            <param name="sourceTextHash">The stable source-text hash.</param>
+            <param name="sourceLanguage">The source language code.</param>
+            <param name="targetLanguage">The target language code.</param>
+            <param name="translationEngine">The translation-engine identifier.</param>
+            <returns>The stable lookup key.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.TranslationService">
+            <summary>
+                Provides translation services using various translation engines.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.#ctor(Echoglossian.Config,Dalamud.Plugin.Services.IPluginLog,Dalamud.Game.Text.Sanitizer.Sanitizer)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.Translators.TranslationService" /> class.
+            </summary>
+            <param name="config">The configuration settings for the translation service.</param>
+            <param name="pluginLog">The plugin logger for logging purposes.</param>
+            <param name="sanitizer">
+                The sanitizer used to clean input text before
+                translation.
+            </param>
+        </member>
+        <member name="M: code.</param>
             <param name="targetLanguage">The normalized target language code.</param>
             <param name="originContext">The origin context associated with the request.</param>
         </member>
@@ -21993,6 +21974,114 @@
         <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForBattleTalk(Echoglossian.Config)">
             <summary>
             Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for battle talk translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigTalkSubtitle(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for talk subtitle translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForMiniTalk(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for MiniTalk translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForCutSceneSelectString(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for CutSceneSelectString overlays.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForTextGimmickHint(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for text gimmick hint translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForWideTextToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for Screen Info (_WideText) toast
+            translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForErrorToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for error toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForAreaToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for area toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForClassChangeToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for class/job change toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForQuestToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for quest toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForChatBubble(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for chat bubble translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="T:TextTextureGenerator">
+            <summary>
+            Generates textures from text using a specified font and size.
+            </summary>
+        </member>
+        <member name="M:TextTextureGenerator.#ctor(Dalamud.Plugin.Services.ITextureProvider)">
+            <summary>
+            Initializes a new instance of the <see cref="T:TextTextureGenerator"/> class.
+            </summary>
+            <param name="textureProvider"></param>
+        </member>
+        <member name="M:TextTextureGenerator.CreateTextTextureAsync(System.String,System.String,System.Single,System.Nullable{System.Drawing.Color},System.Nullable{System.Drawing.Color},System.Drawing.FontStyle,System.Nullable{System.Int32})">
+            <summary>
+            Creates a texture from the specified text using the given font and size.
+            </summary>
+            <param name="text"></param>
+            <param name="fontPath"></param>
+            <param name="fontSize"></param>
+            <param name="textColor"></param>
+            <param name="backgroundColor"></param>
+            <param name="fontStyle"></param>
+            <parame cref="T:Echoglossian.Config"/> for battle talk translations.
             </summary>
             <param name="config"></param>
             <returns></returns>

--- a/NativeUI/Helpers/AddonHandlerRegistrar.cs
+++ b/NativeUI/Helpers/AddonHandlerRegistrar.cs
@@ -5,11 +5,18 @@
 
 namespace Echoglossian.NativeUI.Helpers;
 
+using System.Runtime.CompilerServices;
+
 /// <summary>
 ///     Utility for registering and unregistering addon translation handlers.
 /// </summary>
 public static class AddonHandlerRegistrar
 {
+    private static readonly ConditionalWeakTable<
+        IAddonTranslationHandler,
+        Dictionary<AddonEvent, IAddonLifecycle.AddonEventDelegate>>
+        StableHandlerDelegates = new();
+
     /// <summary>
     ///     Registers an addon translation handler with the specified addon lifecycle.
     /// </summary>
@@ -21,7 +28,7 @@ public static class AddonHandlerRegistrar
         IAddonTranslationHandler handler,
         IAddonLifecycle addonLifecycle)
     {
-        foreach (var (evt, del) in handler.GetEventHandlers())
+        foreach (var (evt, del) in GetStableEventHandlers(handler))
         {
             addonLifecycle.RegisterListener(evt, new[] { addonName }, del);
         }
@@ -59,10 +66,17 @@ public static class AddonHandlerRegistrar
         IAddonTranslationHandler handler,
         IAddonLifecycle addonLifecycle)
     {
-        foreach (var (evt, del) in handler.GetEventHandlers())
+        if (!StableHandlerDelegates.TryGetValue(handler, out var eventHandlers))
+        {
+            return;
+        }
+
+        foreach (var (evt, del) in eventHandlers)
         {
             addonLifecycle.UnregisterListener(evt, new[] { addonName }, del);
         }
+
+        StableHandlerDelegates.Remove(handler);
     }
 
     /// <summary>
@@ -83,5 +97,20 @@ public static class AddonHandlerRegistrar
         {
             Unregister(addonName, handler, addonLifecycle);
         }
+    }
+
+    /// <summary>
+    ///     Returns one stable event-handler map for the lifetime of the supplied
+    ///     addon handler instance so register and unregister use the same
+    ///     delegate instances.
+    /// </summary>
+    /// <param name="handler">The addon handler instance.</param>
+    /// <returns>The stable event-handler map for that handler instance.</returns>
+    private static Dictionary<AddonEvent, IAddonLifecycle.AddonEventDelegate>
+        GetStableEventHandlers(IAddonTranslationHandler handler)
+    {
+        return StableHandlerDelegates.GetValue(
+            handler,
+            static addonHandler => addonHandler.GetEventHandlers());
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ surface uses, and which surfaces are temporarily hidden or disabled in the
 current release, see
 [docs/translation-surface-support-matrix.md](docs/translation-surface-support-matrix.md).
 
+For current translation-engine architecture and future LLM-specific
+improvements such as surface-group engine routing and optional dialogue
+session context, see:
+
+- [docs/translation-engines-architecture-and-flows.md](docs/translation-engines-architecture-and-flows.md)
+- [docs/llm-translation-improvements-plan.md](docs/llm-translation-improvements-plan.md)
+
 Localized versions of that document:
 
 - [English](docs/translation-surface-support-matrix.md)

--- a/docs/llm-translation-improvements-plan.md
+++ b/docs/llm-translation-improvements-plan.md
@@ -1,0 +1,395 @@
+# LLM Translation Improvements Plan
+
+## Purpose
+
+This document captures the current direction for improving Echoglossian's
+LLM-backed translation path.
+
+The immediate motivation is twofold:
+
+- reduce avoidable latency and token cost in the current single-shot LLM flow
+- allow better control over which UI surfaces should use expensive LLM engines
+  versus cheaper or simpler engines
+
+This is a design-direction document, not a promise that every item here should
+land in one branch or one release.
+
+## Problem Summary
+
+Today, Echoglossian mostly treats LLM-backed engines as stateless
+single-request translators:
+
+- one text in
+- one prompt built
+- one request sent
+- one translated text returned
+
+That keeps persistence and caching deterministic, but it has clear downsides:
+
+- the same large instruction block is rebuilt and resent for many short lines
+- local LLM setups such as LM Studio and Ollama pay repeated per-request
+  overhead
+- the plugin cannot distinguish between "use LLM for dialogue" and "use a
+  cheaper engine for generic UI"
+- there is no controlled concept of short-lived dialogue context
+
+## Design Goals
+
+1. Reduce avoidable token and request overhead for LLM engines.
+2. Keep the current shared `TranslationService` architecture.
+3. Avoid breaking DB semantics or canonical cache behavior.
+4. Allow finer control over engine usage by UI surface category.
+5. Introduce dialogue context only where it improves quality enough to justify
+   the extra complexity.
+
+## Non-Goals
+
+- no global always-on chat session shared by the whole plugin
+- no engine-specific persistence pipeline
+- no context-dependent DB pollution by default
+- no broad rewrite of non-LLM translators just to match the LLM flow
+
+## Current Architectural Constraint
+
+The current persistence model assumes that a translated output is primarily a
+function of:
+
+- source text
+- source language
+- target language
+- chosen engine
+
+Long-lived multi-turn history weakens that assumption.
+
+If the same line is translated differently because a different history was
+attached, then:
+
+- cache reuse becomes less predictable
+- DB rows become less stable
+- reproducing bugs becomes harder
+
+That means session/history support should start as an in-memory runtime
+improvement, not as a new persistence contract.
+
+## Recommendation Overview
+
+```mermaid
+flowchart TD
+    A[Current global engine selection] --> B[Shared TranslationService]
+    B --> C[Per-surface routing policy]
+    C --> D1[Dialogue-family surfaces]
+    C --> D2[Quest and game-window surfaces]
+    C --> D3[Tooltip and detail surfaces]
+    D1 --> E1[Optional LLM engine with short-lived session context]
+    D2 --> E2[Stable engine or canonical DB-first path]
+    D3 --> E3[Stable engine or canonical DB-first path]
+```
+
+The key idea is:
+
+- **dialogue-family surfaces** may benefit from a short-lived LLM session
+- **quest, tooltip, and canonical UI surfaces** usually benefit more from
+  determinism, cache reuse, and lower token cost
+
+## Improvement Areas
+
+## 1. Shared LLM Request Infrastructure
+
+This is the safest first step.
+
+### Current pain
+
+- prompt construction is duplicated across multiple translators
+- some engines still embed a long monolithic prompt inline
+- request shape is similar across OpenAI-style engines but implemented
+  separately
+
+### Desired outcome
+
+- a shared prompt builder for LLM engines
+- shared helper(s) for OpenAI-style chat-completions request assembly
+- consistent trimming, quote removal, and synthetic-error handling
+
+### Why this matters
+
+It reduces drift, makes prompt compaction easier, and creates one place to
+apply future improvements across:
+
+- ChatGPT / OpenAI
+- OpenRouter
+- DeepSeek
+- LM Studio
+- possibly other OpenAI-compatible providers later
+
+## 2. Compact Prompt Strategy
+
+### Current pain
+
+- local engines are paying for a verbose instruction block on every line
+- issue `#176` suggests there is material overhead outside pure model runtime
+
+### Desired outcome
+
+- keep a high-quality default prompt
+- add a shorter prompt variant specifically for local LLM workloads
+- prefer `system` + `user` separation where the target API supports it
+
+### Guardrail
+
+Prompt shortening should be measured against translation quality and not be
+treated as a free win.
+
+## 3. Per-Surface Engine Routing
+
+This is the feature most directly related to token control.
+
+### User-facing need
+
+A user may want:
+
+- an LLM for `Talk`, `BattleTalk`, or other dialogue-family content
+- a cheaper or simpler engine for UI surfaces such as mission windows,
+  tooltips, or menus
+
+That is a valid and useful direction.
+
+### Why it helps
+
+- reduces token spend
+- reduces local-LLM queue pressure
+- allows stable non-dialogue surfaces to stay on more deterministic engines
+- lets users reserve LLM quality for the places where tone and context matter
+  most
+
+### Recommended scope model
+
+Do not start with per-addon-per-engine for every single handler.
+
+Start with **surface groups**:
+
+- `Dialogue LLM surfaces`
+  - `Talk`
+  - `BattleTalk`
+  - `TalkSubtitle`
+  - `MiniTalk`
+- `Quest and mission UI`
+  - `Journal`
+  - `JournalDetail`
+  - `ScenarioTree`
+  - `ToDoList`
+  - `RecommendList`
+  - `JournalAccept`
+  - `JournalResult`
+- `Reference and game-window UI`
+  - `MainCommand`
+  - `ActionMenu`
+  - `AddonContextMenuTitle`
+  - other DB-first game windows
+- `Tooltip and detail UI`
+  - structured tooltip/detail families once re-enabled
+
+This gives meaningful token control without exploding the config model.
+
+### Suggested routing model
+
+```mermaid
+flowchart TD
+    A[Incoming translation request] --> B[Surface classification]
+    B --> C{Override configured?}
+    C -- yes --> D[Use surface-group engine]
+    C -- no --> E[Use global default engine]
+    D --> F[Shared TranslationService]
+    E --> F
+```
+
+### Guardrails
+
+- keep one shared `TranslationService`
+- do not fork persistence by engine family
+- do not create per-addon bespoke translator pipelines
+- route by policy before translator invocation
+
+## 4. Short-Lived Dialogue Session Context
+
+This is the most attractive feature for quality, but also the riskiest.
+
+### Where it makes sense
+
+- `Talk`
+- maybe `BattleTalk`
+- maybe `MiniTalk`
+
+### Where it does **not** make sense
+
+- `Journal`
+- `JournalDetail`
+- `ScenarioTree`
+- `ToDoList`
+- `MainCommand`
+- `ActionMenu`
+- tooltip/detail surfaces
+
+### Recommended constraints
+
+- in-memory only
+- no cross-surface session sharing
+- short TTL
+- small rolling window, for example the last 2 to 4 translated turns
+- keyed by conversation-like runtime identity
+
+### Example session key inputs
+
+- addon family
+- speaker name when available
+- active conversation or visible addon instance identity
+- optional target language / engine
+
+### Why not a global chat session
+
+A single global session would:
+
+- bleed context across unrelated NPCs and windows
+- make translations less deterministic
+- increase debugging difficulty
+- create more pressure to persist or replay history
+
+### First safe policy
+
+- use session context only for runtime quality
+- do not let that history redefine canonical DB semantics at first
+
+## 5. Persistence and Cache Semantics
+
+This is the main safety boundary.
+
+### Recommendation
+
+For the first version of dialogue session context:
+
+- keep persistence behavior conservative
+- prefer runtime-only benefit over aggressive DB reuse
+- do not assume history-aware output is equivalent to a canonical no-history
+  translation
+
+### Practical options
+
+1. **No persistence for session-aware output initially**
+   - safest
+   - lowest semantic risk
+   - loses some reuse
+
+2. **Persist only when output matches the base no-history result**
+   - safer than unconditional persistence
+   - more complex
+
+3. **Persist session-aware output with explicit metadata**
+   - richest
+   - highest complexity
+   - not a first-pass target
+
+The recommended first option is **runtime-only session improvement**.
+
+## Implementation Phases
+
+## Phase 1: Shared LLM Infrastructure
+
+Target:
+
+- prompt builder shared by LLM translators
+- OpenAI-style request helper(s)
+- consistent response normalization
+
+Expected benefit:
+
+- lower maintenance cost
+- easier future compaction and instrumentation
+
+## Phase 2: Prompt Compaction and Telemetry
+
+Target:
+
+- compact prompt profile for local LLMs
+- optional instrumentation for:
+  - request latency
+  - prompt size
+  - completion size
+
+Expected benefit:
+
+- measurable path to improve `#176`
+
+## Phase 3: Surface-Group Engine Routing
+
+Target:
+
+- optional engine override per surface group
+- global engine remains default
+
+Expected benefit:
+
+- token-control feature users actually asked for
+- better split between dialogue quality and UI-cost control
+
+## Phase 4: Experimental Dialogue Session Context
+
+Target:
+
+- runtime-only short-lived context for `Talk`
+- guarded rollout, ideally behind explicit config
+
+Expected benefit:
+
+- better tone and consistency across consecutive lines
+
+## Phase 5: Expansion to Other Dialogue Families
+
+Only after `Talk` proves stable:
+
+- evaluate `BattleTalk`
+- evaluate `MiniTalk`
+
+Do not expand by default to non-dialogue surfaces.
+
+## Suggested Configuration Direction
+
+This is a direction, not a final schema:
+
+- `GlobalTranslationEngine`
+- `UseDialogueEngineOverride`
+- `DialogueTranslationEngine`
+- `UseQuestUiEngineOverride`
+- `QuestUiTranslationEngine`
+- `UseReferenceUiEngineOverride`
+- `ReferenceUiTranslationEngine`
+- `UseTooltipEngineOverride`
+- `TooltipTranslationEngine`
+- `EnableDialogueSessionContext`
+- `DialogueSessionHistoryLimit`
+- `DialogueSessionTtlSeconds`
+
+That is already a lot. It should be introduced carefully and grouped in the UI
+so it does not become a configuration disaster.
+
+## Open Questions
+
+1. Should surface-group routing be available for all engines, or only when the
+   global engine is an LLM?
+2. Should local-LLM compact prompts be per-engine or shared across local
+   engines?
+3. Should session-aware translations ever be persisted?
+4. How should metrics be exposed without creating hot-path logging noise?
+5. Is `BattleTalk` close enough to `Talk` to share the same session strategy,
+   or does it need stricter isolation?
+
+## Recommended Next Step
+
+The next implementation step should be:
+
+1. build shared LLM prompt/request infrastructure
+2. introduce prompt-compaction support for local LLM engines
+3. only then add surface-group engine routing
+
+Dialogue session context should come after those pieces exist, not before.
+
+That order gives the best chance of improving latency and token control without
+making persistence and debugging dramatically worse.

--- a/docs/translation-engines-architecture-and-flows.md
+++ b/docs/translation-engines-architecture-and-flows.md
@@ -239,6 +239,12 @@ For requested-but-not-yet-implemented engine candidates, see:
 
 - [translation-engine-backlog.md](/C:/Dante/_dalamud/Echoglossian/docs/translation-engine-backlog.md)
 
+For planned improvements specific to LLM-backed engines, including compact
+prompting, surface-group engine routing, and optional short-lived dialogue
+session context, see:
+
+- [llm-translation-improvements-plan.md](/C:/Dante/_dalamud/Echoglossian/docs/llm-translation-improvements-plan.md)
+
 ## Governance Reminder
 
 Development-time AI usage disclosure for official repository submissions is a


### PR DESCRIPTION
## Summary

- fix `#198` by stabilizing addon-handler register/unregister delegate identity so runtime refreshes do not accumulate stale listeners
- add the LLM translation improvements planning doc and link it from the existing engine architecture docs and README
- add the repo-local `dalamud-release-workflow` skill and checklist for future Echoglossian releases and official `DalamudPluginsD17` submissions

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] `dotnet build Echoglossian.csproj -c Release --no-restore`

## Notes

- the `#198` fix is centralized in `AddonHandlerRegistrar`, so it hardens handler refresh behavior beyond the OpenAI model-change reproduction path
- self-approval is still blocked by GitHub platform rules, so merge may require admin bypass
