### PR TITLE
fix(#204): OpenRouter translations engine

### DIFF
--- a/Echoglossian.Tests/TranslatorContractTests.cs
+++ b/Echoglossian.Tests/TranslatorContractTests.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.Translators;
 using Echoglossian.Translators.LibreTranslate;
+using Echoglossian.PluginUI.Helpers;
 
 using Xunit;
 
@@ -135,5 +136,42 @@ public class TranslatorContractTests
         Assert.Equal(
             "https://libretranslate.de/translate",
             LibreTranslateTranslator.DetermineEndpoint(deConfig));
+    }
+
+    /// <summary>
+    ///     Ensures OpenRouter prompt expansion preserves placeholder-like text inside the translated input.
+    /// </summary>
+    [Fact]
+    public void OpenRouter_BuildPrompt_DoesNotReprocessInsertedText()
+    {
+        var prompt = OpenRouterTranslator.BuildPrompt(
+            "Translate from {sourceLanguage} to {targetLanguage}: {text}",
+            "Keep literal {sourceLanguage} and {targetLanguage} tokens.",
+            "en",
+            "pt-BR");
+
+        Assert.Equal(
+            "Translate from en to pt-BR: Keep literal {sourceLanguage} and {targetLanguage} tokens.",
+            prompt);
+    }
+
+    /// <summary>
+    ///     Ensures OpenRouter prompt expansion falls back to the shared default template when the config prompt is blank.
+    /// </summary>
+    [Fact]
+    public void OpenRouter_BuildPrompt_UsesDefaultTemplateWhenBlank()
+    {
+        var prompt = OpenRouterTranslator.BuildPrompt(
+            "   ",
+            "hello",
+            "en",
+            "pt-BR");
+
+        Assert.Equal(
+            PromptTemplateManager.DefaultPrompt
+                .Replace("{sourceLanguage}", "en", StringComparison.Ordinal)
+                .Replace("{targetLanguage}", "pt-BR", StringComparison.Ordinal)
+                .Replace("{text}", "hello", StringComparison.Ordinal),
+            prompt);
     }
 }

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -33,7 +33,9 @@ public class OpenRouterTranslator : ITranslator
         this.openRouterUrl = string.IsNullOrWhiteSpace(config.OpenRouterBaseUrl)
             ? DefaultOpenRouterUrl
             : config.OpenRouterBaseUrl!;
-        this.prompt = config.OpenRouterPrompt ?? string.Empty;
+        this.prompt = string.IsNullOrWhiteSpace(config.OpenRouterPrompt)
+            ? PromptTemplateManager.DefaultPrompt
+            : config.OpenRouterPrompt!;
 
         if (string.IsNullOrWhiteSpace(this.apiKey))
         {
@@ -109,12 +111,18 @@ public class OpenRouterTranslator : ITranslator
         string targetLanguage,
         string cacheKey)
     {
+        var fullPrompt = BuildPrompt(
+            this.prompt,
+            text,
+            sourceLanguage,
+            targetLanguage);
+
         var request = new
         {
             this.model,
             messages = new[]
             {
-                new { role = "user", content = this.prompt },
+                new { role = "user", content = fullPrompt },
             },
             this.temperature,
         };
@@ -152,6 +160,28 @@ public class OpenRouterTranslator : ITranslator
         }
 
         return string.Empty;
+    }
+
+    internal static string BuildPrompt(
+        string? promptTemplate,
+        string text,
+        string sourceLanguage,
+        string targetLanguage)
+    {
+        var normalizedTemplate = string.IsNullOrWhiteSpace(promptTemplate)
+            ? PromptTemplateManager.DefaultPrompt
+            : promptTemplate;
+
+        return normalizedTemplate
+            .Replace("{text}", FixText(text), StringComparison.Ordinal)
+            .Replace(
+                "{sourceLanguage}",
+                sourceLanguage,
+                StringComparison.Ordinal)
+            .Replace(
+                "{targetLanguage}",
+                targetLanguage,
+                StringComparison.Ordinal);
     }
 
     private class OpenRouterResponse

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -173,7 +173,6 @@ public class OpenRouterTranslator : ITranslator
             : promptTemplate;
 
         return normalizedTemplate
-            .Replace("{text}", FixText(text), StringComparison.Ordinal)
             .Replace(
                 "{sourceLanguage}",
                 sourceLanguage,
@@ -181,7 +180,8 @@ public class OpenRouterTranslator : ITranslator
             .Replace(
                 "{targetLanguage}",
                 targetLanguage,
-                StringComparison.Ordinal);
+                StringComparison.Ordinal)
+            .Replace("{text}", FixText(text), StringComparison.Ordinal);
     }
 
     private class OpenRouterResponse


### PR DESCRIPTION
## Summary

Translations with OpenRouter were not working due to the fact that the code was sending the prompt with placeholders inside, instead of replacing them and send to the endpoint.

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] in-game verification was performed when runtime UI behavior changed

## AI Usage Disclosure

Required for submissions to the official Dalamud plugin repository when AI use
went beyond basic autocomplete or inline suggestions.

Select one when applicable:

- [ ] `Assist` — human-led work with AI used for specific tasks
- [ ] `Pair` — active human/AI collaboration throughout
- [x] `Copilot` — AI did most of the writing while the human planned and reviewed
- [ ] `Auto` — AI acted mostly autonomously with minimal human direction

If you selected one of the levels above, describe the scope briefly:

```text
AI scope:
Used github copilot to review and understand the code. Described the problem with the example and simply ran agent mode. Fixed at first try.
```

If no AI was used, or only basic autocomplete / inline suggestions were used,
you do not need to disclose anything here.

## AI-Generated Assets Disclosure

If this PR adds or changes AI-generated icons, images, music, sounds, textures,
or other user-facing assets, disclose them here so the plugin description can be
updated if needed.

```text
AI-generated assets:
- none
```
