### PR TITLE
fix(openai): Remove hardcoded prompt

### DIFF
--- a/Echoglossian.Tests/TranslatorContractTests.cs
+++ b/Echoglossian.Tests/TranslatorContractTests.cs
@@ -174,4 +174,41 @@ public class TranslatorContractTests
                 .Replace("{text}", "hello", StringComparison.Ordinal),
             prompt);
     }
+
+    /// <summary>
+    ///     Ensures ChatGPT prompt expansion preserves placeholder-like text inside the translated input.
+    /// </summary>
+    [Fact]
+    public void ChatGpt_BuildPrompt_DoesNotReprocessInsertedText()
+    {
+        var prompt = ChatGPTTranslator.BuildPrompt(
+            "Translate from {sourceLanguage} to {targetLanguage}: {text}",
+            "Keep literal {sourceLanguage} and {targetLanguage} tokens.",
+            "en",
+            "pt-BR");
+
+        Assert.Equal(
+            "Translate from en to pt-BR: Keep literal {sourceLanguage} and {targetLanguage} tokens.",
+            prompt);
+    }
+
+    /// <summary>
+    ///     Ensures ChatGPT prompt expansion falls back to the shared default template when the config prompt is blank.
+    /// </summary>
+    [Fact]
+    public void ChatGpt_BuildPrompt_UsesDefaultTemplateWhenBlank()
+    {
+        var prompt = ChatGPTTranslator.BuildPrompt(
+            "   ",
+            "hello",
+            "en",
+            "pt-BR");
+
+        Assert.Equal(
+            PromptTemplateManager.DefaultPrompt
+                .Replace("{sourceLanguage}", "en", StringComparison.Ordinal)
+                .Replace("{targetLanguage}", "pt-BR", StringComparison.Ordinal)
+                .Replace("{text}", "hello", StringComparison.Ordinal),
+            prompt);
+    }
 }

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.ClientModel;
+using Echoglossian.PluginUI.Helpers;
 using Echoglossian.Translators.Helpers;
 using OpenAI;
 using OpenAI.Chat;
@@ -15,6 +16,7 @@ public class ChatGPTTranslator : ITranslator
     private readonly ChatClient? chatClient;
     private readonly string model;
     private readonly IPluginLog pluginLog;
+    private readonly string promptTemplate;
     private readonly float temperature;
     private readonly ConcurrentTranslationRequestCache translationCache = new();
 
@@ -26,16 +28,21 @@ public class ChatGPTTranslator : ITranslator
     /// <param name="apiKey"></param>
     /// <param name="model"></param>
     /// <param name="temperature"></param>
+    /// <param name="promptTemplate"></param>
     public ChatGPTTranslator(
         IPluginLog pluginLog,
         string baseUrl = "https://api.openai.com/v1",
         string apiKey = "",
         string model = "gpt-4o-mini",
-        float temperature = 0.1f)
+        float temperature = 0.1f,
+        string? promptTemplate = null)
     {
         this.pluginLog = pluginLog;
         this.model = model;
         this.temperature = temperature;
+        this.promptTemplate = string.IsNullOrWhiteSpace(promptTemplate)
+            ? PromptTemplateManager.DefaultPrompt
+            : promptTemplate;
 
         if (string.IsNullOrWhiteSpace(apiKey))
         {
@@ -148,23 +155,18 @@ public class ChatGPTTranslator : ITranslator
         string targetLanguage,
         string cacheKey)
     {
-        var prompt =
-            @$"As an expert translator and cultural localization specialist with deep knowledge of video game localization, your task is to translate dialogues from the game Final Fantasy XIV from {sourceLanguage} to {targetLanguage}. This is not just a translation, but a full localization effort tailored for the Final Fantasy XIV universe. Please adhere to the following guidelines:
+        var client = this.chatClient;
 
-                                1. Preserve the original tone, humor, personality, and emotional nuances of the dialogue, considering the unique style and atmosphere of Final Fantasy XIV.
-                                2. Adapt idioms, cultural references, and wordplay to resonate naturally with native {targetLanguage} speakers while maintaining the fantasy RPG context.
-                                3. Maintain consistency in character voices, terminology, and naming conventions specific to Final Fantasy XIV throughout the translation.
-                                4. Avoid literal translations that may lose the original intent or impact, especially for game-specific terms or lore elements.
-                                5. Ensure the translation flows naturally and reads as if it were originally written in {targetLanguage}, while staying true to the game's narrative style.
-                                6. Consider the context and subtext of the dialogue, including any references to the game's lore, world, or ongoing storylines.
-                                7. If a word, phrase, or name has been translated in a specific way, maintain that translation consistently unless the context demands otherwise, respecting established localization choices for Final Fantasy XIV.
-                                8. Pay attention to formal/informal speech patterns and adjust accordingly for the target language and cultural norms, considering the speaker's role and status within the game world.
-                                9. Be mindful of character limits or text box constraints that may be present in the game, adapting the translation to fit if necessary.
-                                10. Preserve any game-specific jargon, spell names, or technical terms according to the official localization guidelines for Final Fantasy XIV in the target language.
+        if (client is null)
+        {
+            return Resources.ChatGPTTranslationUnavailablePleaseCheckYourAPIKey;
+        }
 
-                                Text to translate: ""{text}""
-
-                                Please provide only the translated text in your response, without any explanations, additional comments, or quotation marks. Your goal is to create a localized version that captures the essence of the original Final Fantasy XIV dialogue while feeling authentic to {targetLanguage} speakers and seamlessly fitting into the game world.";
+        var prompt = BuildPrompt(
+            this.promptTemplate,
+            text,
+            sourceLanguage,
+            targetLanguage);
 
         try
         {
@@ -179,10 +181,12 @@ public class ChatGPTTranslator : ITranslator
             };
 
             ChatCompletion completion =
-                await this.chatClient.CompleteChatAsync(
+                await client.CompleteChatAsync(
                     messages,
                     chatCompletionOptions).ConfigureAwait(false);
-            var translatedText = completion.Content[0].Text.Trim();
+            var translatedText = completion.Content.Count > 0
+                ? completion.Content[0].Text?.Trim() ?? string.Empty
+                : string.Empty;
 
             translatedText = translatedText.Trim('"');
 
@@ -203,5 +207,27 @@ public class ChatGPTTranslator : ITranslator
         }
 
         return string.Empty;
+    }
+
+    internal static string BuildPrompt(
+        string? promptTemplate,
+        string text,
+        string sourceLanguage,
+        string targetLanguage)
+    {
+        var normalizedTemplate = string.IsNullOrWhiteSpace(promptTemplate)
+            ? PromptTemplateManager.DefaultPrompt
+            : promptTemplate;
+
+        return normalizedTemplate
+            .Replace(
+                "{sourceLanguage}",
+                sourceLanguage,
+                StringComparison.Ordinal)
+            .Replace(
+                "{targetLanguage}",
+                targetLanguage,
+                StringComparison.Ordinal)
+            .Replace("{text}", FixText(text), StringComparison.Ordinal);
     }
 }

--- a/Translators/TranslatorFactory.cs
+++ b/Translators/TranslatorFactory.cs
@@ -40,7 +40,8 @@ public static class TranslatorFactory
                     config.ChatGPTBaseUrl,
                     config.ChatGptApiKey,
                     config.OpenAILlmModel,
-                    config.ChatGptTemperature),
+                    config.ChatGptTemperature,
+                    config.ChatGptPrompt),
             Echoglossian.TransEngines.YandexCloud =>
                 new YandexTranslator(pluginLog, config),
             Echoglossian.TransEngines.GTranslate =>


### PR DESCRIPTION
## Summary

OpenAI translations were not honoring the custom prompt configured in the UI because the runtime translator was still using a hardcoded prompt string. This change wires the configured ChatGPT prompt into the OpenAI translation path, expands the standard placeholders {text}, {sourceLanguage}, and {targetLanguage}, and falls back to the shared default prompt when no custom prompt is provided.

- Pass the configured ChatGPT prompt from the translator factory to the OpenAI translator.
- Replace the hardcoded OpenAI prompt with runtime prompt-template expansion.
- Support the standard placeholders {text}, {sourceLanguage}, and {targetLanguage}.
- Preserve existing behavior by falling back to the shared default prompt when the custom prompt is empty.
- Add regression tests covering placeholder expansion and default-template fallback.

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] in-game verification was performed when runtime UI behavior changed

## AI Usage Disclosure

Required for submissions to the official Dalamud plugin repository when AI use
went beyond basic autocomplete or inline suggestions.

Select one when applicable:

- [ ] `Assist` — human-led work with AI used for specific tasks
- [ ] `Pair` — active human/AI collaboration throughout
- [x] `Copilot` — AI did most of the writing while the human planned and reviewed
- [ ] `Auto` — AI acted mostly autonomously with minimal human direction

If you selected one of the levels above, describe the scope briefly:

```text
AI scope:
- tooling used: Github Copilot
- files or areas most affected:
- how the result was reviewed/tested:
```

If no AI was used, or only basic autocomplete / inline suggestions were used,
you do not need to disclose anything here.

## AI-Generated Assets Disclosure

If this PR adds or changes AI-generated icons, images, music, sounds, textures,
or other user-facing assets, disclose them here so the plugin description can be
updated if needed.

```text
AI-generated assets:
- none
```
