### PR TITLE
fix(#188): stabilize native reflow + ToastGui routing

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -851,6 +851,13 @@ public class Config : IPluginConfiguration
   /// <summary>Translate toast popup messages.</summary>
   [DefaultValue(false)] public bool TranslateToast = false;
 
+  /// <summary>
+  ///     Uses Dalamud's ToastGui callbacks to prefetch source text and
+  ///     translations for supported normal and error toasts before the addon
+  ///     handlers see the live nodes.
+  /// </summary>
+  [DefaultValue(false)] public bool UseToastGuiCaptureForSupportedToasts = false;
+
   /// <summary>Translate To-Do List entries.</summary>
   [DefaultValue(false)] public bool TranslateToDoList = false;
 

--- a/Config.cs
+++ b/Config.cs
@@ -858,6 +858,13 @@ public class Config : IPluginConfiguration
   /// </summary>
   [DefaultValue(false)] public bool UseToastGuiCaptureForSupportedToasts = false;
 
+  /// <summary>
+  ///     Enables debug-only automatic login probes for `_BattleTalk` and
+  ///     `_MiniTalk` so their earliest addon state can be captured without
+  ///     manually issuing the probe command after login.
+  /// </summary>
+  [DefaultValue(false)] public bool EnableDebugLoginAddonProbe = false;
+
   /// <summary>Translate To-Do List entries.</summary>
   [DefaultValue(false)] public bool TranslateToDoList = false;
 

--- a/Config.cs
+++ b/Config.cs
@@ -859,6 +859,13 @@ public class Config : IPluginConfiguration
   [DefaultValue(false)] public bool UseToastGuiCaptureForSupportedToasts = false;
 
   /// <summary>
+  ///     Enables the alternate callback-owned ToastGui runtime for supported
+  ///     normal and error toasts instead of the legacy addon-handler path.
+  ///     This stays hidden and opt-in while the route is still being validated.
+  /// </summary>
+  [DefaultValue(false)] public bool UseToastGuiRuntimeForSupportedToasts = false;
+
+  /// <summary>
   ///     Enables debug-only automatic login probes for `_BattleTalk` and
   ///     `_MiniTalk` so their earliest addon state can be captured without
   ///     manually issuing the probe command after login.

--- a/DBManagerUI/Components/DbTableView.cs
+++ b/DBManagerUI/Components/DbTableView.cs
@@ -71,7 +71,7 @@ namespace Echoglossian.DBManagerUI.Components
 
         foreach (var prop in props)
         {
-          ImGui.TableSetupColumn(prop.Name, ImGuiTableColumnFlags.None, 150f);
+          ImGui.TableSetupColumn(prop.Name, ImGuiTableColumnFlags.WidthFixed, 150f);
         }
 
         ImGui.TableHeadersRow();

--- a/Echoglossian.Tests/AddonProbeAutoWatchPolicyTests.cs
+++ b/Echoglossian.Tests/AddonProbeAutoWatchPolicyTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="AddonProbeAutoWatchPolicyTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers the debug-only login gating for automatic addon-probe watches.
+/// </summary>
+public class AddonProbeAutoWatchPolicyTests
+{
+#if DEBUG
+    /// <summary>
+    ///     Ensures the login auto-probe starts only when the client is logged
+    ///     in and the current login session has not already started or
+    ///     suppressed the watch set.
+    /// </summary>
+    [Fact]
+    public void ShouldStartForCurrentLogin_ReturnsTrue_WhenLoginSessionIsEligible()
+    {
+        var shouldStart = AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(
+            isLoggedIn: true,
+            hasStartedForCurrentLogin: false,
+            isSuppressedUntilLogout: false,
+            activeManagedWatchCount: 0);
+
+        Assert.True(shouldStart);
+    }
+
+    /// <summary>
+    ///     Ensures the login auto-probe stays off when the current login session
+    ///     already started or the user suppressed it with the stop command.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false, false, 0)]
+    [InlineData(true, true, false, 0)]
+    [InlineData(true, false, true, 0)]
+    [InlineData(true, false, false, 1)]
+    public void ShouldStartForCurrentLogin_ReturnsFalse_WhenSessionIsNotEligible(
+        bool isLoggedIn,
+        bool hasStartedForCurrentLogin,
+        bool isSuppressedUntilLogout,
+        int activeManagedWatchCount)
+    {
+        var shouldStart = AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(
+            isLoggedIn,
+            hasStartedForCurrentLogin,
+            isSuppressedUntilLogout,
+            activeManagedWatchCount);
+
+        Assert.False(shouldStart);
+    }
+
+    /// <summary>
+    ///     Ensures a logout transition resets the one-login-session auto-probe
+    ///     gate.
+    /// </summary>
+    [Fact]
+    public void ShouldResetForLogout_ReturnsTrue_OnLogoutTransition()
+    {
+        var shouldReset = AddonProbeAutoWatchPolicy.ShouldResetForLogout(
+            wasLoggedIn: true,
+            isLoggedIn: false);
+
+        Assert.True(shouldReset);
+    }
+#endif
+}

--- a/Echoglossian.Tests/ConfigDefaultsTests.cs
+++ b/Echoglossian.Tests/ConfigDefaultsTests.cs
@@ -1,0 +1,25 @@
+// <copyright file="ConfigDefaultsTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers default values for hidden configuration toggles.
+/// </summary>
+public class ConfigDefaultsTests
+{
+    /// <summary>
+    ///     Ensures the debug login addon-probe path stays opt-in by default.
+    /// </summary>
+    [Fact]
+    public void EnableDebugLoginAddonProbe_DefaultsToFalse()
+    {
+        var config = new Config();
+
+        Assert.False(config.EnableDebugLoginAddonProbe);
+    }
+}

--- a/Echoglossian.Tests/ConfigDefaultsTests.cs
+++ b/Echoglossian.Tests/ConfigDefaultsTests.cs
@@ -22,4 +22,16 @@ public class ConfigDefaultsTests
 
         Assert.False(config.EnableDebugLoginAddonProbe);
     }
+
+    /// <summary>
+    ///     Ensures the full ToastGui runtime path for supported toasts stays
+    ///     opt-in by default.
+    /// </summary>
+    [Fact]
+    public void UseToastGuiRuntimeForSupportedToasts_DefaultsToFalse()
+    {
+        var config = new Config();
+
+        Assert.False(config.UseToastGuiRuntimeForSupportedToasts);
+    }
 }

--- a/Echoglossian.Tests/NativeReplacementTextNormalizationHelperTests.cs
+++ b/Echoglossian.Tests/NativeReplacementTextNormalizationHelperTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="NativeReplacementTextNormalizationHelperTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.AddonHandlers.Common;
+using Echoglossian.NativeUI.Helpers;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers native replacement text normalization for shared DB-first
+///     payloads.
+/// </summary>
+public class NativeReplacementTextNormalizationHelperTests
+{
+    /// <summary>
+    ///     Ensures native replacement normalization applies to every payload
+    ///     surface that can be written into the live UI.
+    /// </summary>
+    [Fact]
+    public void NormalizePayload_NormalizesAtkStringArrayAndTextNodeValues()
+    {
+        var payload = new DbFirstGameWindowPayload(
+            new SortedDictionary<int, string>
+            {
+                [0] = "café",
+            },
+            new SortedDictionary<int, string>
+            {
+                [3] = "ação",
+            },
+            new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["7:0"] = "Łódź",
+            });
+
+        var normalizedPayload =
+            NativeReplacementTextNormalizationHelper.NormalizePayload(
+                payload,
+                text => text
+                    .Replace("é", "e", StringComparison.Ordinal)
+                    .Replace("ã", "a", StringComparison.Ordinal)
+                    .Replace("ç", "c", StringComparison.Ordinal)
+                    .Replace("Ł", "L", StringComparison.Ordinal)
+                    .Replace("ó", "o", StringComparison.Ordinal)
+                    .Replace("ź", "z", StringComparison.Ordinal));
+
+        Assert.Equal("cafe", normalizedPayload.AtkValues[0]);
+        Assert.Equal("acao", normalizedPayload.StringArrayValues[3]);
+        Assert.Equal("Lodz", normalizedPayload.TextNodes["7:0"]);
+    }
+
+    /// <summary>
+    ///     Ensures the helper preserves the incoming payload when the supplied
+    ///     normalizer does not change any values.
+    /// </summary>
+    [Fact]
+    public void NormalizePayload_PreservesExistingValuesWhenNoChangesOccur()
+    {
+        var payload = new DbFirstGameWindowPayload(
+            new SortedDictionary<int, string>
+            {
+                [0] = "plain",
+            },
+            new SortedDictionary<int, string>(),
+            new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["7:0"] = "ascii",
+            });
+
+        var normalizedPayload =
+            NativeReplacementTextNormalizationHelper.NormalizePayload(
+                payload,
+                static text => text);
+
+        Assert.Equal(payload, normalizedPayload);
+    }
+}

--- a/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
+++ b/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
@@ -1,0 +1,68 @@
+// <copyright file="NativeTextNodeLayoutHelperTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers reusable geometry calculations in the native text-node reflow
+///     helper.
+/// </summary>
+public class NativeTextNodeLayoutHelperTests
+{
+    /// <summary>
+    ///     Ensures the secondary background width is left untouched when the
+    ///     anchored node already fits inside the current bounds.
+    /// </summary>
+    [Fact]
+    public void ResolveMinimumSecondaryWidthForAnchoredNode_ReturnsCurrentWidth_WhenAnchoredNodeIsAlreadyCovered()
+    {
+        var resolvedWidth = NativeTextNodeLayoutHelper.ResolveMinimumSecondaryWidthForAnchoredNode(
+            secondaryContainerX: 100,
+            currentSecondaryWidth: 220,
+            anchoredNodeX: 260,
+            anchoredNodeWidth: 24,
+            preferredRightPadding: 8);
+
+        Assert.Equal((ushort)220, resolvedWidth);
+    }
+
+    /// <summary>
+    ///     Ensures the secondary background widens enough to cover an anchored
+    ///     timer or spinner node when it would otherwise extend past the
+    ///     current right edge.
+    /// </summary>
+    [Fact]
+    public void ResolveMinimumSecondaryWidthForAnchoredNode_GrowsWidth_WhenAnchoredNodeExtendsPastCurrentBounds()
+    {
+        var resolvedWidth = NativeTextNodeLayoutHelper.ResolveMinimumSecondaryWidthForAnchoredNode(
+            secondaryContainerX: 100,
+            currentSecondaryWidth: 220,
+            anchoredNodeX: 310,
+            anchoredNodeWidth: 24,
+            preferredRightPadding: 8);
+
+        Assert.Equal((ushort)242, resolvedWidth);
+    }
+
+    /// <summary>
+    ///     Ensures negative historical padding still results in coverage up to
+    ///     the anchored node edge instead of shrinking the background further.
+    /// </summary>
+    [Fact]
+    public void ResolveMinimumSecondaryWidthForAnchoredNode_ClampsNegativePaddingToZero()
+    {
+        var resolvedWidth = NativeTextNodeLayoutHelper.ResolveMinimumSecondaryWidthForAnchoredNode(
+            secondaryContainerX: 100,
+            currentSecondaryWidth: 220,
+            anchoredNodeX: 330,
+            anchoredNodeWidth: 20,
+            preferredRightPadding: -12);
+
+        Assert.Equal((ushort)250, resolvedWidth);
+    }
+}

--- a/Echoglossian.Tests/ToastGuiCaptureRuntimeTests.cs
+++ b/Echoglossian.Tests/ToastGuiCaptureRuntimeTests.cs
@@ -16,18 +16,18 @@ namespace Echoglossian.Tests;
 public class ToastGuiCaptureRuntimeTests
 {
     /// <summary>
-    ///     Ensures the legacy capture-only path shuts itself off when the new
-    ///     full callback-owned ToastGui route is enabled for supported toasts.
+    ///     Ensures the legacy capture-only path stays inactive while supported
+    ///     toasts are callback-owned.
     /// </summary>
     [Fact]
-    public void HandleNormalToast_DoesNotPrefetch_WhenFullToastGuiRuntimeIsEnabled()
+    public void HandleNormalToast_DoesNotPrefetch_WhenToastTranslationIsEnabled()
     {
         var config = new Config
         {
             TranslateToast = true,
             TranslateWideTextToast = true,
             UseToastGuiCaptureForSupportedToasts = true,
-            UseToastGuiRuntimeForSupportedToasts = true,
+            UseToastGuiRuntimeForSupportedToasts = false,
         };
         var lookupCalls = 0;
         var runtime = new ToastGuiCaptureRuntime(

--- a/Echoglossian.Tests/ToastGuiCaptureRuntimeTests.cs
+++ b/Echoglossian.Tests/ToastGuiCaptureRuntimeTests.cs
@@ -1,0 +1,50 @@
+// <copyright file="ToastGuiCaptureRuntimeTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Dalamud.Game.Gui.Toast;
+using Dalamud.Game.Text.SeStringHandling;
+using Echoglossian.NativeUI.AddonHandlers.Toasts;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers gating behavior for the legacy ToastGui capture runtime.
+/// </summary>
+public class ToastGuiCaptureRuntimeTests
+{
+    /// <summary>
+    ///     Ensures the legacy capture-only path shuts itself off when the new
+    ///     full callback-owned ToastGui route is enabled for supported toasts.
+    /// </summary>
+    [Fact]
+    public void HandleNormalToast_DoesNotPrefetch_WhenFullToastGuiRuntimeIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateWideTextToast = true,
+            UseToastGuiCaptureForSupportedToasts = true,
+            UseToastGuiRuntimeForSupportedToasts = true,
+        };
+        var lookupCalls = 0;
+        var runtime = new ToastGuiCaptureRuntime(
+            config,
+            null!,
+            _ =>
+            {
+                lookupCalls++;
+                return null;
+            },
+            _ => throw new InvalidOperationException("Insert should not run."));
+        SeString message = string.Empty;
+        ToastOptions options = new();
+        var isHandled = false;
+
+        runtime.HandleNormalToast(ref message, ref options, ref isHandled);
+
+        Assert.Equal(0, lookupCalls);
+    }
+}

--- a/Echoglossian.Tests/ToastGuiSupportedToastPolicyTests.cs
+++ b/Echoglossian.Tests/ToastGuiSupportedToastPolicyTests.cs
@@ -9,22 +9,21 @@ using Xunit;
 namespace Echoglossian.Tests;
 
 /// <summary>
-///     Covers the merged family-level semantics used by the alternate ToastGui
-///     runtime path for supported toasts.
+///     Covers the merged family-level semantics used by the ToastGui runtime
+///     path for supported toasts.
 /// </summary>
 public class ToastGuiSupportedToastPolicyTests
 {
     /// <summary>
-    ///     Ensures the default supported normal-toast route remains on the
-    ///     legacy addon-handler path when neither hidden ToastGui toggle is
-    ///     enabled.
+    ///     Ensures the supported normal-toast route remains on the legacy
+    ///     addon-handler path while global toast translation is disabled.
     /// </summary>
     [Fact]
-    public void GetSupportedNormalToastRouteState_ReturnsLegacyAddonHandlers_ByDefault()
+    public void GetSupportedNormalToastRouteState_ReturnsLegacyAddonHandlers_WhenToastTranslationIsDisabled()
     {
         var config = new Config
         {
-            TranslateToast = true,
+            TranslateToast = false,
         };
 
         Assert.Equal(
@@ -33,99 +32,116 @@ public class ToastGuiSupportedToastPolicyTests
     }
 
     /// <summary>
-    ///     Ensures the supported normal-toast route reports the capture-only
-    ///     prefetch path when the legacy ToastGui capture toggle is enabled.
+    ///     Ensures the supported normal-toast route is callback-owned whenever
+    ///     global toast translation is enabled.
     /// </summary>
     [Fact]
-    public void GetSupportedNormalToastRouteState_ReturnsToastGuiCapturePrefetch_WhenLegacyCaptureIsEnabled()
+    public void GetSupportedNormalToastRouteState_ReturnsToastGuiFullRuntime_WhenToastTranslationIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiFullRuntime,
+            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures legacy hidden toggles no longer change the supported
+    ///     normal-toast route while toast translation is enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedNormalToastRouteState_ReturnsToastGuiFullRuntime_WhenLegacyCaptureToggleIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            UseToastGuiCaptureForSupportedToasts = true,
+            UseToastGuiRuntimeForSupportedToasts = false,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiFullRuntime,
+            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the supported error-toast route remains on the legacy
+    ///     addon-handler path while global toast translation is disabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedErrorToastRouteState_ReturnsLegacyAddonHandlers_WhenToastTranslationIsDisabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = false,
+            TranslateErrorToast = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.LegacyAddonHandlers,
+            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the supported error-toast route remains callback-owned while
+    ///     global toast translation and error-toast translation are both
+    ///     enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedErrorToastRouteState_ReturnsToastGuiFullRuntime_WhenToastAndErrorTranslationAreEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateErrorToast = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiFullRuntime,
+            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures legacy hidden toggles no longer change the supported
+    ///     error-toast route while toast translation is enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedErrorToastRouteState_ReturnsToastGuiFullRuntime_WhenLegacyCaptureToggleIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateErrorToast = true,
+            UseToastGuiCaptureForSupportedToasts = true,
+            UseToastGuiRuntimeForSupportedToasts = false,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiFullRuntime,
+            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the legacy prefetch-only policy gates remain disabled now
+    ///     that supported toasts are permanently callback-owned.
+    /// </summary>
+    [Fact]
+    public void UseLegacyCapturePolicies_ReturnFalse()
     {
         var config = new Config
         {
             TranslateToast = true,
             TranslateWideTextToast = true,
-            UseToastGuiCaptureForSupportedToasts = true,
-        };
-
-        Assert.Equal(
-            ToastGuiRouteState.ToastGuiCapturePrefetch,
-            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
-    }
-
-    /// <summary>
-    ///     Ensures the supported normal-toast family becomes active whenever
-    ///     the hidden runtime toggle is on, without depending on the legacy
-    ///     addon-specific toast toggles.
-    /// </summary>
-    [Fact]
-    public void UseSupportedNormalToastRuntime_ReturnsTrue_WhenHiddenRuntimeToggleIsEnabled()
-    {
-        var config = new Config
-        {
-            TranslateToast = true,
-            UseToastGuiRuntimeForSupportedToasts = true,
-        };
-
-        Assert.True(ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(config));
-        Assert.Equal(
-            ToastGuiRouteState.ToastGuiFullRuntime,
-            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
-    }
-
-    /// <summary>
-    ///     Ensures the default supported error-toast route remains on the
-    ///     legacy addon-handler path when the hidden full-runtime toggle is
-    ///     disabled.
-    /// </summary>
-    [Fact]
-    public void GetSupportedErrorToastRouteState_ReturnsLegacyAddonHandlers_ByDefault()
-    {
-        var config = new Config
-        {
-            TranslateToast = true,
-            TranslateErrorToast = true,
-        };
-
-        Assert.Equal(
-            ToastGuiRouteState.LegacyAddonHandlers,
-            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
-    }
-
-    /// <summary>
-    ///     Ensures the supported error-toast route reports the capture-only
-    ///     prefetch path when the legacy ToastGui capture toggle is enabled.
-    /// </summary>
-    [Fact]
-    public void GetSupportedErrorToastRouteState_ReturnsToastGuiCapturePrefetch_WhenLegacyCaptureIsEnabled()
-    {
-        var config = new Config
-        {
-            TranslateToast = true,
             TranslateErrorToast = true,
             UseToastGuiCaptureForSupportedToasts = true,
+            UseToastGuiRuntimeForSupportedToasts = false,
         };
 
-        Assert.Equal(
-            ToastGuiRouteState.ToastGuiCapturePrefetch,
-            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
-    }
-
-    /// <summary>
-    ///     Ensures the supported error-toast route reports the full callback
-    ///     runtime when the hidden full ToastGui path is enabled.
-    /// </summary>
-    [Fact]
-    public void GetSupportedErrorToastRouteState_ReturnsToastGuiFullRuntime_WhenFullRuntimeIsEnabled()
-    {
-        var config = new Config
-        {
-            TranslateToast = true,
-            TranslateErrorToast = true,
-            UseToastGuiRuntimeForSupportedToasts = true,
-        };
-
-        Assert.Equal(
-            ToastGuiRouteState.ToastGuiFullRuntime,
-            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
+        Assert.False(ToastGuiSupportedToastPolicy.UseLegacyNormalToastCapturePrefetch(config));
+        Assert.False(ToastGuiSupportedToastPolicy.UseLegacyErrorToastCapturePrefetch(config));
     }
 
     /// <summary>

--- a/Echoglossian.Tests/ToastGuiSupportedToastPolicyTests.cs
+++ b/Echoglossian.Tests/ToastGuiSupportedToastPolicyTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="ToastGuiSupportedToastPolicyTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.AddonHandlers.Toasts;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers the merged family-level semantics used by the alternate ToastGui
+///     runtime path for supported toasts.
+/// </summary>
+public class ToastGuiSupportedToastPolicyTests
+{
+    /// <summary>
+    ///     Ensures the supported normal-toast family becomes active whenever
+    ///     the hidden runtime toggle is on, without depending on the legacy
+    ///     addon-specific toast toggles.
+    /// </summary>
+    [Fact]
+    public void UseSupportedNormalToastRuntime_ReturnsTrue_WhenHiddenRuntimeToggleIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            UseToastGuiRuntimeForSupportedToasts = true,
+        };
+
+        Assert.True(ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(config));
+    }
+
+    /// <summary>
+    ///     Ensures the unified normal-toast family reuses the canonical
+    ///     wide-text toast display mode while the alternate ToastGui path is
+    ///     enabled.
+    /// </summary>
+    [Fact]
+    public void GetNormalToastDisplayMode_ReturnsWideTextToastDisplayMode()
+    {
+        var config = new Config
+        {
+            WideTextToastTranslationDisplayMode = JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            AreaToastTranslationDisplayMode = JournalTranslationDisplayMode.TooltipTranslation,
+            ClassChangeToastTranslationDisplayMode = JournalTranslationDisplayMode.NativeUiTranslation,
+        };
+
+        Assert.Equal(
+            JournalTranslationDisplayMode.NativeUiTranslationWithOriginalTooltips,
+            ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(config));
+    }
+}

--- a/Echoglossian.Tests/ToastGuiSupportedToastPolicyTests.cs
+++ b/Echoglossian.Tests/ToastGuiSupportedToastPolicyTests.cs
@@ -15,6 +15,43 @@ namespace Echoglossian.Tests;
 public class ToastGuiSupportedToastPolicyTests
 {
     /// <summary>
+    ///     Ensures the default supported normal-toast route remains on the
+    ///     legacy addon-handler path when neither hidden ToastGui toggle is
+    ///     enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedNormalToastRouteState_ReturnsLegacyAddonHandlers_ByDefault()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.LegacyAddonHandlers,
+            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the supported normal-toast route reports the capture-only
+    ///     prefetch path when the legacy ToastGui capture toggle is enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedNormalToastRouteState_ReturnsToastGuiCapturePrefetch_WhenLegacyCaptureIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateWideTextToast = true,
+            UseToastGuiCaptureForSupportedToasts = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiCapturePrefetch,
+            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
+    }
+
+    /// <summary>
     ///     Ensures the supported normal-toast family becomes active whenever
     ///     the hidden runtime toggle is on, without depending on the legacy
     ///     addon-specific toast toggles.
@@ -29,6 +66,66 @@ public class ToastGuiSupportedToastPolicyTests
         };
 
         Assert.True(ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(config));
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiFullRuntime,
+            ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the default supported error-toast route remains on the
+    ///     legacy addon-handler path when the hidden full-runtime toggle is
+    ///     disabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedErrorToastRouteState_ReturnsLegacyAddonHandlers_ByDefault()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateErrorToast = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.LegacyAddonHandlers,
+            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the supported error-toast route reports the capture-only
+    ///     prefetch path when the legacy ToastGui capture toggle is enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedErrorToastRouteState_ReturnsToastGuiCapturePrefetch_WhenLegacyCaptureIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateErrorToast = true,
+            UseToastGuiCaptureForSupportedToasts = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiCapturePrefetch,
+            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
+    }
+
+    /// <summary>
+    ///     Ensures the supported error-toast route reports the full callback
+    ///     runtime when the hidden full ToastGui path is enabled.
+    /// </summary>
+    [Fact]
+    public void GetSupportedErrorToastRouteState_ReturnsToastGuiFullRuntime_WhenFullRuntimeIsEnabled()
+    {
+        var config = new Config
+        {
+            TranslateToast = true,
+            TranslateErrorToast = true,
+            UseToastGuiRuntimeForSupportedToasts = true,
+        };
+
+        Assert.Equal(
+            ToastGuiRouteState.ToastGuiFullRuntime,
+            ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(config));
     }
 
     /// <summary>

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -77,6 +77,13 @@ public partial class Echoglossian : IDalamudPlugin
   /// </summary>
 #if DEBUG
   private AddonStructureProbe.AddonStructureProbeWatch? addonProbeWatch;
+
+  private readonly List<AddonStructureProbe.AddonStructureProbeWatch>
+      addonManagedProbeWatches = [];
+
+  private bool autoAddonProbeStartedForCurrentLogin;
+  private bool autoAddonProbeSuppressedUntilLogout;
+  private bool autoAddonProbeWasLoggedIn;
 #endif
 
   /// <summary>
@@ -477,8 +484,7 @@ public partial class Echoglossian : IDalamudPlugin
     this.ClearReferenceTextPrefetchState();
 
 #if DEBUG
-    this.addonProbeWatch?.Dispose();
-    this.addonProbeWatch = null;
+    this.StopAllAddonProbeWatches();
 #endif
 
       this.UnregisterQuestToastRuntime();

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -124,6 +124,7 @@ public partial class Echoglossian : IDalamudPlugin
   private readonly bool pluginAssetsState;
   private QuestToastRuntime questToastRuntime;
   private ToastGuiCaptureRuntime toastGuiCaptureRuntime;
+  private ToastGuiSupportedToastRuntime toastGuiSupportedToastRuntime;
   private readonly IDalamudTextureWrap talkImage;
   private static Echoglossian? activeInstance;
   private string? addonHandlerRegistrationSignature;
@@ -328,6 +329,8 @@ public partial class Echoglossian : IDalamudPlugin
 
     this.questToastRuntime = this.CreateQuestToastRuntime();
     this.RegisterQuestToastRuntime();
+    this.toastGuiSupportedToastRuntime = this.CreateToastGuiSupportedToastRuntime();
+    this.RegisterToastGuiSupportedToastRuntime();
     this.toastGuiCaptureRuntime = this.CreateToastGuiCaptureRuntime();
     this.RegisterToastGuiCaptureRuntime();
 
@@ -488,6 +491,7 @@ public partial class Echoglossian : IDalamudPlugin
 #endif
 
       this.UnregisterQuestToastRuntime();
+      this.UnregisterToastGuiSupportedToastRuntime();
       this.UnregisterToastGuiCaptureRuntime();
       this.queuedTranslationBroker.Dispose();
 

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -116,6 +116,7 @@ public partial class Echoglossian : IDalamudPlugin
 
   private readonly bool pluginAssetsState;
   private QuestToastRuntime questToastRuntime;
+  private ToastGuiCaptureRuntime toastGuiCaptureRuntime;
   private readonly IDalamudTextureWrap talkImage;
   private static Echoglossian? activeInstance;
   private string? addonHandlerRegistrationSignature;
@@ -320,6 +321,8 @@ public partial class Echoglossian : IDalamudPlugin
 
     this.questToastRuntime = this.CreateQuestToastRuntime();
     this.RegisterQuestToastRuntime();
+    this.toastGuiCaptureRuntime = this.CreateToastGuiCaptureRuntime();
+    this.RegisterToastGuiCaptureRuntime();
 
     this.EgloAddonHandler();
 
@@ -479,6 +482,7 @@ public partial class Echoglossian : IDalamudPlugin
 #endif
 
       this.UnregisterQuestToastRuntime();
+      this.UnregisterToastGuiCaptureRuntime();
       this.queuedTranslationBroker.Dispose();
 
       PluginInterface.UiBuilder.OpenMainUi -= this.ConfigWindow;

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -249,6 +249,7 @@ public partial class Echoglossian : IDalamudPlugin
     this.MigrateOverlayDisplayModes();
     this.MigrateGameMainMenuTranslationSettings();
     this.MigrateTranslationEngineSelection(loadedConfigVersion);
+    this.EnsureConfigDefaultsPersistedForMissingKeys();
 
     SelectedLanguage = this.languagesDictionary[this.configuration.Lang];
     AssetsManager.RefreshPluginAssetsState(SelectedLanguage);

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2050,6 +2050,10 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
+                Hosts debug-only automatic addon-probe watches that start on login for
+                selected addons with early hidden-state value.
+            </summary>
+            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
             </summary>
@@ -4042,6 +4046,70 @@
         <member name="M:Echoglossian.Echoglossian.EgloAddonHandler">
             <summary>
             Handles the registration of addon handlers.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
+            <summary>
+                Ticks manual and automatic addon-probe watches, including the
+                debug-only login bootstrap for the default watch set.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
+            <summary>
+                Gets how many addon-probe watches are currently active across manual
+                and managed watch sets.
+            </summary>
+            <returns>The active probe-watch count.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
+            <summary>
+                Stops every active addon-probe watch known to the plugin.
+            </summary>
+            <param name="suppressAutoUntilLogout">
+                Whether the current login session should suppress the default
+                automatic watch set after the stop completes.
+            </param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
+            <summary>
+                Ticks the currently active manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
+            <summary>
+                Ticks every managed addon-probe watch and prunes the disposed ones.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic addon-probe watch set when the player
+                logs in, then resets the gate on logout.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic watch set used to capture early
+                structural state for pooled dialogue addons.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
+            <summary>
+                Starts one managed addon-probe watch and tracks it for later stop or
+                pruning.
+            </summary>
+            <param name="addonName">The addon name to watch.</param>
+            <param name="index">The addon instance index.</param>
+            <param name="duration">How long the watch should stay alive.</param>
+            <param name="reason">The debug log reason attached to the startup.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
+            <summary>
+                Stops the current manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
+            <summary>
+                Stops every managed automatic addon-probe watch.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
@@ -6851,171 +6919,165 @@
                 Gets or sets the row update time in UTC.
             </summary>
         </member>
-        <member name="P:EDungeonItem payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.DeepDungeonItemId">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.ActionTooltip.RowVersion">
             <summary>
-                Gets or sets the DeepDungeonItem row identifier.
+                Gets or sets the optimistic-concurrency token.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.ActionTooltip.ToString">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.AozActionText">
             <summary>
-                Represents one canonical DB-first EurekaMagiaAction payload.
+                Represents one canonical DB-first AozAction payload.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText.EurekaMagiaActionId">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.AozActionText.AozActionId">
             <summary>
-                Gets or sets the EurekaMagiaAction row identifier.
+                Gets or sets the AozAction row identifier.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.AozActionText.ToString">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.EventActionText">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage">
             <summary>
-                Represents one canonical DB-first EventAction payload.
+                Adapter to enable <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage" /> to be handled via
+                <see cref="T:Echoglossian.EFCoreSqlite.Models.IMultiTextEntity" />.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.EventActionText.EventActionId">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.#ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Byte[],System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
             <summary>
-                Gets or sets the EventAction row identifier.
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage" /> class.
             </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.EventActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.EventItemText">
-            <summary>
-                Represents one canonical DB-first EventItem payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.EventItemText.EventItemId">
-            <summary>
-                Gets or sets the EventItem row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.EventItemText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.GameWindow">
-            <summary>
-                Represents a game window translation entity in the database.
-            </summary>
-            <summary>
-                Provides <see cref="T:Echoglossian.EFCoreSqlite.Models.IGenericEntity" /> implementation for the
-                <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> entity.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.#ctor(System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.UInt32})">
-            <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> class.
-            </summary>
-            <param name="windowAddonName">The name of the window addon.</param>
-            <param name="originalWindowStrings">The original window strings.</param>
-            <param name="originalWindowStringsLang">
-                The language of the original window
-                strings.
-            </param>
-            <param name="translatedWindowStrings">The translated window strings.</param>
+            <param name="senderName">The name of the sender.</param>
+            <param name="originalBattleTalkMessage">The original battle talk message.</param>
+            <param name="originalBattleTalkMessageLang">The language of the original battle talk message.</param>
+            <param name="originalSenderNameLang">The language of the original sender name.</param>
+            <param name="translatedSenderName">The translated sender name.</param>
+            <param name="translatedBattleTalkMessage">The translated battle talk message.</param>
             <param name="translationLang">The language of the translation.</param>
             <param name="translationEngine">The translation engine used.</param>
-            <param name="gameVersion">The version of the game.</param>
-            <param name="createdDate">The date the record was created.</param>
-            <param name="updatedDate">The date the record was last updated.</param>
-            <param name="classJobId">
-                The class/job identifier associated with this window payload when the
-                addon content varies by the active job.
-            </param>
+            <param name="rtlLangTranslationImageData">The RTL language translation image data.</param>
+            <param name="createdDate">The date the message was created.</param>
+            <param name="updatedDate">The date the message was last updated.</param>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.GameWindow.WindowAddonName">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.#ctor">
             <summary>
-                Gets or sets the name of the window addon or unique key that identifies
-                this entity context.
+             Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage"/> class.
+             </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalLang">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalLang(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalSecondaryText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalSecondaryText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslatedText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslatedText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslatedSecondaryText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslatedSecondaryText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslationLang">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslationLang(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslationEngine">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslationEngine(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetEntityKey">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetEntityKey(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetGameVersion">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetGameVersion(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText">
+            <summary>
+                Represents one canonical DB-first BgcArmyAction payload.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.GameWindow.ClassJobId">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText.BgcArmyActionId">
             <summary>
-                Gets or sets the class/job identifier associated with this window
-                payload when the addon content varies by the active job.
+                Gets or sets the BgcArmyAction row identifier.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.#ctor">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.BuddyActionText">
             <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> class for use
-                with the <see cref="!:GenericAddonHandler" />.
+                Represents one canonical DB-first BuddyAction payload.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetOriginalText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetOriginalText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetOriginalLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetOriginalLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetTranslatedText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetTranslatedText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetTranslationLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetTranslationLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetTranslationEngine">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetTranslationEngine(System.Int32)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetEntityKey">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetEntityKey(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetGameVersion">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetGameVersion(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.GeneralActionText">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.BuddyActionText.BuddyActionId">
             <summary>
-                Represents one canonical DB-first GeneralAction payload.
+                Gets or sets the BuddyAction row identifier.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.GeneralActionText.GeneralActionId">
-            <summary>
-                Gets or sets the GeneralAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.GeneralActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.BuddyActionText.ToString">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.IComplexEntity">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.CompanyActionText">
             <summary>
-            Enhances the IMultiTextEntity interface to include additional properties and methods
+                Represents one canonical DB-first CompanyAction payload.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.IComplexEntity.GetType">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.CompanyActionText.CompanyActionId">
             <summary>
-            Gets the type of the StringArrayData.
+                Gets or sets the CompanyAction row identifier.
             </summary>
-            <returns>Returns the type of the StringArrayData.</returns>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.IComplexEntity.SetType(System.Stri   </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.CompanyActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.CraftActionText">
+            <summary>
+                Represents one canonical DB-first CraftAction payload.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.CraftActionText.CraftActionId">
+            <summary>
+                Gets or sets the CraftAction row identifier.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.CraftActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText">
+            <summary>
+                Represents one canonical DB-first DeepDungeonItem payload.
+            </summary>
+        </member>
         <member name="P:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.DeepDungeonItemId">
             <summary>
                 Gets or sets the DeepDungeonItem row identifier.
@@ -7725,82 +7787,76 @@
             </summary>
             <param name="prettyPrint">Should it be pretty printed?.</param>
         </member>
-        <member</member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.CategoryId">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.UpdateFieldsFromText">
             <summary>
-                Gets or sets the sheet category value.
+                Forces loading the Objectives and Summaries from the stored text fields.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.MainCommandCategoryId">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.LoadDictionaryFromTextOrKeepCurrent(System.String,System.Collections.Generic.Dictionary{System.String,System.String})">
             <summary>
-                Gets or sets the linked MainCommandCategory row identifier.
+                Loads a serialized dictionary when available and otherwise preserves
+                any current in-memory state that has not yet been materialized.
+            </summary>
+            <param name="serializedText">The serialized dictionary text.</param>
+            <param name="currentValue">The current in-memory dictionary.</param>
+            <returns>The resolved dictionary.</returns>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.LoadFromTextOrKeepCurrent``1(System.String,System.Collections.Generic.List{``0},System.Func{System.Collections.Generic.List{``0}})">
+            <summary>
+                Loads a serialized payload when available and otherwise preserves
+                any current in-memory state that has not yet been materialized.
+            </summary>
+            <typeparam name="T">The payload item type.</typeparam>
+            <param name="serializedText">The serialized payload text.</param>
+            <param name="currentValue">The current in-memory payload.</param>
+            <param name="loadFromText">The loader to invoke when serialized text exists.</param>
+            <returns>The resolved payload collection.</returns>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection">
+            <summary>
+                Identifies one canonical quest-text row section inside the persisted
+                quest payload.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.Unknown0">
+        <member name="F:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection.Summary">
             <summary>
-                Gets or sets the MainCommand sheet's <c>Unknown0</c> value.
+                A SEQ / journal summary row.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.SortId">
+        <member name="F:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection.Objective">
             <summary>
-                Gets or sets the sheet sort identifier.
+                A TODO / objective row.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MainCommandText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage">
+        <member name="F:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection.System">
             <summary>
-                Adapter to enable <see cref="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage" /> to be handled via
-                <see cref="T:Echoglossian.EFCoreSqlite.Models.IGenericEntity" />.
+                A SYSTEM / system-message row.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.#ctor(System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow">
             <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage" /> class.
+                Represents one canonical persisted quest row with section, row key,
+                ordering, original text, and translated text kept together.
             </summary>
-            <param name="originalMiniTalkMessage">The original MiniTalk message.</param>
-            <param name="originalMiniTalkMessageLang">The language of the original MiniTalk message.</param>
-            <param name="translatedMiniTalkMessage">The translated MiniTalk message.</param>
-            <param name="translationLang">The language of the translated MiniTalk message.</param>
-            <param name="translationEngine">The translation engine used.</param>
-            <param name="createdDate">The date the message was created.</param>
-            <param name="updatedDate">The date the message was last updated.</param>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetOriginalText">
-            <inheritdoc />
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow" />
+                class.
+            </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetOriginalText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetOriginalLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetOriginalLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetTranslatedText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetTranslatedText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetTranslationLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetTranslationLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetTranslationEngine">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetTranslationEngine(System.Int32)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetEntityKey">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.">The stable section-relative order.</param>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow.#ctor(Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection,System.String,System.String,System.Int32,System.Boolean,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow" />
+                class.
+            </summary>
+            <param name="section">The row section.</param>
+            <param name="rowKey">The canonical row key.</param>
+            <param name="originalText">The original row text.</param>
+            <param name="order">The stable section-relative order.</param>
             <param name="isCurrentSequence">Whether this row is the live current SEQ row.</param>
             <param name="translatedText">The translated row text when available.</param>
         </member>
@@ -7948,81 +8004,89 @@
         <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetEntityKey">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetEntityKey(SyelectString">The translated question/title.</param>
-            <param name="translatedOptionsAsText">The translated option list serialized as JSON.</param>
-            <param name="translationLang">The language of the translated dialog.</param>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetEntityKey(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetGameVersion">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetGameVersion(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.MountActionText">
+            <summary>
+                Represents one canonical DB-first MountAction payload.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.MountActionText.MountActionId">
+            <summary>
+                Gets or sets the MountAction row identifier.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MountActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.NpcNames.#ctor(System.Int32,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.NpcNames" /> class.
+            </summary>
+            <param name="id">The unique identifier for the NPC.</param>
+            <param name="originalNpcName">The original name of the NPC.</param>
+            <param name="originalNpcNameLang">The language of the original NPC name.</param>
+            <param name="translatedNpcName">The translated name of the NPC.</param>
+            <param name="translationLang">The language of the translated NPC name.</param>
             <param name="translationEngine">The translation engine used.</param>
-            <param name="createdDate">The date the record was created.</param>
-            <param name="updatedDate">The date the record was last updated.</param>
+            <param name="createdDate">The date the NPC name was created.</param>
+            <param name="updatedDate">The date the NPC name was last updated.</param>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.SelectString.OriginalOptions">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.PetActionText">
             <summary>
-                Gets or sets the original options as a list of strings.
+                Represents one canonical DB-first PetAction payload.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.SelectString.TranslatedOptions">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.PetActionText.PetActionId">
             <summary>
-                Gets or sets the translated options as a list of strings.
+                Gets or sets the PetAction row identifier.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.UpdateFieldsAsText(System.Boolean)">
-            <summary>
-                Updates the serialized text fields from the current option lists.
-            </summary>
-            <param name="prettyPrint">Should the JSON be pretty printed?.</param>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.PetActionText.ToString">
+            <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.UpdateFieldsFromText">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.PvPActionText">
             <summary>
-                Forces loading the option lists from the stored text fields.
+                Represents one canonical DB-first PvPAction payload.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetOriginalText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetOriginalText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetOriginalLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetOriginalLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetTranslatedText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetTranslatedText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetTranslationLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetTranslationEngine">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetTranslationEngine(System.Int32)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetEntityKey(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetGameVersion">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetGameVersion(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetEntityKey">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.StringArrayDatas">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.PvPActionText.PvPActionId">
             <summary>
-            Represents a record of a translated string array, including raw data and translation metadata.
+                Gets or sets the PvPAction row identifier.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.#ctor(System.String,System.Int32,System.Byte[],System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.String,System.DateTime,System.DateTime)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.PvPActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase">
             <summary>
-             Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.StringArrayDatas"/> classs.ReferenceTextRowBase.OriginalDescription">
+                Provides the shared canonical persisted fields for action-adjacent
+                Excel-sheet reference-text rows.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.Id">
+            <summary>
+                Gets or sets the primary key.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.ReferenceId">
+            <summary>
+                Gets or sets the stable sheet-row identifier.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.OriginalName">
+            <summary>
+                Gets or sets the canonical original name.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.OriginalDescription">
             <summary>
                 Gets or sets the canonical original description, when available.
             </summary>
@@ -8253,82 +8317,92 @@
         </member>
         <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.ContextKey">
             <summary>
-            Gets or sets the semantic context key for this string-array 
-                <see cref="T:Echoglossian.EFCoreSqlite.Models.IMultiTextEntity" />.
+            Gets or sets the semantic context key for this string-array surface.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.#ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Byte[],System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SchemaVersion">
             <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.TalkMessage" /> class.
+            Gets or sets the schema version used to serialize the structured payload.
             </summary>
-            <param name="senderName">The name of the sender.</param>
-            <param name="originalTalkMessage">The original talk message.</param>
-            <param name="originalTalkMessageLang">
-                The language of the original talk
-                message.
-            </param>
-            <param name="originalSenderNameLang">
-                The language of the original sender's
-                name.
-            </param>
-            <param name="translatedSenderName">The translated sender's name.</param>
-            <param name="translatedTalkMessage">The translated talk message.</param>
-            <param name="translationLang">The language of the translation.</param>
-            <param name="translationEngine">The translation engine used.</param>
-            <param name="rtlLangTranslationImageData">The RTL language translation image data.</param>
-            <param name="createdDate">The date the message was created.</param>
-            <param name="updatedDate">The date the message was last updated.</param>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.#ctor">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SourceContentHash">
             <summary>
-            Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.TalkMessage"/> class.
+            Gets or sets the stable source-content hash for the canonical payload.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetOriginalText">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.OriginalStructuredPayload">
+            <summary>
+            Gets or sets the structured original payload for this surface.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.TranslatedStructuredPayload">
+            <summary>
+            Gets or sets the structured translated payload for this surface.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.CreatedAt">
+            <summary>
+            Gets or sets the creation timestamp.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.UpdatedAt">
+            <summary>
+            Gets or sets the last updated timestamp.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.RowVersion">
+            <summary>
+            Gets or sets the row version for concurrency handling.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.StringArrayDatas"/> class.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetType">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetOriginalText(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetType(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetOriginalLang">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetSize">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetOriginalLang(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetSize(System.Int32)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetOriginalSecondaryText">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetRawData">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetOriginalSecondaryText(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetRawData(System.Byte[])">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslatedText">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetFormattedRawData">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslatedText(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetFormattedRawData(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslatedSecondaryText">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetTranslatedStringsWithPayloads">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslatedSecondaryText(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetTranslatedStringsWithPayloads(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslationLang">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetOriginalLang">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslationLang(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetOriginalLang(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslationEngine">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetOriginalStrings">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslationEngine(System.Int32)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetOriginalStrings(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetEntityKey">
-            <inheritdoc />
-    ang">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetTranslationLang">
             <inheritdoc />
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetTranslationLang(System.String)">
@@ -8708,7 +8782,185 @@
                 Gets or sets the trait icon identifier.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Tra          <param name="languageInfo">The language to inspect.</param>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.ClassJobId">
+            <summary>
+                Gets or sets the active class-job identifier used to scope the trait.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.ClassJobCategoryId">
+            <summary>
+                Gets or sets the class-job-category row identifier.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TraitName">
+            <summary>
+                Gets or sets the canonical original trait name.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TraitDescription">
+            <summary>
+                Gets or sets the canonical original trait description.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.OriginalTooltipText">
+            <summary>
+                Gets or sets the fully assembled original tooltip text.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.OriginalLang">
+            <summary>
+                Gets or sets the language of the original source payload.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslatedTraitName">
+            <summary>
+                Gets or sets the translated trait name.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslatedTraitDescription">
+            <summary>
+                Gets or sets the translated trait description.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslatedTooltipText">
+            <summary>
+                Gets or sets the fully assembled translated tooltip text.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslationLang">
+            <summary>
+                Gets or sets the target translation language.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslationEngine">
+            <summary>
+                Gets or sets the translation-engine identifier.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.GameVersion">
+            <summary>
+                Gets or sets the game version associated with the source payload.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.SourceContentHash">
+            <summary>
+                Gets or sets the stable source-content hash.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.CanonicalPayloadAsText">
+            <summary>
+                Gets or sets the serialized canonical payload, including translated fields when available.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.CreatedDate">
+            <summary>
+                Gets or sets the row creation time in UTC.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.UpdatedDate">
+            <summary>
+                Gets or sets the row update time in UTC.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.RowVersion">
+            <summary>
+                Gets or sets the optimistic-concurrency token.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.Trait.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.TranslationFailure">
+            <summary>
+                Represents one exact translation request that previously returned no
+                usable translated text for a specific source/target language pair and
+                translation engine.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.Id">
+            <summary>
+                Gets or sets the primary key.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceText">
+            <summary>
+                Gets or sets the exact sanitized text that was sent to the
+                translation engine.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceTextHash">
+            <summary>
+                Gets or sets the stable hash of <see cref="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceText" /> used for
+                lookup and indexing.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceLanguage">
+            <summary>
+                Gets or sets the normalized source language code.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.TargetLanguage">
+            <summary>
+                Gets or sets the normalized target language code.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.TranslationEngine">
+            <summary>
+                Gets or sets the translation-engine identifier.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.FailureReason">
+            <summary>
+                Gets or sets the last recorded failure reason.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.FirstSeenOrigin">
+            <summary>
+                Gets or sets the origin context that first produced this exact
+                failed translation request.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.LastSeenOrigin">
+            <summary>
+                Gets or sets the most recent origin context that produced this exact
+                failed translation request.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.FailureCount">
+            <summary>
+                Gets or sets how many times this exact request failed.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.CreatedDate">
+            <summary>
+                Gets or sets the row creation time in UTC.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.UpdatedDate">
+            <summary>
+                Gets or sets the last update time in UTC.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.RowVersion">
+            <summary>
+                Gets or sets the optimistic-concurrency token.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TranslationFailure.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.AssetsManager.RequiresDownloadedAsset(System.String)">
+            <summary>
+            Determines whether a font file name depends on a downloaded external asset.
+            </summary>
+            <param name="fontFileName">The font file name to inspect.</param>
+            <returns><c>true</c> if the font requires a downloaded asset; otherwise, <c>false</c>.</returns>
+        </member>
+        <member name="M:Echoglossian.AssetsManager.RequiresDownloadedAssets(Echoglossian.LanguagesHandling.LanguageInfo)">
+            <summary>
+            Determines whether the specified language requires a downloaded font asset.
+            </summary>
+            <param name="languageInfo">The language to inspect.</param>
             <returns><c>true</c> if the language depends on a downloaded asset; otherwise, <c>false</c>.</returns>
         </member>
         <member name="M:Echoglossian.AssetsManager.GetRequiredAssetFiles(Echoglossian.LanguagesHandling.LanguageInfo)">
@@ -9154,86 +9406,80 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ResolveSupportedEngineSelection(System.Int32,System.Collections.Generic.IReadOnlyCollection{e to an explicit logger sink.
-            </summary>
-            <param name="pluginLog">The explicit logger sink to use.</param>
-            <param name="message">The message to write.</param>
-        </member>
-        <member name="M:Echoglossian.PluginRuntimeLog.Warning(System.String,System.String)">
+        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ResolveSupportedEngineSelection(System.Int32,System.Collections.Generic.IReadOnlyCollection{System.Int32})">
             <summary>
-                Writes a scoped warning log line.
+                Normalizes a selected engine id against the currently supported engine
+                ids for the target language.
             </summary>
-            <param name="scope">The logical scope to render inside square brackets.</param>
-            <param name="message">The message to write.</param>
-        </member>
-        <member name="M:Echoglossian.PluginRuntimeLog.Error(System.String)">
-            <summary>
-                Writes an error log line.
-            </summary>
-            <param name="message">The message to write.</param>
-        </member>
-        <member name="M:Echoglossian.PluginRuntimeLog.Error(Dalamud.Plugin.Services.IPluginLog,System.String)">
-            <summary>
-                Writes an error log line to an explicit logger sink.
-            </summary>
-            <param name="pluginLog">The explicit logger sink to use.</param>
-            <param name="message">The message to write.</param>
-        </member>
-        <member name="M:Echoglossian.PluginRuntimeLog.Error(System.String,System.String)">
-            <summary>
-                Writes a scoped error log line.
-            </summary>
-            <param name="scope">The logical scope to render inside square brackets.</param>
-            <param name="message">The message to write.</param>
-        </member>
-        <member name="M:Echoglossian.PluginRuntimeLog.Format(System.String,System.String)">
-            <summary>
-                Prepends an optional logical scope to a message.
-            </summary>
-            <param name="scope">The logical scope to render inside square brackets.</param>
-            <param name="message">The message to format.</param>
-            <returns>The formatted message.</returns>
-        </member>
-        <member name="T:Echoglossian.RuntimeLanguageHelper">
-            <summary>
-                Normalizes the runtime game and target language values so DB-first
-                recovery code can compare persisted rows safely without hardcoding a
-                single target language.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.RuntimeLanguageHelper.GetCurrentGameLanguageCode">
-            <summary>
-                Gets the current native client language as a normalized language
-                code.
-            </summary>
-            <returns>The normalized current game language code.</returns>
-        </member>
-        <member name="M:Echoglossian.RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(System.Int32)">
-            <summary>
-                Gets the configured translation target language as a normalized
-                language code.
-            </summary>
-            <param name="languageIndex">The configured target-language index.</param>
-            <returns>The normalized configured target language code.</returns>
-        </member>
-        <member name="M:Echoglossian.RuntimeLanguageHelper.LanguagesMatch(System.String,System.String)">
-            <summary>
-                Determines whether two language values represent the same effective
-                language.
-            </summary>
-            <param name="left">The first language value.</param>
-            <param name="right">The second language value.</param>
+            <param name="selectedEngineId">The currently selected engine id.</param>
+            <param name="supportedEngineIds">
+                The supported engine ids for the active
+                target language.
+            </param>
             <returns>
-                <see langword="true" /> when both values normalize to the same
-                code; otherwise <see langword="false" />.
+                The selected engine id when it is supported; otherwise, the first
+                supported concrete engine id, or Google when the language exposes no
+                concrete engine list.
             </returns>
         </member>
-        <member name="M:Echoglossian.RuntimeLanguageHelper.NormalizeLanguage(System.String)">
+        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.NormalizeAndSyncSelection(Echoglossian.Config,System.Int32,System.Collections.Generic.IReadOnlyCollection{System.Int32})">
             <summary>
-                Normalizes one runtime language value to a stable comparison code.
+                Normalizes and synchronizes the persisted translation engine
+                selection, preferring the persisted engine key when available and
+                keeping the numeric and string forms aligned.
             </summary>
-            <param name="language">The raw language value.</param>
-            <returns>The normalized .</param>
+            <param name="config">The active plugin configuration.</param>
+            <param name="loadedConfigVersion">
+                The config version loaded from disk before
+                migrations.
+            </param>
+            <param name="supportedEngineIds">
+                The supported engine ids for the active target
+                language, when that constraint should be applied.
+            </param>
+            <returns><see langword="true" /> when the config changed.</returns>
+        </member>
+        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ApplyExplicitSelection(Echoglossian.Config,System.Int32)">
+            <summary>
+                Applies an explicit user-selected engine to both persisted selection
+                forms so later normalization cannot silently revert the choice.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <param name="selectedEngineId">The explicitly selected concrete engine id.</param>
+        </member>
+        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.NormalizeLegacyChatGptBaseUrl(System.String)">
+            <summary>
+                Normalizes the legacy ChatGPT base URL that pointed directly at the
+                completions endpoint instead of the API root.
+            </summary>
+            <param name="chatGptBaseUrl">The configured ChatGPT base URL.</param>
+            <returns>The normalized base URL.</returns>
+        </member>
+        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ResolvePersistedEngineSelection(System.Int32,System.Int32,System.String)">
+            <summary>
+                Resolves the effective persisted engine selection from the available
+                persisted forms.
+            </summary>
+            <param name="loadedConfigVersion">
+                The config version loaded from disk before
+                migrations.
+            </param>
+            <param name="chosenEngineId">The persisted numeric engine id.</param>
+            <param name="chosenEngineKey">The persisted engine key.</param>
+            <returns>The resolved concrete engine id.</returns>
+        </member>
+        <member name="T:Echoglossian.TranslationPersistenceGuard">
+            <summary>
+            Provides shared guards for deciding whether translated results and
+            translation failures are safe to persist or reuse.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.TranslationPersistenceGuard.IsPersistentFailureReason(System.String)">
+            <summary>
+            Determines whether a translation failure reason is stable enough to
+            persist across sessions.
+            </summary>
+            <param name="failureReason">The recorded failure reason.</param>
             <returns>
             <c>true</c> when the failure reason should be persisted; otherwise,
             <c>false</c>.
@@ -10545,122 +10791,6 @@
             <param name="keyPrefix">The stable key prefix to match.</param>
             <returns>
                 The number of distinct non-empty values whose keys start with the
-                requested prefix.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.CanonicalizeIntMap(System.Collections.Generic.SortedDictionary{System.Int32,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Boolean@)">
-            <summary>
-                Canonicalizes one integer-keyed payload map through an exact text
-                lookup.
-            </summary>
-            <param name="sourceValues">The source values.</param>
-            <param name="lookup">The exact text lookup.</param>
-            <param name="changed">
-                Receives whether any resulting value differs from the source.
-            </param>
-            <returns>The canonicalized map.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.CanonicalizeStringMap(System.Collections.Generic.SortedDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Boolean@)">
-            <summary>
-                Canonicalizes one text-node payload map through an exact text
-                lookup.
-            </summary>
-            <param name="sourceValues">The source values.</param>
-            <param name="lookup">The exact text lookup.</param>
-            <param name="changed">
-                Receives whether any resulting value differs from the source.
-            </param>
-            <returns>The canonicalized map.</returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.AppendLookupEntry(System.String,System.String,System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.ISet{System.String},System.Boolean)">
-            <summary>
-                Appends one exact original/translated text pair to the supplied
-                lookups.
-            </summary>
-            <param name="originalText">The canonical original text.</param>
-            <param name="translatedText">The canonical translated text.</param>
-            <param name="originalLookup">
-                The lookup mapping any known visible text back to the canonical
-                original text.
-            </param>
-            <param name="translatedLookup">
-                The lookup mapping any known visible text to the canonical
-                translated text.
-            </param>
-            <param name="knownTexts">
-                The known-text set used to keep capture shape stable in both
-                original and translated states.
-            </param>
-            <param name="requireDifference">
-                When set, only pairs whose original and translated text differ are
-                appended.
-            </param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.AppendValueMapEntries``1(System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{``0,System.String},System.Collections.Generic.IReadOnlyDictionary{``0,System.String})">
-            <summary>
-                Appends one exact source-text to target-text mapping from matching
-                payload keys.
-            </summary>
-            <typeparam name="TKey">The payload key type.</typeparam>
-            <param name="valueMap">The target value map to augment.</param>
-            <param name="sourceValues">The source-facing payload values.</param>
-            <param name="targetValues">The target-facing payload values.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.TryDetermineDirectValueMapDirection(System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Boolean@)">
-            <summary>
-                Determines whether the direct payload-pair map represents one
-                source-original to target-translated transition or the reverse.
-            </summary>
-            <param name="directValueMap">The direct payload-pair map.</param>
-            <param name="originalLookup">The canonical original lookup.</param>
-            <param name="translatedLookup">The canonical translated lookup.</param>
-            <param name="sourceIsOriginal">
-                Receives <see langword="true" /> when the direct map flows from
-                original to translated text; otherwise <see langword="false" />
-                when it flows from translated to original text.
-            </param>
-            <returns>
-                <see langword="true" /> when one direction could be inferred;
-                otherwise <see langword="false" />.
-            </returns>
-        </member>
-        <member name="T:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler">
-            <summary>
-                Handles translation for the "CharacterClass" addon using visible text
-                nodes only.
-                Lifecycle-safe: extracts and applies values within valid memory scope per
-                frame.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.#ctor(Echoglossian.Config,Echoglossian.NativeUI.Helpers.HoverTooltipManager,Echoglossian.Translators.TranslationService)">
-            <summary>
-                Initializes a new instance of the
-                <see cref="T:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler" /> class.
-            </summary>
-            <param name="config">The configuration settings for the plugin.</param>
-            <param name="hoverTooltipManager">The shared hover-tooltip manager.</param>
-            <param name="translationService">The service used for translating text.</param>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldCaptureTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldReuseCompatiblePayloads">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldPersistNewGameWindowPayload(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldQueueNewGameWindowTranslation(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldRefreshAppliedStateOnPreDraw">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.OnCleanupEvent(Dalamud.Game.Addon.Lifecycle.AddonEvent,Dalamud.Game.Addon.Lifecycle.AddonArgTypes.AddonArgs)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.TryApplyCustomTextNodePayload(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload)">
-            <se keys start with the
                 requested prefix.
             </returns>
         </member>
@@ -17162,6 +17292,46 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
+            <summary>
+                Encapsulates the login-session gating rules for debug-only automatic
+                addon-probe watches.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
+            <summary>
+                Determines whether the current login session should start the default
+                automatic addon-probe watch set.
+            </summary>
+            <param name="isLoggedIn">Whether the client is currently logged in.</param>
+            <param name="hasStartedForCurrentLogin">
+                Whether the current login session already started its automatic probe
+                set.
+            </param>
+            <param name="isSuppressedUntilLogout">
+                Whether the user explicitly suppressed the automatic probe set until
+                the next logout.
+            </param>
+            <param name="activeManagedWatchCount">
+                How many managed automatic probe watches are currently alive.
+            </param>
+            <returns>
+                <see langword="true" /> when the automatic probe set should start.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
+            <summary>
+                Determines whether the automatic login-session gate should reset
+                because the player logged out.
+            </summary>
+            <param name="wasLoggedIn">
+                Whether the client was logged in on the previous tick.
+            </param>
+            <param name="isLoggedIn">Whether the client is logged in now.</param>
+            <returns>
+                <see langword="true" /> when the automatic probe gate should reset.
+            </returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -22122,7 +22292,151 @@
                 language using AWS Translate.
             </summary>
             <param name="text"></param>
-            <param name="sourceLanguage"></paraaram name="targetLanguage"></param>
+            <param name="sourceLanguage"></param>
+            <param name="targetLanguage"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.Translators.AmazonTranslateTranslator.TranslateAsync(System.String,System.String,System.String)">
+            <summary>
+                Asynchronously translates the given text from source language to target
+                language using AWS Translate.
+            </summary>
+            <param name="text"></param>
+            <param name="sourceLanguage"></param>
+            <param name="targetLanguage"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.#ctor(Dalamud.Plugin.Services.IPluginLog,System.String,System.String,System.String,System.Single,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.Translators.ChatGPTTranslator" /> class.
+            </summary>
+            <param name="pluginLog"></param>
+            <param name="baseUrl"></param>
+            <param name="apiKey"></param>
+            <param name="model"></param>
+            <param name="temperature"></param>
+            <param name="promptTemplate"></param>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.Translate(System.String,System.String,System.String)">
+            <summary>
+                Translates the specified text from the source language to the target
+                language.
+            </summary>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <returns>The translated text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.TranslateAsync(System.String,System.String,System.String)">
+            <summary>
+                Translates the specified text from the source language to the target
+                language asynchronously.
+            </summary>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <returns>
+                A task that represents the asynchronous translation operation. The
+                task result contains the translated text.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.TranslateCoreAsync(System.String,System.String,System.String,System.String)">
+            <summary>
+                Performs the actual OpenAI chat completion call for a single cache
+                key. Concurrent callers for the same key share the same in-flight
+                task.
+            </summary>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <param name="cacheKey">The normalized cache key for this request.</param>
+            <returns>The translated text, or a synthetic error placeholder.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.ClaudeTranslator">
+            <summary>
+                Translator implementation for Anthropic Claude using the Messages API.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.ClaudeTranslator.#ctor(Dalamud.Plugin.Services.IPluginLog,Echoglossian.Config)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.Translators.ClaudeTranslator" /> class.
+            </summary>
+            <param name="pluginLog">The plugin log instance for diagnostics.</param>
+            <param name="config">The active plugin configuration.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.ClaudeTranslator.Translate(System.String,System.String,System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Echoglossian.Translators.ClaudeTranslator.TranslateAsync(System.String,System.String,System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Echoglossian.Translators.ClaudeTranslator.TranslateCoreAsync(System.String,System.String,System.String,System.String)">
+            <summary>
+                Performs the actual Claude Messages API request for one cache key.
+            </summary>
+            <param name="text">The text to translate.</param>
+            <param name="sourceLanguage">The source language of the text.</param>
+            <param name="targetLanguage">The target language for the translation.</param>
+            <param name="cacheKey">The normalized cache key for this request.</param>
+            <returns>The translated text or an error placeholder.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Claude.ClaudeModelManager">
+            <summary>
+                Manages the optional live Claude model catalog used by the engine configuration UI.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Claude.ClaudeModelManager.CurrentModelList">
+            <summary>
+                Gets the current Claude model list used by the UI.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Claude.ClaudeModelManager.ResetToDefault">
+            <summary>
+                Restores the committed fallback model list.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Claude.ClaudeModelManager.RefreshAsync(System.String,System.String)">
+            <summary>
+                Refreshes the Claude model list from Anthropic's official models endpoint.
+            </summary>
+            <param name="apiKey">The Anthropic API key.</param>
+            <param name="baseUrl">The Anthropic API base URL.</param>
+            <returns>A task that completes when refresh finishes.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Claude.ClaudeTextModelDefaults">
+            <summary>
+                Provides the committed fallback Claude model list used when live fetch is disabled or unavailable.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Claude.ClaudeTextModelDefaults.PredefinedModels">
+            <summary>
+                Gets the predefined Claude models.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.Translators.DeepLTranslator">
+            <summary>
+                Provides translation services using the DeepL API or Free API based on the
+                configuration.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.DeepLTranslator.Echoglossian#Translators#ITranslator#TranslateAsync(System.String,System.String,System.String)">
+            <summary>
+                Asynchronously translates the given text from source language to target
+                language using the DeepL API or Free API based on the configuration.
+            </summary>
+            <param name="text"></param>
+            <param name="sourceLanguage"></param>
+            <param name="targetLanguage"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.Translators.DeepLTranslator.Echoglossian#Translators#ITranslator#Translate(System.String,System.String,System.String)">
+            <summary>
+                Synchronously translates the given text from source language to target
+                language using the DeepL API or Free API based on the configuration.
+            </summary>
+            <param name="text"></param>
+            <param name="sourceLanguage"></param>
+            <param name="targetLanguage"></param>
             <returns></returns>
         </member>
         <member name="M:Echoglossian.Translators.DeepLTranslator.Translate(System.String,System.String,System.String)">
@@ -22756,139 +23070,6 @@
         <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForTalk(Echoglossian.Config)">
             <summary>
             Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for talk translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForBattleTalk(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for battle talk translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigTalkSubtitle(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for talk subtitle translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForMiniTalk(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for MiniTalk translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForCutSceneSelectString(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for CutSceneSelectString overlays.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForTextGimmickHint(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for text gimmick hint translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForToast(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for toast translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForWideTextToast(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
-            provided <see cref="T:Echoglossian.Config"/> for Screen Info (_WideText) toast
-            translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForErrorToast(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for error toast translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForAreaToast(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
-            provided <see cref="T:Echoglossian.Config"/> for area toast translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForClassChangeToast(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
-            provided <see cref="T:Echoglossian.Config"/> for class/job change toast translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForQuestToast(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
-            provided <see cref="T:Echoglossian.Config"/> for quest toast translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForChatBubble(Echoglossian.Config)">
-            <summary>
-            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for chat bubble translations.
-            </summary>
-            <param name="config"></param>
-            <returns></returns>
-        </member>
-        <member name="T:TextTextureGenerator">
-            <summary>
-            Generates textures from text using a specified font and size.
-            </summary>
-        </member>
-        <member name="M:TextTextureGenerator.#ctor(Dalamud.Plugin.Services.ITextureProvider)">
-            <summary>
-            Initializes a new instance of the <see cref="T:TextTextureGenerator"/> class.
-            </summary>
-            <param name="textureProvider"></param>
-        </member>
-        <member name="M:TextTextureGenerator.CreateTextTextureAsync(System.String,System.String,System.Single,System.Nullable{System.Drawing.Color},System.Nullable{System.Drawing.Color},System.Drawing.FontStyle,System.Nullable{System.Int32})">
-            <summary>
-            Creates a texture from the specified text using the given font and size.
-            </summary>
-            <param name="text"></param>
-            <param name="fontPath"></param>
-            <param name="fontSize"></param>
-            <param name="textColor"></param>
-            <param name="backgroundColor"></param>
-            <param name="fontStyle"></param>
-            <param name="maxWidth"></param>
-            <returns></returns>
-        </member>
-        <member name="T:Microsoft.Extensions.DependencyInjection.DiscoveredServicesExtensions">
-            <summary>
-            Extension methods for discovered service registrations
-            </summary>
-        </member>
-        <member name="M:Microsoft.Extensions.DependencyInjection.DiscoveredServicesExtensions.AddEchoglossian(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String[])">
-            <summary>
-            Adds discovered services from Echoglossian to the specified service collection
-            </summary>
-            <param name="serviceCollection">The service collection.</param>
-            <param name="tags">The service registration tags to include.</param>
-            <returns>The service collection</returns>
-        </member>
-    </members>
-</doc>
-ossian.Config"/> for talk translations.
             </summary>
             <param name="config"></param>
             <returns></returns>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -14894,6 +14894,22 @@
                 <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryConfirmOriginalPointerMatchesVisible(System.IntPtr,System.String,System.String,System.String@)">
+            <summary>
+                Confirms that a MiniTalk node's original-text pointer really belongs to
+                the currently visible bubble text before the handler trusts it as the
+                logical source line.
+            </summary>
+            <param name="bubbleKey">The stable bubble key.</param>
+            <param name="originalPointerText">The text read from <c>OriginalTextPointer</c>.</param>
+            <param name="visibleText">The text currently visible in the node.</param>
+            <param name="originalText">Receives the confirmed original text.</param>
+            <returns>
+                <see langword="true" /> when the pointer text can be proven to explain
+                the visible replacement inside MiniTalk; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryReadOriginalPointerText(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">
             <summary>
                 Tries to read the original game-provided text payload from a MiniTalk
@@ -15081,7 +15097,7 @@
             <param name="originalName">The original sender name for the active line.</param>
             <param name="originalText">The original source text for the active line.</param>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.String)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.String,System.Boolean)">
             <summary>
                 Restores one tracked native BattleTalk layout snapshot back to the
                 original game state.
@@ -16150,6 +16166,21 @@
                 <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.TryConfirmOriginalPointerMatchesVisible(System.String,System.String,System.String@)">
+            <summary>
+                Confirms that a toast node's original-text pointer really belongs to
+                the currently visible toast text before the handler trusts it as the
+                logical source line.
+            </summary>
+            <param name="originalPointerText">The text read from <c>OriginalTextPointer</c>.</param>
+            <param name="visibleText">The text currently visible in the node.</param>
+            <param name="originalText">Receives the confirmed original toast text.</param>
+            <returns>
+                <see langword="true" /> when the pointer text can be proven to explain
+                the visible replacement inside the same toast surface; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.TryReadOriginalPointerText(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">
             <summary>
                 Tries to read the original game-provided text payload from a toast text
@@ -16847,6 +16878,21 @@
             <returns>
                 <see langword="true" /> when readable text is available; otherwise,
                 <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryConfirmOriginalPointerMatchesVisible(System.String,System.String,System.String@)">
+            <summary>
+                Confirms that a gimmick-hint node's original-text pointer really
+                belongs to the currently visible text before the handler trusts it as
+                the logical source line.
+            </summary>
+            <param name="originalPointerText">The text read from <c>OriginalTextPointer</c>.</param>
+            <param name="visibleText">The text currently visible in the node.</param>
+            <param name="originalText">Receives the confirmed original text.</param>
+            <returns>
+                <see langword="true" /> when the pointer text can be proven to explain
+                the visible replacement inside the same gimmick-hint surface;
+                otherwise, <see langword="false" />.
             </returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryReadOriginalPointerText(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2054,6 +2054,11 @@
                 payloads.
             </summary>
             <summary>
+                Handles the quest probe command used to inspect the complete quest data
+                shape from Lumina, the live quest progress resolver, and the current
+                QuestPlate database rows.
+            </summary>
+            <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
                 <see cref="E:Dalamud.Plugin.Services.IToastGui.QuestToast" /> instead of the addon-handler
                 registrar.
@@ -2568,6 +2573,11 @@
             Holds the database editor window instance.
             </summary>
         </member>
+        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
+            <summary>
+            Holds the currently active addon structure probe watch, if any.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -2680,6 +2690,11 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
+            <summary>
+                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -4029,6 +4044,45 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
+            <summary>
+            Dumps a recursive probe of the requested addon to the log so we can
+            inspect its live node tree, component roots, and likely overlay anchors.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
+            <summary>
+            Parses the addon probe command arguments into an addon name, optional index,
+            and optional watch duration.
+            </summary>
+            <param name="args">The raw command arguments.</param>
+            <returns>The addon name, index, and duration to probe.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
+            <summary>
+            Parses one addon-probe duration token such as "90s" or "15m".
+            </summary>
+            <param name="token">The raw duration token.</param>
+            <param name="duration">Receives the parsed duration.</param>
+            <returns><see langword="true"/> when the token parsed successfully.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
+            <summary>
+            Determines whether a token looks like an addon-probe duration even when the
+            value is outside the accepted range.
+            </summary>
+            <param name="token">The token to inspect.</param>
+            <returns><see langword="true"/> when the token resembles a duration.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
+            <summary>
+            Formats one addon-probe watch duration for chat feedback.
+            </summary>
+            <param name="duration">The duration to format.</param>
+            <returns>The human-readable duration string.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -4297,6 +4351,102 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
+            <summary>
+                Handles the quest probe command.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
+            <summary>
+                Tries to resolve the quest probe target from either a quest id or a
+                quest name.
+            </summary>
+            <param name="input">The command argument.</param>
+            <param name="questIdText">The resolved quest id as text.</param>
+            <param name="questName">The resolved quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>True when the quest could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the quest data structure for inspection.
+            </summary>
+            <param name="questIdText">The quest id as text.</param>
+            <param name="questName">The quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the raw Lumina quest row properties.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs all rows from the quest text sheet, not just the live todo
+                entries, so we can inspect the full structure of the quest sheet.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
+            <summary>
+                Logs the QuestPlate rows currently stored for the quest.
+            </summary>
+            <param name="questIdText">The quest id text.</param>
+            <param name="questName">The quest name.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Logs the resolved live quest progression snapshot.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves a human-readable quest name from a quest row.
+            </summary>
+            <param name="questRow">The quest row.</param>
+            <returns>The resolved quest name, if available.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
+            <summary>
+                Converts quest text to a readable string for probe output.
+            </summary>
+            <param name="text">The quest text.</param>
+            <returns>The evaluated text string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
+            <summary>
+                Formats a probe value for log output.
+            </summary>
+            <param name="value">The value to format.</param>
+            <returns>A human-readable value string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Builds the raw quest sheet name used by the game files.
+            </summary>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>The quest text sheet name, if it can be derived.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest row id as text through reflection so the probe
+                stays compatible with generated sheet shapes.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest row id as text, or an empty string if unavailable.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest sheet identifier used to mount the quest text
+                sheet path.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -6701,165 +6851,171 @@
                 Gets or sets the row update time in UTC.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.ActionTooltip.RowVersion">
-            <summary>
-                Gets or sets the optimistic-concurrency token.
+        <member name="P:EDungeonItem payload.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.ActionTooltip.ToString">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.DeepDungeonItemId">
+            <summary>
+                Gets or sets the DeepDungeonItem row identifier.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.ToString">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.AozActionText">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText">
             <summary>
-                Represents one canonical DB-first AozAction payload.
+                Represents one canonical DB-first EurekaMagiaAction payload.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.AozActionText.AozActionId">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText.EurekaMagiaActionId">
             <summary>
-                Gets or sets the AozAction row identifier.
+                Gets or sets the EurekaMagiaAction row identifier.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.AozActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.EurekaMagiaActionText.ToString">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.EventActionText">
             <summary>
-                Adapter to enable <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage" /> to be handled via
-                <see cref="T:Echoglossian.EFCoreSqlite.Models.IMultiTextEntity" />.
+                Represents one canonical DB-first EventAction payload.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.#ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Byte[],System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.EventActionText.EventActionId">
             <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage" /> class.
+                Gets or sets the EventAction row identifier.
             </summary>
-            <param name="senderName">The name of the sender.</param>
-            <param name="originalBattleTalkMessage">The original battle talk message.</param>
-            <param name="originalBattleTalkMessageLang">The language of the original battle talk message.</param>
-            <param name="originalSenderNameLang">The language of the original sender name.</param>
-            <param name="translatedSenderName">The translated sender name.</param>
-            <param name="translatedBattleTalkMessage">The translated battle talk message.</param>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.EventActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.EventItemText">
+            <summary>
+                Represents one canonical DB-first EventItem payload.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.EventItemText.EventItemId">
+            <summary>
+                Gets or sets the EventItem row identifier.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.EventItemText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.GameWindow">
+            <summary>
+                Represents a game window translation entity in the database.
+            </summary>
+            <summary>
+                Provides <see cref="T:Echoglossian.EFCoreSqlite.Models.IGenericEntity" /> implementation for the
+                <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> entity.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.#ctor(System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.String,System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.Nullable{System.UInt32})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> class.
+            </summary>
+            <param name="windowAddonName">The name of the window addon.</param>
+            <param name="originalWindowStrings">The original window strings.</param>
+            <param name="originalWindowStringsLang">
+                The language of the original window
+                strings.
+            </param>
+            <param name="translatedWindowStrings">The translated window strings.</param>
             <param name="translationLang">The language of the translation.</param>
             <param name="translationEngine">The translation engine used.</param>
-            <param name="rtlLangTranslationImageData">The RTL language translation image data.</param>
-            <param name="createdDate">The date the message was created.</param>
-            <param name="updatedDate">The date the message was last updated.</param>
+            <param name="gameVersion">The version of the game.</param>
+            <param name="createdDate">The date the record was created.</param>
+            <param name="updatedDate">The date the record was last updated.</param>
+            <param name="classJobId">
+                The class/job identifier associated with this window payload when the
+                addon content varies by the active job.
+            </param>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.#ctor">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.GameWindow.WindowAddonName">
             <summary>
-             Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage"/> class.
-             </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetOriginalSecondaryText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetOriginalSecondaryText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslatedText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslatedText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslatedSecondaryText">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslatedSecondaryText(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslationLang">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslationLang(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetTranslationEngine">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetTranslationEngine(System.Int32)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetEntityKey">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetEntityKey(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.GetGameVersion">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage.SetGameVersion(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText">
-            <summary>
-                Represents one canonical DB-first BgcArmyAction payload.
+                Gets or sets the name of the window addon or unique key that identifies
+                this entity context.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText.BgcArmyActionId">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.GameWindow.ClassJobId">
             <summary>
-                Gets or sets the BgcArmyAction row identifier.
+                Gets or sets the class/job identifier associated with this window
+                payload when the addon content varies by the active job.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BgcArmyActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> class for use
+                with the <see cref="!:GenericAddonHandler" />.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetOriginalText">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.BuddyActionText">
-            <summary>
-                Represents one canonical DB-first BuddyAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.BuddyActionText.BuddyActionId">
-            <summary>
-                Gets or sets the BuddyAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.BuddyActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetOriginalText(System.String)">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.CompanyActionText">
-            <summary>
-                Represents one canonical DB-first CompanyAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.CompanyActionText.CompanyActionId">
-            <summary>
-                Gets or sets the CompanyAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.CompanyActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetOriginalLang">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.CraftActionText">
-            <summary>
-                Represents one canonical DB-first CraftAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.CraftActionText.CraftActionId">
-            <summary>
-                Gets or sets the CraftAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.CraftActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetOriginalLang(System.String)">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetTranslatedText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetTranslatedText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetTranslationLang">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetTranslationLang(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetTranslationEngine">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetTranslationEngine(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetEntityKey">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetEntityKey(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.GetGameVersion">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GameWindow.SetGameVersion(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.GeneralActionText">
             <summary>
-                Represents one canonical DB-first DeepDungeonItem payload.
+                Represents one canonical DB-first GeneralAction payload.
             </summary>
         </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.GeneralActionText.GeneralActionId">
+            <summary>
+                Gets or sets the GeneralAction row identifier.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.GeneralActionText.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.IComplexEntity">
+            <summary>
+            Enhances the IMultiTextEntity interface to include additional properties and methods
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.IComplexEntity.GetType">
+            <summary>
+            Gets the type of the StringArrayData.
+            </summary>
+            <returns>Returns the type of the StringArrayData.</returns>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.IComplexEntity.SetType(System.Stri   </member>
         <member name="P:Echoglossian.EFCoreSqlite.Models.DeepDungeonItemText.DeepDungeonItemId">
             <summary>
                 Gets or sets the DeepDungeonItem row identifier.
@@ -7569,76 +7725,82 @@
             </summary>
             <param name="prettyPrint">Should it be pretty printed?.</param>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.UpdateFieldsFromText">
+        <member</member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.CategoryId">
             <summary>
-                Forces loading the Objectives and Summaries from the stored text fields.
+                Gets or sets the sheet category value.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.LoadDictionaryFromTextOrKeepCurrent(System.String,System.Collections.Generic.Dictionary{System.String,System.String})">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.MainCommandCategoryId">
             <summary>
-                Loads a serialized dictionary when available and otherwise preserves
-                any current in-memory state that has not yet been materialized.
+                Gets or sets the linked MainCommandCategory row identifier.
             </summary>
-            <param name="serializedText">The serialized dictionary text.</param>
-            <param name="currentValue">The current in-memory dictionary.</param>
-            <returns>The resolved dictionary.</returns>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.LoadFromTextOrKeepCurrent``1(System.String,System.Collections.Generic.List{``0},System.Func{System.Collections.Generic.List{``0}})">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.Unknown0">
             <summary>
-                Loads a serialized payload when available and otherwise preserves
-                any current in-memory state that has not yet been materialized.
+                Gets or sets the MainCommand sheet's <c>Unknown0</c> value.
             </summary>
-            <typeparam name="T">The payload item type.</typeparam>
-            <param name="serializedText">The serialized payload text.</param>
-            <param name="currentValue">The current in-memory payload.</param>
-            <param name="loadFromText">The loader to invoke when serialized text exists.</param>
-            <returns>The resolved payload collection.</returns>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate.ToString">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.MainCommandText.SortId">
+            <summary>
+                Gets or sets the sheet sort identifier.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MainCommandText.ToString">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection">
+        <member name="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage">
             <summary>
-                Identifies one canonical quest-text row section inside the persisted
-                quest payload.
+                Adapter to enable <see cref="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage" /> to be handled via
+                <see cref="T:Echoglossian.EFCoreSqlite.Models.IGenericEntity" />.
             </summary>
         </member>
-        <member name="F:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection.Summary">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.#ctor(System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
             <summary>
-                A SEQ / journal summary row.
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage" /> class.
             </summary>
+            <param name="originalMiniTalkMessage">The original MiniTalk message.</param>
+            <param name="originalMiniTalkMessageLang">The language of the original MiniTalk message.</param>
+            <param name="translatedMiniTalkMessage">The translated MiniTalk message.</param>
+            <param name="translationLang">The language of the translated MiniTalk message.</param>
+            <param name="translationEngine">The translation engine used.</param>
+            <param name="createdDate">The date the message was created.</param>
+            <param name="updatedDate">The date the message was last updated.</param>
         </member>
-        <member name="F:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection.Objective">
-            <summary>
-                A TODO / objective row.
-            </summary>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetOriginalText">
+            <inheritdoc />
         </member>
-        <member name="F:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection.System">
-            <summary>
-                A SYSTEM / system-message row.
-            </summary>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetOriginalText(System.String)">
+            <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow">
-            <summary>
-                Represents one canonical persisted quest row with section, row key,
-                ordering, original text, and translated text kept together.
-            </summary>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetOriginalLang">
+            <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow.#ctor">
-            <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow" />
-                class.
-            </summary>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetOriginalLang(System.String)">
+            <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow.#ctor(Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRowSection,System.String,System.String,System.Int32,System.Boolean,System.String)">
-            <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlateCanonicalRow" />
-                class.
-            </summary>
-            <param name="section">The row section.</param>
-            <param name="rowKey">The canonical row key.</param>
-            <param name="originalText">The original row text.</param>
-            <param name="order">The stable section-relative order.</param>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetTranslatedText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetTranslatedText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetTranslationLang">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetTranslationLang(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetTranslationEngine">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetTranslationEngine(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetEntityKey">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.">The stable section-relative order.</param>
             <param name="isCurrentSequence">Whether this row is the live current SEQ row.</param>
             <param name="translatedText">The translated row text when available.</param>
         </member>
@@ -7786,89 +7948,81 @@
         <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetEntityKey">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetEntityKey(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.GetGameVersion">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetGameVersion(System.String)">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.MountActionText">
-            <summary>
-                Represents one canonical DB-first MountAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.MountActionText.MountActionId">
-            <summary>
-                Gets or sets the MountAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.MountActionText.ToString">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.NpcNames.#ctor(System.Int32,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
-            <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.NpcNames" /> class.
-            </summary>
-            <param name="id">The unique identifier for the NPC.</param>
-            <param name="originalNpcName">The original name of the NPC.</param>
-            <param name="originalNpcNameLang">The language of the original NPC name.</param>
-            <param name="translatedNpcName">The translated name of the NPC.</param>
-            <param name="translationLang">The language of the translated NPC name.</param>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.MiniTalkMessage.SetEntityKey(SyelectString">The translated question/title.</param>
+            <param name="translatedOptionsAsText">The translated option list serialized as JSON.</param>
+            <param name="translationLang">The language of the translated dialog.</param>
             <param name="translationEngine">The translation engine used.</param>
-            <param name="createdDate">The date the NPC name was created.</param>
-            <param name="updatedDate">The date the NPC name was last updated.</param>
+            <param name="createdDate">The date the record was created.</param>
+            <param name="updatedDate">The date the record was last updated.</param>
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.PetActionText">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.SelectString.OriginalOptions">
             <summary>
-                Represents one canonical DB-first PetAction payload.
+                Gets or sets the original options as a list of strings.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.PetActionText.PetActionId">
+        <member name="P:Echoglossian.EFCoreSqlite.Models.SelectString.TranslatedOptions">
             <summary>
-                Gets or sets the PetAction row identifier.
+                Gets or sets the translated options as a list of strings.
             </summary>
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.PetActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.UpdateFieldsAsText(System.Boolean)">
+            <summary>
+                Updates the serialized text fields from the current option lists.
+            </summary>
+            <param name="prettyPrint">Should the JSON be pretty printed?.</param>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.UpdateFieldsFromText">
+            <summary>
+                Forces loading the option lists from the stored text fields.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetOriginalText">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.PvPActionText">
-            <summary>
-                Represents one canonical DB-first PvPAction payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.PvPActionText.PvPActionId">
-            <summary>
-                Gets or sets the PvPAction row identifier.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.PvPActionText.ToString">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetOriginalText(System.String)">
             <inheritdoc />
         </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetOriginalLang">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetOriginalLang(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetTranslatedText">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetTranslatedText(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetTranslationLang">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetTranslationEngine">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetTranslationEngine(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetEntityKey(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetGameVersion">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.SetGameVersion(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.SelectString.GetEntityKey">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.StringArrayDatas">
             <summary>
-                Provides the shared canonical persisted fields for action-adjacent
-                Excel-sheet reference-text rows.
+            Represents a record of a translated string array, including raw data and translation metadata.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.Id">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.#ctor(System.String,System.Int32,System.Byte[],System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.String,System.DateTime,System.DateTime)">
             <summary>
-                Gets or sets the primary key.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.ReferenceId">
-            <summary>
-                Gets or sets the stable sheet-row identifier.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.OriginalName">
-            <summary>
-                Gets or sets the canonical original name.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.ReferenceTextRowBase.OriginalDescription">
+             Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.StringArrayDatas"/> classs.ReferenceTextRowBase.OriginalDescription">
             <summary>
                 Gets or sets the canonical original description, when available.
             </summary>
@@ -8099,92 +8253,82 @@
         </member>
         <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.ContextKey">
             <summary>
-            Gets or sets the semantic context key for this string-array surface.
+            Gets or sets the semantic context key for this string-array 
+                <see cref="T:Echoglossian.EFCoreSqlite.Models.IMultiTextEntity" />.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SchemaVersion">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.#ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Byte[],System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
             <summary>
-            Gets or sets the schema version used to serialize the structured payload.
+                Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.TalkMessage" /> class.
             </summary>
+            <param name="senderName">The name of the sender.</param>
+            <param name="originalTalkMessage">The original talk message.</param>
+            <param name="originalTalkMessageLang">
+                The language of the original talk
+                message.
+            </param>
+            <param name="originalSenderNameLang">
+                The language of the original sender's
+                name.
+            </param>
+            <param name="translatedSenderName">The translated sender's name.</param>
+            <param name="translatedTalkMessage">The translated talk message.</param>
+            <param name="translationLang">The language of the translation.</param>
+            <param name="translationEngine">The translation engine used.</param>
+            <param name="rtlLangTranslationImageData">The RTL language translation image data.</param>
+            <param name="createdDate">The date the message was created.</param>
+            <param name="updatedDate">The date the message was last updated.</param>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SourceContentHash">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.#ctor">
             <summary>
-            Gets or sets the stable source-content hash for the canonical payload.
+            Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.TalkMessage"/> class.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.OriginalStructuredPayload">
-            <summary>
-            Gets or sets the structured original payload for this surface.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.TranslatedStructuredPayload">
-            <summary>
-            Gets or sets the structured translated payload for this surface.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.CreatedAt">
-            <summary>
-            Gets or sets the creation timestamp.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.UpdatedAt">
-            <summary>
-            Gets or sets the last updated timestamp.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.RowVersion">
-            <summary>
-            Gets or sets the row version for concurrency handling.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.#ctor">
-            <summary>
-            Initializes a new instance of the <see cref="T:Echoglossian.EFCoreSqlite.Models.StringArrayDatas"/> class.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetType">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetOriginalText">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetType(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetOriginalText(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetSize">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetOriginalLang">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetSize(System.Int32)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetOriginalLang(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetRawData">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetOriginalSecondaryText">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetRawData(System.Byte[])">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetOriginalSecondaryText(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetFormattedRawData">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslatedText">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetFormattedRawData(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslatedText(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetTranslatedStringsWithPayloads">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslatedSecondaryText">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetTranslatedStringsWithPayloads(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslatedSecondaryText(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetOriginalLang">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslationLang">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetOriginalLang(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslationLang(System.String)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetOriginalStrings">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetTranslationEngine">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetOriginalStrings(System.String)">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.SetTranslationEngine(System.Int32)">
             <inheritdoc />
         </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.GetTranslationLang">
+        <member name="M:Echoglossian.EFCoreSqlite.Models.TalkMessage.GetEntityKey">
+            <inheritdoc />
+    ang">
             <inheritdoc />
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.Models.StringArrayDatas.SetTranslationLang(System.String)">
@@ -8564,185 +8708,7 @@
                 Gets or sets the trait icon identifier.
             </summary>
         </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.ClassJobId">
-            <summary>
-                Gets or sets the active class-job identifier used to scope the trait.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.ClassJobCategoryId">
-            <summary>
-                Gets or sets the class-job-category row identifier.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TraitName">
-            <summary>
-                Gets or sets the canonical original trait name.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TraitDescription">
-            <summary>
-                Gets or sets the canonical original trait description.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.OriginalTooltipText">
-            <summary>
-                Gets or sets the fully assembled original tooltip text.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.OriginalLang">
-            <summary>
-                Gets or sets the language of the original source payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslatedTraitName">
-            <summary>
-                Gets or sets the translated trait name.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslatedTraitDescription">
-            <summary>
-                Gets or sets the translated trait description.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslatedTooltipText">
-            <summary>
-                Gets or sets the fully assembled translated tooltip text.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslationLang">
-            <summary>
-                Gets or sets the target translation language.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.TranslationEngine">
-            <summary>
-                Gets or sets the translation-engine identifier.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.GameVersion">
-            <summary>
-                Gets or sets the game version associated with the source payload.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.SourceContentHash">
-            <summary>
-                Gets or sets the stable source-content hash.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.CanonicalPayloadAsText">
-            <summary>
-                Gets or sets the serialized canonical payload, including translated fields when available.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.CreatedDate">
-            <summary>
-                Gets or sets the row creation time in UTC.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.UpdatedDate">
-            <summary>
-                Gets or sets the row update time in UTC.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.Trait.RowVersion">
-            <summary>
-                Gets or sets the optimistic-concurrency token.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.Trait.ToString">
-            <inheritdoc />
-        </member>
-        <member name="T:Echoglossian.EFCoreSqlite.Models.TranslationFailure">
-            <summary>
-                Represents one exact translation request that previously returned no
-                usable translated text for a specific source/target language pair and
-                translation engine.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.Id">
-            <summary>
-                Gets or sets the primary key.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceText">
-            <summary>
-                Gets or sets the exact sanitized text that was sent to the
-                translation engine.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceTextHash">
-            <summary>
-                Gets or sets the stable hash of <see cref="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceText" /> used for
-                lookup and indexing.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.SourceLanguage">
-            <summary>
-                Gets or sets the normalized source language code.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.TargetLanguage">
-            <summary>
-                Gets or sets the normalized target language code.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.TranslationEngine">
-            <summary>
-                Gets or sets the translation-engine identifier.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.FailureReason">
-            <summary>
-                Gets or sets the last recorded failure reason.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.FirstSeenOrigin">
-            <summary>
-                Gets or sets the origin context that first produced this exact
-                failed translation request.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.LastSeenOrigin">
-            <summary>
-                Gets or sets the most recent origin context that produced this exact
-                failed translation request.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.FailureCount">
-            <summary>
-                Gets or sets how many times this exact request failed.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.CreatedDate">
-            <summary>
-                Gets or sets the row creation time in UTC.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.UpdatedDate">
-            <summary>
-                Gets or sets the last update time in UTC.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.EFCoreSqlite.Models.TranslationFailure.RowVersion">
-            <summary>
-                Gets or sets the optimistic-concurrency token.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.EFCoreSqlite.Models.TranslationFailure.ToString">
-            <inheritdoc />
-        </member>
-        <member name="M:Echoglossian.AssetsManager.RequiresDownloadedAsset(System.String)">
-            <summary>
-            Determines whether a font file name depends on a downloaded external asset.
-            </summary>
-            <param name="fontFileName">The font file name to inspect.</param>
-            <returns><c>true</c> if the font requires a downloaded asset; otherwise, <c>false</c>.</returns>
-        </member>
-        <member name="M:Echoglossian.AssetsManager.RequiresDownloadedAssets(Echoglossian.LanguagesHandling.LanguageInfo)">
-            <summary>
-            Determines whether the specified language requires a downloaded font asset.
-            </summary>
-            <param name="languageInfo">The language to inspect.</param>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Tra          <param name="languageInfo">The language to inspect.</param>
             <returns><c>true</c> if the language depends on a downloaded asset; otherwise, <c>false</c>.</returns>
         </member>
         <member name="M:Echoglossian.AssetsManager.GetRequiredAssetFiles(Echoglossian.LanguagesHandling.LanguageInfo)">
@@ -9188,80 +9154,86 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ResolveSupportedEngineSelection(System.Int32,System.Collections.Generic.IReadOnlyCollection{System.Int32})">
-            <summary>
-                Normalizes a selected engine id against the currently supported engine
-                ids for the target language.
+        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ResolveSupportedEngineSelection(System.Int32,System.Collections.Generic.IReadOnlyCollection{e to an explicit logger sink.
             </summary>
-            <param name="selectedEngineId">The currently selected engine id.</param>
-            <param name="supportedEngineIds">
-                The supported engine ids for the active
-                target language.
-            </param>
+            <param name="pluginLog">The explicit logger sink to use.</param>
+            <param name="message">The message to write.</param>
+        </member>
+        <member name="M:Echoglossian.PluginRuntimeLog.Warning(System.String,System.String)">
+            <summary>
+                Writes a scoped warning log line.
+            </summary>
+            <param name="scope">The logical scope to render inside square brackets.</param>
+            <param name="message">The message to write.</param>
+        </member>
+        <member name="M:Echoglossian.PluginRuntimeLog.Error(System.String)">
+            <summary>
+                Writes an error log line.
+            </summary>
+            <param name="message">The message to write.</param>
+        </member>
+        <member name="M:Echoglossian.PluginRuntimeLog.Error(Dalamud.Plugin.Services.IPluginLog,System.String)">
+            <summary>
+                Writes an error log line to an explicit logger sink.
+            </summary>
+            <param name="pluginLog">The explicit logger sink to use.</param>
+            <param name="message">The message to write.</param>
+        </member>
+        <member name="M:Echoglossian.PluginRuntimeLog.Error(System.String,System.String)">
+            <summary>
+                Writes a scoped error log line.
+            </summary>
+            <param name="scope">The logical scope to render inside square brackets.</param>
+            <param name="message">The message to write.</param>
+        </member>
+        <member name="M:Echoglossian.PluginRuntimeLog.Format(System.String,System.String)">
+            <summary>
+                Prepends an optional logical scope to a message.
+            </summary>
+            <param name="scope">The logical scope to render inside square brackets.</param>
+            <param name="message">The message to format.</param>
+            <returns>The formatted message.</returns>
+        </member>
+        <member name="T:Echoglossian.RuntimeLanguageHelper">
+            <summary>
+                Normalizes the runtime game and target language values so DB-first
+                recovery code can compare persisted rows safely without hardcoding a
+                single target language.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.RuntimeLanguageHelper.GetCurrentGameLanguageCode">
+            <summary>
+                Gets the current native client language as a normalized language
+                code.
+            </summary>
+            <returns>The normalized current game language code.</returns>
+        </member>
+        <member name="M:Echoglossian.RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(System.Int32)">
+            <summary>
+                Gets the configured translation target language as a normalized
+                language code.
+            </summary>
+            <param name="languageIndex">The configured target-language index.</param>
+            <returns>The normalized configured target language code.</returns>
+        </member>
+        <member name="M:Echoglossian.RuntimeLanguageHelper.LanguagesMatch(System.String,System.String)">
+            <summary>
+                Determines whether two language values represent the same effective
+                language.
+            </summary>
+            <param name="left">The first language value.</param>
+            <param name="right">The second language value.</param>
             <returns>
-                The selected engine id when it is supported; otherwise, the first
-                supported concrete engine id, or Google when the language exposes no
-                concrete engine list.
+                <see langword="true" /> when both values normalize to the same
+                code; otherwise <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.NormalizeAndSyncSelection(Echoglossian.Config,System.Int32,System.Collections.Generic.IReadOnlyCollection{System.Int32})">
+        <member name="M:Echoglossian.RuntimeLanguageHelper.NormalizeLanguage(System.String)">
             <summary>
-                Normalizes and synchronizes the persisted translation engine
-                selection, preferring the persisted engine key when available and
-                keeping the numeric and string forms aligned.
+                Normalizes one runtime language value to a stable comparison code.
             </summary>
-            <param name="config">The active plugin configuration.</param>
-            <param name="loadedConfigVersion">
-                The config version loaded from disk before
-                migrations.
-            </param>
-            <param name="supportedEngineIds">
-                The supported engine ids for the active target
-                language, when that constraint should be applied.
-            </param>
-            <returns><see langword="true" /> when the config changed.</returns>
-        </member>
-        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ApplyExplicitSelection(Echoglossian.Config,System.Int32)">
-            <summary>
-                Applies an explicit user-selected engine to both persisted selection
-                forms so later normalization cannot silently revert the choice.
-            </summary>
-            <param name="config">The active plugin configuration.</param>
-            <param name="selectedEngineId">The explicitly selected concrete engine id.</param>
-        </member>
-        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.NormalizeLegacyChatGptBaseUrl(System.String)">
-            <summary>
-                Normalizes the legacy ChatGPT base URL that pointed directly at the
-                completions endpoint instead of the API root.
-            </summary>
-            <param name="chatGptBaseUrl">The configured ChatGPT base URL.</param>
-            <returns>The normalized base URL.</returns>
-        </member>
-        <member name="M:Echoglossian.TranslationEngineSelectionMigrationHelper.ResolvePersistedEngineSelection(System.Int32,System.Int32,System.String)">
-            <summary>
-                Resolves the effective persisted engine selection from the available
-                persisted forms.
-            </summary>
-            <param name="loadedConfigVersion">
-                The config version loaded from disk before
-                migrations.
-            </param>
-            <param name="chosenEngineId">The persisted numeric engine id.</param>
-            <param name="chosenEngineKey">The persisted engine key.</param>
-            <returns>The resolved concrete engine id.</returns>
-        </member>
-        <member name="T:Echoglossian.TranslationPersistenceGuard">
-            <summary>
-            Provides shared guards for deciding whether translated results and
-            translation failures are safe to persist or reuse.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.TranslationPersistenceGuard.IsPersistentFailureReason(System.String)">
-            <summary>
-            Determines whether a translation failure reason is stable enough to
-            persist across sessions.
-            </summary>
-            <param name="failureReason">The recorded failure reason.</param>
+            <param name="language">The raw language value.</param>
+            <returns>The normalized .</param>
             <returns>
             <c>true</c> when the failure reason should be persisted; otherwise,
             <c>false</c>.
@@ -10573,6 +10545,122 @@
             <param name="keyPrefix">The stable key prefix to match.</param>
             <returns>
                 The number of distinct non-empty values whose keys start with the
+                requested prefix.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.CanonicalizeIntMap(System.Collections.Generic.SortedDictionary{System.Int32,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Boolean@)">
+            <summary>
+                Canonicalizes one integer-keyed payload map through an exact text
+                lookup.
+            </summary>
+            <param name="sourceValues">The source values.</param>
+            <param name="lookup">The exact text lookup.</param>
+            <param name="changed">
+                Receives whether any resulting value differs from the source.
+            </param>
+            <returns>The canonicalized map.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.CanonicalizeStringMap(System.Collections.Generic.SortedDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Boolean@)">
+            <summary>
+                Canonicalizes one text-node payload map through an exact text
+                lookup.
+            </summary>
+            <param name="sourceValues">The source values.</param>
+            <param name="lookup">The exact text lookup.</param>
+            <param name="changed">
+                Receives whether any resulting value differs from the source.
+            </param>
+            <returns>The canonicalized map.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.AppendLookupEntry(System.String,System.String,System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.ISet{System.String},System.Boolean)">
+            <summary>
+                Appends one exact original/translated text pair to the supplied
+                lookups.
+            </summary>
+            <param name="originalText">The canonical original text.</param>
+            <param name="translatedText">The canonical translated text.</param>
+            <param name="originalLookup">
+                The lookup mapping any known visible text back to the canonical
+                original text.
+            </param>
+            <param name="translatedLookup">
+                The lookup mapping any known visible text to the canonical
+                translated text.
+            </param>
+            <param name="knownTexts">
+                The known-text set used to keep capture shape stable in both
+                original and translated states.
+            </param>
+            <param name="requireDifference">
+                When set, only pairs whose original and translated text differ are
+                appended.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.AppendValueMapEntries``1(System.Collections.Generic.IDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{``0,System.String},System.Collections.Generic.IReadOnlyDictionary{``0,System.String})">
+            <summary>
+                Appends one exact source-text to target-text mapping from matching
+                payload keys.
+            </summary>
+            <typeparam name="TKey">The payload key type.</typeparam>
+            <param name="valueMap">The target value map to augment.</param>
+            <param name="sourceValues">The source-facing payload values.</param>
+            <param name="targetValues">The target-facing payload values.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterCanonicalPayloadHelper.TryDetermineDirectValueMapDirection(System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,System.String},System.Boolean@)">
+            <summary>
+                Determines whether the direct payload-pair map represents one
+                source-original to target-translated transition or the reverse.
+            </summary>
+            <param name="directValueMap">The direct payload-pair map.</param>
+            <param name="originalLookup">The canonical original lookup.</param>
+            <param name="translatedLookup">The canonical translated lookup.</param>
+            <param name="sourceIsOriginal">
+                Receives <see langword="true" /> when the direct map flows from
+                original to translated text; otherwise <see langword="false" />
+                when it flows from translated to original text.
+            </param>
+            <returns>
+                <see langword="true" /> when one direction could be inferred;
+                otherwise <see langword="false" />.
+            </returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler">
+            <summary>
+                Handles translation for the "CharacterClass" addon using visible text
+                nodes only.
+                Lifecycle-safe: extracts and applies values within valid memory scope per
+                frame.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.#ctor(Echoglossian.Config,Echoglossian.NativeUI.Helpers.HoverTooltipManager,Echoglossian.Translators.TranslationService)">
+            <summary>
+                Initializes a new instance of the
+                <see cref="T:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler" /> class.
+            </summary>
+            <param name="config">The configuration settings for the plugin.</param>
+            <param name="hoverTooltipManager">The shared hover-tooltip manager.</param>
+            <param name="translationService">The service used for translating text.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldCaptureTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldReuseCompatiblePayloads">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldPersistNewGameWindowPayload(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldQueueNewGameWindowTranslation(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.ShouldRefreshAppliedStateOnPreDraw">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.OnCleanupEvent(Dalamud.Game.Addon.Lifecycle.AddonEvent,Dalamud.Game.Addon.Lifecycle.AddonArgTypes.AddonArgs)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Character.CharacterClassSubWindowHandler.TryApplyCustomTextNodePayload(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload)">
+            <se keys start with the
                 requested prefix.
             </returns>
         </member>
@@ -14447,6 +14535,16 @@
                 when the current mutation should always be restored.
             </param>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.PrepareTrackedBubbleLayoutForReapply(System.IntPtr,System.String)">
+            <summary>
+                Restores the tracked native MiniTalk layout for the current bubble even
+                when the source line has not changed, so repeated native apply passes
+                always restart from the original bubble geometry instead of stacking
+                width and height growth from the prior frame.
+            </summary>
+            <param name="bubbleKey">The stable bubble key.</param>
+            <param name="originalText">The original source line currently assigned to the bubble.</param>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean)">
             <summary>
                 Restores one tracked native MiniTalk layout snapshot back to the
@@ -14835,6 +14933,16 @@
                 The next original source text expected for the addon, or an empty value
                 when the current mutation should always be restored.
             </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.PrepareTrackedNativeLayoutForReapply(System.String,System.String)">
+            <summary>
+                Restores the tracked native BattleTalk layout even when the visible
+                source line has not changed, so a repeat native apply pass starts from
+                the original addon geometry instead of stacking height and width
+                mutations from the previous frame.
+            </summary>
+            <param name="originalName">The original sender name for the active line.</param>
+            <param name="originalText">The original source text for the active line.</param>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.String)">
             <summary>
@@ -22014,150 +22122,7 @@
                 language using AWS Translate.
             </summary>
             <param name="text"></param>
-            <param name="sourceLanguage"></param>
-            <param name="targetLanguage"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.Translators.AmazonTranslateTranslator.TranslateAsync(System.String,System.String,System.String)">
-            <summary>
-                Asynchronously translates the given text from source language to target
-                language using AWS Translate.
-            </summary>
-            <param name="text"></param>
-            <param name="sourceLanguage"></param>
-            <param name="targetLanguage"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.Translators.ChatGPTTranslator.#ctor(Dalamud.Plugin.Services.IPluginLog,System.String,System.String,System.String,System.Single)">
-            <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.Translators.ChatGPTTranslator" /> class.
-            </summary>
-            <param name="pluginLog"></param>
-            <param name="baseUrl"></param>
-            <param name="apiKey"></param>
-            <param name="model"></param>
-            <param name="temperature"></param>
-        </member>
-        <member name="M:Echoglossian.Translators.ChatGPTTranslator.Translate(System.String,System.String,System.String)">
-            <summary>
-                Translates the specified text from the source language to the target
-                language.
-            </summary>
-            <param name="text">The text to translate.</param>
-            <param name="sourceLanguage">The source language of the text.</param>
-            <param name="targetLanguage">The target language for the translation.</param>
-            <returns>The translated text.</returns>
-        </member>
-        <member name="M:Echoglossian.Translators.ChatGPTTranslator.TranslateAsync(System.String,System.String,System.String)">
-            <summary>
-                Translates the specified text from the source language to the target
-                language asynchronously.
-            </summary>
-            <param name="text">The text to translate.</param>
-            <param name="sourceLanguage">The source language of the text.</param>
-            <param name="targetLanguage">The target language for the translation.</param>
-            <returns>
-                A task that represents the asynchronous translation operation. The
-                task result contains the translated text.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.Translators.ChatGPTTranslator.TranslateCoreAsync(System.String,System.String,System.String,System.String)">
-            <summary>
-                Performs the actual OpenAI chat completion call for a single cache
-                key. Concurrent callers for the same key share the same in-flight
-                task.
-            </summary>
-            <param name="text">The text to translate.</param>
-            <param name="sourceLanguage">The source language of the text.</param>
-            <param name="targetLanguage">The target language for the translation.</param>
-            <param name="cacheKey">The normalized cache key for this request.</param>
-            <returns>The translated text, or a synthetic error placeholder.</returns>
-        </member>
-        <member name="T:Echoglossian.Translators.ClaudeTranslator">
-            <summary>
-                Translator implementation for Anthropic Claude using the Messages API.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Translators.ClaudeTranslator.#ctor(Dalamud.Plugin.Services.IPluginLog,Echoglossian.Config)">
-            <summary>
-                Initializes a new instance of the <see cref="T:Echoglossian.Translators.ClaudeTranslator" /> class.
-            </summary>
-            <param name="pluginLog">The plugin log instance for diagnostics.</param>
-            <param name="config">The active plugin configuration.</param>
-        </member>
-        <member name="M:Echoglossian.Translators.ClaudeTranslator.Translate(System.String,System.String,System.String)">
-            <inheritdoc/>
-        </member>
-        <member name="M:Echoglossian.Translators.ClaudeTranslator.TranslateAsync(System.String,System.String,System.String)">
-            <inheritdoc/>
-        </member>
-        <member name="M:Echoglossian.Translators.ClaudeTranslator.TranslateCoreAsync(System.String,System.String,System.String,System.String)">
-            <summary>
-                Performs the actual Claude Messages API request for one cache key.
-            </summary>
-            <param name="text">The text to translate.</param>
-            <param name="sourceLanguage">The source language of the text.</param>
-            <param name="targetLanguage">The target language for the translation.</param>
-            <param name="cacheKey">The normalized cache key for this request.</param>
-            <returns>The translated text or an error placeholder.</returns>
-        </member>
-        <member name="T:Echoglossian.Translators.Claude.ClaudeModelManager">
-            <summary>
-                Manages the optional live Claude model catalog used by the engine configuration UI.
-            </summary>
-        </member>
-        <member name="P:Echoglossian.Translators.Claude.ClaudeModelManager.CurrentModelList">
-            <summary>
-                Gets the current Claude model list used by the UI.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Translators.Claude.ClaudeModelManager.ResetToDefault">
-            <summary>
-                Restores the committed fallback model list.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Translators.Claude.ClaudeModelManager.RefreshAsync(System.String,System.String)">
-            <summary>
-                Refreshes the Claude model list from Anthropic's official models endpoint.
-            </summary>
-            <param name="apiKey">The Anthropic API key.</param>
-            <param name="baseUrl">The Anthropic API base URL.</param>
-            <returns>A task that completes when refresh finishes.</returns>
-        </member>
-        <member name="T:Echoglossian.Translators.Claude.ClaudeTextModelDefaults">
-            <summary>
-                Provides the committed fallback Claude model list used when live fetch is disabled or unavailable.
-            </summary>
-        </member>
-        <member name="F:Echoglossian.Translators.Claude.ClaudeTextModelDefaults.PredefinedModels">
-            <summary>
-                Gets the predefined Claude models.
-            </summary>
-        </member>
-        <member name="T:Echoglossian.Translators.DeepLTranslator">
-            <summary>
-                Provides translation services using the DeepL API or Free API based on the
-                configuration.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Translators.DeepLTranslator.Echoglossian#Translators#ITranslator#TranslateAsync(System.String,System.String,System.String)">
-            <summary>
-                Asynchronously translates the given text from source language to target
-                language using the DeepL API or Free API based on the configuration.
-            </summary>
-            <param name="text"></param>
-            <param name="sourceLanguage"></param>
-            <param name="targetLanguage"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Echoglossian.Translators.DeepLTranslator.Echoglossian#Translators#ITranslator#Translate(System.String,System.String,System.String)">
-            <summary>
-                Synchronously translates the given text from source language to target
-                language using the DeepL API or Free API based on the configuration.
-            </summary>
-            <param name="text"></param>
-            <param name="sourceLanguage"></param>
-            <param name="targetLanguage"></param>
+            <param name="sourceLanguage"></paraaram name="targetLanguage"></param>
             <returns></returns>
         </member>
         <member name="M:Echoglossian.Translators.DeepLTranslator.Translate(System.String,System.String,System.String)">
@@ -22791,6 +22756,139 @@
         <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForTalk(Echoglossian.Config)">
             <summary>
             Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for talk translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForBattleTalk(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for battle talk translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigTalkSubtitle(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for talk subtitle translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForMiniTalk(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for MiniTalk translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForCutSceneSelectString(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for CutSceneSelectString overlays.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForTextGimmickHint(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for text gimmick hint translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForWideTextToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for Screen Info (_WideText) toast
+            translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForErrorToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for error toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForAreaToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for area toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForClassChangeToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for class/job change toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForQuestToast(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for quest toast translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForChatBubble(Echoglossian.Config)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the provided <see cref="T:Echoglossian.Config"/> for chat bubble translations.
+            </summary>
+            <param name="config"></param>
+            <returns></returns>
+        </member>
+        <member name="T:TextTextureGenerator">
+            <summary>
+            Generates textures from text using a specified font and size.
+            </summary>
+        </member>
+        <member name="M:TextTextureGenerator.#ctor(Dalamud.Plugin.Services.ITextureProvider)">
+            <summary>
+            Initializes a new instance of the <see cref="T:TextTextureGenerator"/> class.
+            </summary>
+            <param name="textureProvider"></param>
+        </member>
+        <member name="M:TextTextureGenerator.CreateTextTextureAsync(System.String,System.String,System.Single,System.Nullable{System.Drawing.Color},System.Nullable{System.Drawing.Color},System.Drawing.FontStyle,System.Nullable{System.Int32})">
+            <summary>
+            Creates a texture from the specified text using the given font and size.
+            </summary>
+            <param name="text"></param>
+            <param name="fontPath"></param>
+            <param name="fontSize"></param>
+            <param name="textColor"></param>
+            <param name="backgroundColor"></param>
+            <param name="fontStyle"></param>
+            <param name="maxWidth"></param>
+            <returns></returns>
+        </member>
+        <member name="T:Microsoft.Extensions.DependencyInjection.DiscoveredServicesExtensions">
+            <summary>
+            Extension methods for discovered service registrations
+            </summary>
+        </member>
+        <member name="M:Microsoft.Extensions.DependencyInjection.DiscoveredServicesExtensions.AddEchoglossian(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String[])">
+            <summary>
+            Adds discovered services from Echoglossian to the specified service collection
+            </summary>
+            <param name="serviceCollection">The service collection.</param>
+            <param name="tags">The service registration tags to include.</param>
+            <returns>The service collection</returns>
+        </member>
+    </members>
+</doc>
+ossian.Config"/> for talk translations.
             </summary>
             <param name="config"></param>
             <returns></returns>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2057,17 +2057,8 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
-                Hosts debug-only automatic addon-probe watches that start on login for
-                selected addons with early hidden-state value.
-            </summary>
-            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
-            </summary>
-            <summary>
-                Handles the quest probe command used to inspect the complete quest data
-                shape from Lumina, the live quest progress resolver, and the current
-                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -2584,11 +2575,6 @@
             Holds the database editor window instance.
             </summary>
         </member>
-        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
-            <summary>
-            Holds the currently active addon structure probe watch, if any.
-            </summary>
-        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -2701,11 +2687,6 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
-            <summary>
-                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -4055,109 +4036,6 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
-        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
-            <summary>
-                Ticks manual and automatic addon-probe watches, including the
-                debug-only login bootstrap for the default watch set.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
-            <summary>
-                Gets how many addon-probe watches are currently active across manual
-                and managed watch sets.
-            </summary>
-            <returns>The active probe-watch count.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
-            <summary>
-                Stops every active addon-probe watch known to the plugin.
-            </summary>
-            <param name="suppressAutoUntilLogout">
-                Whether the current login session should suppress the default
-                automatic watch set after the stop completes.
-            </param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
-            <summary>
-                Ticks the currently active manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
-            <summary>
-                Ticks every managed addon-probe watch and prunes the disposed ones.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic addon-probe watch set when the player
-                logs in, then resets the gate on logout.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic watch set used to capture early
-                structural state for pooled dialogue addons.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
-            <summary>
-                Starts one managed addon-probe watch and tracks it for later stop or
-                pruning.
-            </summary>
-            <param name="addonName">The addon name to watch.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="duration">How long the watch should stay alive.</param>
-            <param name="reason">The debug log reason attached to the startup.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
-            <summary>
-                Stops the current manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
-            <summary>
-                Stops every managed automatic addon-probe watch.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log so we can
-            inspect its live node tree, component roots, and likely overlay anchors.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
-            <summary>
-            Parses the addon probe command arguments into an addon name, optional index,
-            and optional watch duration.
-            </summary>
-            <param name="args">The raw command arguments.</param>
-            <returns>The addon name, index, and duration to probe.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
-            <summary>
-            Parses one addon-probe duration token such as "90s" or "15m".
-            </summary>
-            <param name="token">The raw duration token.</param>
-            <param name="duration">Receives the parsed duration.</param>
-            <returns><see langword="true"/> when the token parsed successfully.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
-            <summary>
-            Determines whether a token looks like an addon-probe duration even when the
-            value is outside the accepted range.
-            </summary>
-            <param name="token">The token to inspect.</param>
-            <returns><see langword="true"/> when the token resembles a duration.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
-            <summary>
-            Formats one addon-probe watch duration for chat feedback.
-            </summary>
-            <param name="duration">The duration to format.</param>
-            <returns>The human-readable duration string.</returns>
-        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -4426,102 +4304,6 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
-            <summary>
-                Handles the quest probe command.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
-            <summary>
-                Tries to resolve the quest probe target from either a quest id or a
-                quest name.
-            </summary>
-            <param name="input">The command argument.</param>
-            <param name="questIdText">The resolved quest id as text.</param>
-            <param name="questName">The resolved quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>True when the quest could be resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the quest data structure for inspection.
-            </summary>
-            <param name="questIdText">The quest id as text.</param>
-            <param name="questName">The quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the raw Lumina quest row properties.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs all rows from the quest text sheet, not just the live todo
-                entries, so we can inspect the full structure of the quest sheet.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
-            <summary>
-                Logs the QuestPlate rows currently stored for the quest.
-            </summary>
-            <param name="questIdText">The quest id text.</param>
-            <param name="questName">The quest name.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
-            <summary>
-                Logs the resolved live quest progression snapshot.
-            </summary>
-            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves a human-readable quest name from a quest row.
-            </summary>
-            <param name="questRow">The quest row.</param>
-            <returns>The resolved quest name, if available.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
-            <summary>
-                Converts quest text to a readable string for probe output.
-            </summary>
-            <param name="text">The quest text.</param>
-            <returns>The evaluated text string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
-            <summary>
-                Formats a probe value for log output.
-            </summary>
-            <param name="value">The value to format.</param>
-            <returns>A human-readable value string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Builds the raw quest sheet name used by the game files.
-            </summary>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>The quest text sheet name, if it can be derived.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest row id as text through reflection so the probe
-                stays compatible with generated sheet shapes.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest row id as text, or an empty string if unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest sheet identifier used to mount the quest text
-                sheet path.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -17344,46 +17126,6 @@
             <param name="addonLifecycle">The add-on lifecycle instance from which logging event listeners will be removed. Cannot be null.</param>
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
-        </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
-            <summary>
-                Encapsulates the login-session gating rules for debug-only automatic
-                addon-probe watches.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
-            <summary>
-                Determines whether the current login session should start the default
-                automatic addon-probe watch set.
-            </summary>
-            <param name="isLoggedIn">Whether the client is currently logged in.</param>
-            <param name="hasStartedForCurrentLogin">
-                Whether the current login session already started its automatic probe
-                set.
-            </param>
-            <param name="isSuppressedUntilLogout">
-                Whether the user explicitly suppressed the automatic probe set until
-                the next logout.
-            </param>
-            <param name="activeManagedWatchCount">
-                How many managed automatic probe watches are currently alive.
-            </param>
-            <returns>
-                <see langword="true" /> when the automatic probe set should start.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
-            <summary>
-                Determines whether the automatic login-session gate should reset
-                because the player logged out.
-            </summary>
-            <param name="wasLoggedIn">
-                Whether the client was logged in on the previous tick.
-            </param>
-            <param name="isLoggedIn">Whether the client is logged in now.</param>
-            <returns>
-                <see langword="true" /> when the automatic probe gate should reset.
-            </returns>
         </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -1855,6 +1855,13 @@
         <member name="F:Echoglossian.Config.TranslateToast">
             <summary>Translate toast popup messages.</summary>
         </member>
+        <member name="F:Echoglossian.Config.UseToastGuiCaptureForSupportedToasts">
+            <summary>
+                Uses Dalamud's ToastGui callbacks to prefetch source text and
+                translations for supported normal and error toasts before the addon
+                handlers see the live nodes.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Config.TranslateToDoList">
             <summary>Translate To-Do List entries.</summary>
         </member>
@@ -2054,6 +2061,10 @@
             <summary>
                 Provides reusable DB-first background prefetch for action-adjacent
                 reference-text sheets used by <c>ActionMenu</c>.
+            </summary>
+            <summary>
+                Handles bootstrap and teardown of the experimental ToastGui-assisted
+                toast capture runtime for supported normal and error toasts.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -4991,6 +5002,25 @@
             <param name="referenceId">The sheet-row identifier.</param>
             <param name="payload">The resolved payload.</param>
             <returns>True when the payload resolved successfully.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.CreateToastGuiCaptureRuntime">
+            <summary>
+                Creates the ToastGui-assisted capture runtime using the same shared
+                toast persistence helpers already used by the addon-handler path.
+            </summary>
+            <returns>The initialized runtime.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.RegisterToastGuiCaptureRuntime">
+            <summary>
+                Registers the ToastGui-assisted capture runtime with Dalamud's
+                callback surface for supported normal and error toasts.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.UnregisterToastGuiCaptureRuntime">
+            <summary>
+                Unregisters the ToastGui-assisted capture runtime from Dalamud's
+                callback surface.
+            </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
             <summary>
@@ -16612,6 +16642,140 @@
             <param name="text">The translated text to normalize.</param>
             <returns>The text that should be written back into the native addon.</returns>
         </member>
+        <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime">
+            <summary>
+                Uses Dalamud's <see cref="T:Dalamud.Plugin.Services.IToastGui" /> callbacks to capture supported
+                normal and error toast source payloads before the addon-node handlers
+                read the live UI.
+            </summary>
+            <remarks>
+                This runtime is intentionally conservative. It does not replace the
+                addon-handler presentation path, and it does not publish overlays or
+                mutate native nodes. It only prefetches translations into the existing
+                toast persistence path so the addon handlers can later reuse the same
+                cache/DB semantics with lower latency and less dependence on reading a
+                live node that may already be mutated.
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.ToastMessage,Echoglossian.EFCoreSqlite.Models.ToastMessage},System.Func{Echoglossian.EFCoreSqlite.Models.ToastMessage,System.Threading.Tasks.Task{System.String}})">
+            <summary>
+                Initializes a new instance of the
+                <see cref="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime" /> class.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <param name="translationService">The shared translation service.</param>
+            <param name="findToastMessage">
+                Delegate used to look up previously translated toast rows.
+            </param>
+            <param name="insertToastMessageAsync">
+                Delegate used to persist translated toast rows.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.HandleNormalToast(Dalamud.Game.Text.SeStringHandling.SeString@,Dalamud.Game.Gui.Toast.ToastOptions@,System.Boolean@)">
+            <summary>
+                Handles generic normal-toast callbacks from Dalamud and opportunistically
+                prefetches translations for supported addon-backed toast surfaces.
+            </summary>
+            <param name="message">The toast payload.</param>
+            <param name="options">The generic toast options.</param>
+            <param name="isHandled">
+                Whether another callback already consumed the toast.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.HandleErrorToast(Dalamud.Game.Text.SeStringHandling.SeString@,System.Boolean@)">
+            <summary>
+                Handles error-toast callbacks from Dalamud and opportunistically
+                prefetches translations for the native error-toast addon.
+            </summary>
+            <param name="message">The toast payload.</param>
+            <param name="isHandled">
+                Whether another callback already consumed the toast.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.ShouldCaptureNormalToasts">
+            <summary>
+                Determines whether the experimental ToastGui-assisted capture path
+                should run for normal toasts.
+            </summary>
+            <returns>
+                <see langword="true" /> when supported normal toasts should be
+                prefetched from ToastGui; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.ShouldCaptureErrorToasts">
+            <summary>
+                Determines whether the experimental ToastGui-assisted capture path
+                should run for error toasts.
+            </summary>
+            <returns>
+                <see langword="true" /> when error toasts should be prefetched from
+                ToastGui; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.TryPrefetchToast(System.String,System.String)">
+            <summary>
+                Prefetches one toast source line into the existing translation
+                persistence path when no usable translated row already exists.
+            </summary>
+            <param name="toastType">The persisted toast type.</param>
+            <param name="originalText">The original toast text.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.TryBeginPrefetch(System.String,System.String,System.String@)">
+            <summary>
+                Starts one background prefetch request when the same toast line is not
+                already being resolved.
+            </summary>
+            <param name="toastType">The persisted toast type.</param>
+            <param name="originalText">The original toast text.</param>
+            <param name="inFlightKey">
+                Receives the unique in-flight key for the request.
+            </param>
+            <returns>
+                <see langword="true" /> when a new request should be queued;
+                otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.ResolveTranslationAsync(System.String,System.String,System.String)">
+            <summary>
+                Resolves one toast translation asynchronously and persists it into the
+                existing toast history tables when successful.
+            </summary>
+            <param name="toastType">The persisted toast type.</param>
+            <param name="originalText">The original toast text.</param>
+            <param name="inFlightKey">The key representing the queued request.</param>
+            <returns>A task that completes when the translation attempt finishes.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.BuildLookupMessage(System.String,System.String)">
+            <summary>
+                Builds a lookup entity matching the historical toast schema already
+                used by the plugin database.
+            </summary>
+            <param name="toastType">The persisted toast type.</param>
+            <param name="originalText">The original toast text.</param>
+            <returns>A formatted <see cref="T:Echoglossian.EFCoreSqlite.Models.ToastMessage" /> for DB lookup.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.IsStoredTranslationUsable(Echoglossian.EFCoreSqlite.Models.ToastMessage,System.String,System.String)">
+            <summary>
+                Determines whether a stored toast row already contains a usable
+                translation for the observed callback payload.
+            </summary>
+            <param name="toastMessage">The stored row to validate.</param>
+            <param name="originalText">The expected original toast text.</param>
+            <param name="toastType">The persisted toast type.</param>
+            <returns>
+                <see langword="true" /> when the stored row can be reused; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiCaptureRuntime.BuildInFlightKey(System.String,System.String)">
+            <summary>
+                Builds the in-flight key used to deduplicate concurrent callback
+                prefetch requests.
+            </summary>
+            <param name="toastType">The persisted toast type.</param>
+            <param name="originalText">The original toast text.</param>
+            <returns>The stable in-flight dedupe key.</returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.WideTextToastHandler">
             <summary>
                 Handles the "_WideText" toast runtime inside the new addon-handler model.
@@ -21562,6 +21726,16 @@
         <member name="P:Echoglossian.Properties.Resources.WhichToastsToTranslate">
             <summary>
               Looks up a localized string similar to Select which kind of in-game message toasts to translate.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiCaptureForSupportedToastsLabel">
+            <summary>
+              Looks up a localized string similar to Use ToastGui-assisted capture for supported normal/error toasts (experimental).
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiCaptureForSupportedToastsDescription">
+            <summary>
+              Looks up a localized string similar to Keeps overlay bounds and native replacement on the addon handlers, but listens to ToastGui callbacks to prefetch translations earlier. Quest toasts already use ToastGui; Text Gimmick Hint still uses the addon path..
             </summary>
         </member>
         <member name="P:Echoglossian.Properties.Resources.YandexCloudApiKey">

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -17138,6 +17138,27 @@
             <param name="originalText">The original toast text.</param>
             <returns>The stable in-flight dedupe key.</returns>
         </member>
+        <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState">
+            <summary>
+                Describes which family-level route currently owns one supported toast
+                path at runtime.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState.LegacyAddonHandlers">
+            <summary>
+                The legacy addon-handler route remains active.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState.ToastGuiCapturePrefetch">
+            <summary>
+                The legacy ToastGui capture-only prefetch path is active.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState.ToastGuiFullRuntime">
+            <summary>
+                The alternate full ToastGui runtime owns the route.
+            </summary>
+        </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy">
             <summary>
                 Centralizes the family-level routing rules for the alternate
@@ -17145,6 +17166,20 @@
                 are intentionally treated as one unified logical family rather than as
                 addon-specific subtypes.
             </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(Echoglossian.Config)">
+            <summary>
+                Gets the effective route state for the supported normal-toast family.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>The effective route state for supported normal toasts.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(Echoglossian.Config)">
+            <summary>
+                Gets the effective route state for supported error toasts.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>The effective route state for supported error toasts.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedToastGuiRuntime(Echoglossian.Config)">
             <summary>
@@ -20907,6 +20942,14 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
+            <summary>
+                Maps one effective toast route state to the localized UI label used
+                in the toast general page.
+            </summary>
+            <param name="routeState">The effective route state.</param>
+            <returns>The localized UI label for the route state.</returns>
+        </member>
         <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawMiniTalkOverlay(Echoglossian.Config)">
             <summary>
                 Draws the MiniTalk overlay settings without exposing a title bar
@@ -22577,6 +22620,46 @@
         <member name="P:Echoglossian.Properties.Resources.ToastGuiCaptureForSupportedToastsDescription">
             <summary>
               Looks up a localized string similar to Keeps overlay bounds and native replacement on the addon handlers, but listens to ToastGui callbacks to prefetch translations earlier. Quest toasts already use ToastGui; Text Gimmick Hint still uses the addon path..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiNormalToastRouteStatusLabel">
+            <summary>
+              Looks up a localized string similar to Supported normal toast route.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiErrorToastRouteStatusLabel">
+            <summary>
+              Looks up a localized string similar to Supported error toast route.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiQuestToastRouteStatusLabel">
+            <summary>
+              Looks up a localized string similar to Quest toast route.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiTextGimmickHintRouteStatusLabel">
+            <summary>
+              Looks up a localized string similar to Text Gimmick Hint route.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiRouteStateLegacyAddonHandlers">
+            <summary>
+              Looks up a localized string similar to Legacy addon handlers.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiRouteStateCapturePrefetch">
+            <summary>
+              Looks up a localized string similar to ToastGui capture/prefetch.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiRouteStateFullRuntime">
+            <summary>
+              Looks up a localized string similar to ToastGui full runtime.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.ToastGuiRouteStateAddonHandlerOnly">
+            <summary>
+              Looks up a localized string similar to Addon handler only.
             </summary>
         </member>
         <member name="P:Echoglossian.Properties.Resources.YandexCloudApiKey">

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -1862,6 +1862,13 @@
                 handlers see the live nodes.
             </summary>
         </member>
+        <member name="F:Echoglossian.Config.UseToastGuiRuntimeForSupportedToasts">
+            <summary>
+                Enables the alternate callback-owned ToastGui runtime for supported
+                normal and error toasts instead of the legacy addon-handler path.
+                This stays hidden and opt-in while the route is still being validated.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Config.EnableDebugLoginAddonProbe">
             <summary>
                 Enables debug-only automatic login probes for `_BattleTalk` and
@@ -2072,6 +2079,10 @@
             <summary>
                 Handles bootstrap and teardown of the experimental ToastGui-assisted
                 toast capture runtime for supported normal and error toasts.
+            </summary>
+            <summary>
+                Handles bootstrap and teardown for the alternate callback-owned
+                ToastGui route that owns supported normal and error toasts.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -2663,7 +2674,7 @@
                 Recreates the shared queued-translation broker for the current engine.
             </summary>
         </member>
-        <member name="M:Echoglossian.Echoglossian.RebuildQuestToastRuntime">
+        <member name="M:Echoglossian.Echoglossian.RebuildToastGuiRuntimes">
             <summary>
                 Recreates and re-registers the quest-toast runtime so it uses the
                 current translation service.
@@ -5027,6 +5038,26 @@
             <summary>
                 Unregisters the ToastGui-assisted capture runtime from Dalamud's
                 callback surface.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.CreateToastGuiSupportedToastRuntime">
+            <summary>
+                Creates the alternate supported-toast runtime using the same shared
+                toast persistence and overlay helpers already used elsewhere in the
+                plugin.
+            </summary>
+            <returns>The initialized supported-toast runtime.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.RegisterToastGuiSupportedToastRuntime">
+            <summary>
+                Registers the alternate supported-toast runtime with Dalamud's normal
+                and error-toast callbacks.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.UnregisterToastGuiSupportedToastRuntime">
+            <summary>
+                Unregisters the alternate supported-toast runtime from Dalamud's
+                normal and error-toast callbacks.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
@@ -16857,6 +16888,368 @@
             <param name="toastType">The persisted toast type.</param>
             <param name="originalText">The original toast text.</param>
             <returns>The stable in-flight dedupe key.</returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy">
+            <summary>
+                Centralizes the family-level routing rules for the alternate
+                ToastGui-owned runtime path. Under that route, supported normal toasts
+                are intentionally treated as one unified logical family rather than as
+                addon-specific subtypes.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedToastGuiRuntime(Echoglossian.Config)">
+            <summary>
+                Gets whether the alternate callback-owned ToastGui route is enabled at
+                all.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>
+                <see langword="true" /> when the alternate ToastGui route is enabled;
+                otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(Echoglossian.Config)">
+            <summary>
+                Gets whether the alternate callback-owned ToastGui route should own
+                the unified normal-toast family.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>
+                <see langword="true" /> when the alternate route should own the
+                supported non-error toast family; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedErrorToastRuntime(Echoglossian.Config)">
+            <summary>
+                Gets whether the alternate callback-owned ToastGui route should own
+                error toasts.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>
+                <see langword="true" /> when the alternate route should own error
+                toasts; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(Echoglossian.Config)">
+            <summary>
+                Gets the canonical family-level display mode used by the alternate
+                callback-owned runtime for the unified normal-toast family.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>
+                The effective family-level display mode for supported non-error
+                toasts, currently sourced from the wide-text toast config.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseLegacyNormalToastCapturePrefetch(Echoglossian.Config)">
+            <summary>
+                Gets whether the legacy ToastGui prefetch-only path should stay active
+                for supported normal toasts.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>
+                <see langword="true" /> when the capture-only path should remain
+                active; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseLegacyErrorToastCapturePrefetch(Echoglossian.Config)">
+            <summary>
+                Gets whether the legacy ToastGui prefetch-only path should stay active
+                for error toasts.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <returns>
+                <see langword="true" /> when the capture-only error-toast path should
+                remain active; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime">
+            <summary>
+                Owns the alternate callback-driven ToastGui route for supported normal
+                and error toasts. Under this path, supported normal toasts are treated
+                as one logical family and no longer rely on addon-specific native
+                mutation or overlay anchoring.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.ToastMessage,Echoglossian.EFCoreSqlite.Models.ToastMessage},System.Func{Echoglossian.EFCoreSqlite.Models.ToastMessage,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String})">
+            <summary>
+                Initializes a new instance of the
+                <see cref="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime" /> class.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <param name="translationService">The shared translation service.</param>
+            <param name="findToastMessage">The shared toast DB lookup delegate.</param>
+            <param name="insertToastMessageAsync">
+                The shared toast persistence delegate.
+            </param>
+            <param name="updateNormalOverlay">
+                Delegate used to publish content into the unified normal-toast
+                overlay.
+            </param>
+            <param name="clearNormalOverlay">
+                Delegate used to clear the unified normal-toast overlay.
+            </param>
+            <param name="updateErrorOverlay">
+                Delegate used to publish content into the error-toast overlay.
+            </param>
+            <param name="clearErrorOverlay">
+                Delegate used to clear the error-toast overlay.
+            </param>
+            <param name="normalizeReplacementText">
+                Delegate used to normalize text before native replacement when the
+                game font requires it.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.HandleNormalToast(Dalamud.Game.Text.SeStringHandling.SeString@,Dalamud.Game.Gui.Toast.ToastOptions@,System.Boolean@)">
+            <summary>
+                Handles generic normal-toast callbacks through the alternate family
+                route.
+            </summary>
+            <param name="message">The toast payload.</param>
+            <param name="options">The toast options supplied by Dalamud.</param>
+            <param name="isHandled">Whether another callback consumed the toast.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.HandleErrorToast(Dalamud.Game.Text.SeStringHandling.SeString@,System.Boolean@)">
+            <summary>
+                Handles error-toast callbacks through the alternate callback-owned
+                route.
+            </summary>
+            <param name="message">The error-toast payload.</param>
+            <param name="isHandled">Whether another callback consumed the toast.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.TrySyncNormalToastOverlayToViewport(Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay)">
+            <summary>
+                Synchronizes the unified normal-toast overlay to a stable viewport
+                anchor based on the last callback-reported toast position.
+            </summary>
+            <param name="overlay">The overlay to synchronize.</param>
+            <returns>
+                <see langword="true" /> when the overlay currently has visible
+                content; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.TrySyncErrorToastOverlayToViewport(Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay)">
+            <summary>
+                Synchronizes the error-toast overlay to a stable top-center viewport
+                anchor.
+            </summary>
+            <param name="overlay">The overlay to synchronize.</param>
+            <returns>
+                <see langword="true" /> when the overlay currently has visible
+                content; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ApplyResolvedNormalToast(Dalamud.Game.Text.SeStringHandling.SeString@,System.String,System.String,System.Int32)">
+            <summary>
+                Applies one cache-hit normal toast immediately to the current callback.
+            </summary>
+            <param name="message">The live callback payload.</param>
+            <param name="originalText">The original toast text.</param>
+            <param name="translatedText">The translated toast text.</param>
+            <param name="requestId">The active request identifier.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ApplyResolvedErrorToast(Dalamud.Game.Text.SeStringHandling.SeString@,System.String,System.String,System.Int32)">
+            <summary>
+                Applies one cache-hit error toast immediately to the current callback.
+            </summary>
+            <param name="message">The live callback payload.</param>
+            <param name="originalText">The original toast text.</param>
+            <param name="translatedText">The translated toast text.</param>
+            <param name="requestId">The active request identifier.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ResolveNormalTranslationAsync(System.String,System.Int32)">
+            <summary>
+                Resolves one supported normal-toast line asynchronously.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <param name="requestId">The active request identifier.</param>
+            <returns>A task that completes after the translation attempt.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ResolveErrorTranslationAsync(System.String,System.Int32)">
+            <summary>
+                Resolves one supported error-toast line asynchronously.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <param name="requestId">The active request identifier.</param>
+            <returns>A task that completes after the translation attempt.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.BeginNormalRequest(System.String,Dalamud.Game.Gui.Toast.ToastOptions)">
+            <summary>
+                Starts one supported normal-toast request.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <param name="options">The current toast options.</param>
+            <returns>The active request identifier.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.BeginErrorRequest(System.String)">
+            <summary>
+                Starts one error-toast request.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <returns>The active request identifier.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ScheduleNormalOverlayClearAsync(System.Int32)">
+            <summary>
+                Delays clearing the unified normal-toast overlay so the overlay
+                lifetime roughly matches the transient toast lifetime.
+            </summary>
+            <param name="requestId">The owning request identifier.</param>
+            <returns>A task that completes after the clear delay.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ScheduleErrorOverlayClearAsync(System.Int32)">
+            <summary>
+                Delays clearing the error-toast overlay so the overlay lifetime roughly
+                matches the transient toast lifetime.
+            </summary>
+            <param name="requestId">The owning request identifier.</param>
+            <returns>A task that completes after the clear delay.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.GetNormalOverlayLifetimeMs">
+            <summary>
+                Gets the overlay lifetime for the current supported normal-toast
+                request.
+            </summary>
+            <returns>The overlay clear delay in milliseconds.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.IsCurrentNormalRequest(System.Int32,System.String)">
+            <summary>
+                Determines whether the specified request still belongs to the current
+                supported normal-toast line.
+            </summary>
+            <param name="requestId">The request identifier to validate.</param>
+            <param name="originalText">The original toast text.</param>
+            <returns>
+                <see langword="true" /> when the request is still current; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.IsCurrentErrorRequest(System.Int32,System.String)">
+            <summary>
+                Determines whether the specified request still belongs to the current
+                error-toast line.
+            </summary>
+            <param name="requestId">The request identifier to validate.</param>
+            <param name="originalText">The original toast text.</param>
+            <returns>
+                <see langword="true" /> when the request is still current; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ShouldUseNormalOverlay">
+            <summary>
+                Gets whether the unified normal-toast family should publish overlay
+                text.
+            </summary>
+            <returns>
+                <see langword="true" /> when the unified normal-toast overlay is
+                active; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ShouldApplyNativeNormalText">
+            <summary>
+                Gets whether the unified normal-toast family should write translated
+                text into the native toast callback payload.
+            </summary>
+            <returns>
+                <see langword="true" /> when native replacement is active; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ShouldSwapNormalTexts">
+            <summary>
+                Gets whether the unified normal-toast overlay should show original text
+                while the native toast displays the translation.
+            </summary>
+            <returns>
+                <see langword="true" /> when swap mode is active; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ShouldUseErrorOverlay">
+            <summary>
+                Gets whether error toasts should publish overlay text.
+            </summary>
+            <returns>
+                <see langword="true" /> when the error-toast overlay is active;
+                otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ShouldApplyNativeErrorText">
+            <summary>
+                Gets whether error toasts should write translated text into the native
+                callback payload.
+            </summary>
+            <returns>
+                <see langword="true" /> when native replacement is active; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.ShouldSwapErrorTexts">
+            <summary>
+                Gets whether the error-toast overlay should show the original text
+                while the native error toast displays the translation.
+            </summary>
+            <returns>
+                <see langword="true" /> when swap mode is active; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.PublishNormalOverlay(System.String,System.String,System.String)">
+            <summary>
+                Publishes content into the unified normal-toast overlay.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <param name="translatedText">The translated toast text.</param>
+            <param name="trigger">The trigger label associated with the call.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.PublishErrorOverlay(System.String,System.String,System.String)">
+            <summary>
+                Publishes content into the error-toast overlay.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <param name="translatedText">The translated toast text.</param>
+            <param name="trigger">The trigger label associated with the call.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.SelectOverlayText(System.String,System.String,System.Boolean)">
+            <summary>
+                Selects the overlay text for one callback-owned toast route.
+            </summary>
+            <param name="originalText">The original toast text.</param>
+            <param name="translatedText">The translated toast text.</param>
+            <param name="showOriginalOverlayText">
+                Whether the overlay should show the original text.
+            </param>
+            <returns>The overlay text to display.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.BuildLookupMessage(System.String,System.String)">
+            <summary>
+                Builds one toast DB lookup entity using the plugin's existing toast
+                persistence schema.
+            </summary>
+            <param name="toastType">The persisted toast type.</param>
+            <param name="originalText">The original toast text.</param>
+            <returns>A lookup <see cref="T:Echoglossian.EFCoreSqlite.Models.ToastMessage" />.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.IsStoredTranslationUsable(Echoglossian.EFCoreSqlite.Models.ToastMessage,System.String,System.String)">
+            <summary>
+                Determines whether one stored toast row contains a usable translation
+                for the requested source line and toast type.
+            </summary>
+            <param name="toastMessage">The stored row to validate.</param>
+            <param name="originalText">The expected original text.</param>
+            <param name="toastType">The expected toast type.</param>
+            <returns>
+                <see langword="true" /> when the stored row is usable; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastRuntime.NormalizeForReplacement(System.String)">
+            <summary>
+                Normalizes translated text before native replacement when the game font
+                requires it.
+            </summary>
+            <param name="translatedText">The translated text to normalize.</param>
+            <returns>The text that should be written back into the callback payload.</returns>
         </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.WideTextToastHandler">
             <summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -17161,10 +17161,9 @@
         </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy">
             <summary>
-                Centralizes the family-level routing rules for the alternate
-                ToastGui-owned runtime path. Under that route, supported normal toasts
-                are intentionally treated as one unified logical family rather than as
-                addon-specific subtypes.
+                Centralizes the family-level routing rules for the ToastGui-owned
+                runtime path. Supported normal toasts are intentionally treated as one
+                unified logical family rather than as addon-specific subtypes.
             </summary>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(Echoglossian.Config)">
@@ -17183,18 +17182,17 @@
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedToastGuiRuntime(Echoglossian.Config)">
             <summary>
-                Gets whether the alternate callback-owned ToastGui route is enabled at
-                all.
+                Gets whether the callback-owned ToastGui route is enabled at all.
             </summary>
             <param name="config">The active plugin configuration.</param>
             <returns>
-                <see langword="true" /> when the alternate ToastGui route is enabled;
+                <see langword="true" /> when the ToastGui route is enabled;
                 otherwise, <see langword="false" />.
             </returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(Echoglossian.Config)">
             <summary>
-                Gets whether the alternate callback-owned ToastGui route should own
+                Gets whether the callback-owned ToastGui route should own
                 the unified normal-toast family.
             </summary>
             <param name="config">The active plugin configuration.</param>
@@ -17205,7 +17203,7 @@
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedErrorToastRuntime(Echoglossian.Config)">
             <summary>
-                Gets whether the alternate callback-owned ToastGui route should own
+                Gets whether the callback-owned ToastGui route should own
                 error toasts.
             </summary>
             <param name="config">The active plugin configuration.</param>
@@ -17216,7 +17214,7 @@
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(Echoglossian.Config)">
             <summary>
-                Gets the canonical family-level display mode used by the alternate
+                Gets the canonical family-level display mode used by the
                 callback-owned runtime for the unified normal-toast family.
             </summary>
             <param name="config">The active plugin configuration.</param>
@@ -17227,8 +17225,7 @@
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseLegacyNormalToastCapturePrefetch(Echoglossian.Config)">
             <summary>
-                Gets whether the legacy ToastGui prefetch-only path should stay active
-                for supported normal toasts.
+                Gets whether the legacy ToastGui prefetch-only path should stay active.
             </summary>
             <param name="config">The active plugin configuration.</param>
             <returns>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2047,11 +2047,6 @@
                 payloads.
             </summary>
             <summary>
-                Handles the quest probe command used to inspect the complete quest data
-                shape from Lumina, the live quest progress resolver, and the current
-                QuestPlate database rows.
-            </summary>
-            <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
                 <see cref="E:Dalamud.Plugin.Services.IToastGui.QuestToast" /> instead of the addon-handler
                 registrar.
@@ -2562,11 +2557,6 @@
             Holds the database editor window instance.
             </summary>
         </member>
-        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
-            <summary>
-            Holds the currently active addon structure probe watch, if any.
-            </summary>
-        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -2679,11 +2669,6 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
-            <summary>
-                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -4033,21 +4018,6 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log so we can
-            inspect its live node tree, component roots, and likely overlay anchors.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
-            <summary>
-            Parses the addon probe command arguments into an addon name and optional index.
-            </summary>
-            <param name="args">The raw command arguments.</param>
-            <returns>The addon name and index to probe.</returns>
-        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -4316,102 +4286,6 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
-            <summary>
-                Handles the quest probe command.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
-            <summary>
-                Tries to resolve the quest probe target from either a quest id or a
-                quest name.
-            </summary>
-            <param name="input">The command argument.</param>
-            <param name="questIdText">The resolved quest id as text.</param>
-            <param name="questName">The resolved quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>True when the quest could be resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the quest data structure for inspection.
-            </summary>
-            <param name="questIdText">The quest id as text.</param>
-            <param name="questName">The quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the raw Lumina quest row properties.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs all rows from the quest text sheet, not just the live todo
-                entries, so we can inspect the full structure of the quest sheet.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
-            <summary>
-                Logs the QuestPlate rows currently stored for the quest.
-            </summary>
-            <param name="questIdText">The quest id text.</param>
-            <param name="questName">The quest name.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
-            <summary>
-                Logs the resolved live quest progression snapshot.
-            </summary>
-            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves a human-readable quest name from a quest row.
-            </summary>
-            <param name="questRow">The quest row.</param>
-            <returns>The resolved quest name, if available.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
-            <summary>
-                Converts quest text to a readable string for probe output.
-            </summary>
-            <param name="text">The quest text.</param>
-            <returns>The evaluated text string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
-            <summary>
-                Formats a probe value for log output.
-            </summary>
-            <param name="value">The value to format.</param>
-            <returns>A human-readable value string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Builds the raw quest sheet name used by the game files.
-            </summary>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>The quest text sheet name, if it can be derived.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest row id as text through reflection so the probe
-                stays compatible with generated sheet shapes.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest row id as text, or an empty string if unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest sheet identifier used to mount the quest text
-                sheet path.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -14532,6 +14406,25 @@
             </summary>
             <param name="activeBubbleKeys">The bubble keys seen in this frame.</param>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.RestoreTrackedBubbleLayoutIfNeeded(System.IntPtr,System.String)">
+            <summary>
+                Restores any native MiniTalk mutation currently tracked for the bubble
+                when the source text changes or native mode is left.
+            </summary>
+            <param name="bubbleKey">The stable bubble key.</param>
+            <param name="nextOriginalText">
+                The next original source text expected for the bubble, or an empty value
+                when the current mutation should always be restored.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean)">
+            <summary>
+                Restores one tracked native MiniTalk layout snapshot back to the
+                original game state.
+            </summary>
+            <param name="snapshot">The captured layout snapshot.</param>
+            <param name="originalText">The original text to write back.</param>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.OnPreUpdate(Dalamud.Game.Addon.Lifecycle.AddonEvent,Dalamud.Game.Addon.Lifecycle.AddonArgTypes.AddonArgs)">
             <summary>
                 Captures MiniTalk source text early in the lifecycle so a translation
@@ -14736,6 +14629,45 @@
                 <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryReadOriginalPointerText(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">
+            <summary>
+                Tries to read the original game-provided text payload from a MiniTalk
+                text node even when the visible node text has already been replaced.
+            </summary>
+            <param name="textNode">The text node to inspect.</param>
+            <param name="originalText">Receives the original payload text.</param>
+            <returns>
+                <see langword="true" /> when the original payload can be read;
+                otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryMapVisibleReplacementToKnownOriginal(System.String,System.String@)">
+            <summary>
+                Tries to resolve a visible translated MiniTalk line back to an original
+                source line already known to another tracked bubble state.
+            </summary>
+            <param name="visibleText">The visible text currently rendered by the node.</param>
+            <param name="originalText">Receives the matched original source line.</param>
+            <returns>
+                <see langword="true" /> when a tracked replacement matches the visible
+                line; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryHandleVisibleSourceChange(System.IntPtr,System.String,System.String)">
+            <summary>
+                Reconciles a visible MiniTalk source line against the tracked bubble
+                state so recycled bubble slots do not keep using a stale translation or
+                a stale native layout snapshot from the prior occupant.
+            </summary>
+            <param name="bubbleKey">The stable bubble key.</param>
+            <param name="visibleOriginalText">The current visible source line.</param>
+            <param name="trigger">The trigger label used for capture/queue routing.</param>
+            <returns>
+                <see langword="true" /> when the visible source changed and the new
+                source was captured, restored, or queued; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryCaptureOrQueueMiniTalkSource(System.IntPtr,System.String,System.String)">
             <summary>
                 Resolves the source MiniTalk line against cache, database, or background
@@ -14859,6 +14791,29 @@
             <summary>
                 Resets the active in-memory BattleTalk state.
             </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.RestoreTrackedNativeLayoutIfNeeded(System.String,System.String)">
+            <summary>
+                Restores any tracked native BattleTalk mutation when the source changes
+                or native mode is left.
+            </summary>
+            <param name="nextOriginalName">
+                The next original sender name expected for the addon, or an empty value
+                when the current mutation should always be restored.
+            </param>
+            <param name="nextOriginalText">
+                The next original source text expected for the addon, or an empty value
+                when the current mutation should always be restored.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.String)">
+            <summary>
+                Restores one tracked native BattleTalk layout snapshot back to the
+                original game state.
+            </summary>
+            <param name="layoutSnapshot">The captured layout snapshot.</param>
+            <param name="originalName">The original sender name to write back.</param>
+            <param name="originalText">The original text to write back.</param>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.BuildLookupMessage(System.String,System.String)">
             <summary>
@@ -15100,7 +15055,7 @@
                 translated output for the active source; otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.ApplyTranslatedNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,System.String,System.String,System.String)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.ApplyTranslatedNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,System.String,System.String,System.String,System.String,System.String)">
             <summary>
                 Applies translated values directly to the visible BattleTalk addon when
                 replacement mode is enabled.
@@ -15847,6 +15802,37 @@
             <param name="type">The lifecycle event that triggered the reset.</param>
             <param name="args">The addon arguments associated with the reset.</param>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.RestoreTrackedNativeLayoutIfNeeded(System.String)">
+            <summary>
+                Restores any tracked native toast mutation when the source changes or
+                native mode is left.
+            </summary>
+            <param name="nextOriginalText">
+                The next original source text expected for the toast, or an empty value
+                when the current mutation should always be restored.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean)">
+            <summary>
+                Restores one tracked native toast layout snapshot back to the original
+                game state.
+            </summary>
+            <param name="layoutSnapshot">The captured layout snapshot.</param>
+            <param name="originalText">The original text to write back.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.TryHandleVisibleSourceChange(System.String,System.String)">
+            <summary>
+                Reconciles the visible toast source against the tracked state so a
+                recycled toast slot does not keep a stale translated line or a stale
+                native layout snapshot from the prior source.
+            </summary>
+            <param name="visibleOriginalText">The currently visible toast source.</param>
+            <param name="trigger">The trigger label used for capture or queueing.</param>
+            <returns>
+                <see langword="true" /> when the source changed and the new source was
+                handled immediately; otherwise, <see langword="false" />.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.ResolveTranslationAsync(System.String,System.Int32)">
             <summary>
                 Resolves a toast translation without blocking the game UI and persists the
@@ -15887,6 +15873,18 @@
             <returns>
                 <see langword="true" /> when readable text is available; otherwise,
                 <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.TryReadOriginalPointerText(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">
+            <summary>
+                Tries to read the original game-provided text payload from a toast text
+                node even when the visible node text has already been replaced.
+            </summary>
+            <param name="textNode">The text node to inspect.</param>
+            <param name="originalText">Receives the original payload text.</param>
+            <returns>
+                <see langword="true" /> when the original payload can be read;
+                otherwise, <see langword="false" />.
             </returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.AddonTextToastHandler.ReadTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
@@ -16368,6 +16366,49 @@
             <param name="type">The lifecycle event that triggered the reset.</param>
             <param name="args">The addon arguments associated with the reset.</param>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.RestoreTrackedNativeLayoutIfNeeded(System.String)">
+            <summary>
+                Restores any tracked native gimmick-hint mutation when the source
+                changes or native mode is left.
+            </summary>
+            <param name="nextOriginalText">
+                The next original source text expected for the hint, or an empty value
+                when the current mutation should always be restored.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryRestoreNativeLayout(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean)">
+            <summary>
+                Restores one tracked native gimmick-hint layout snapshot back to the
+                original game state.
+            </summary>
+            <param name="layoutSnapshot">The captured layout snapshot.</param>
+            <param name="originalText">The original text to write back.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryHandleVisibleSourceChange(System.String,System.String)">
+            <summary>
+                Reconciles the visible gimmick-hint source against the tracked state so
+                a recycled slot does not keep a stale translated line or a stale native
+                layout snapshot from the prior source.
+            </summary>
+            <param name="visibleOriginalText">The currently visible source line.</param>
+            <param name="trigger">The trigger label used for capture or queueing.</param>
+            <returns>
+                <see langword="true" /> when the source changed and the new source was
+                handled immediately; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryCaptureOrQueueSource(System.String,System.String)">
+            <summary>
+                Resolves the visible TextGimmickHint source line against cache,
+                database, or background translation work without blocking the game UI.
+            </summary>
+            <param name="originalText">The current visible source line.</param>
+            <param name="trigger">The trigger label associated with the call.</param>
+            <returns>
+                <see langword="true" /> when the source was handled immediately;
+                otherwise, <see langword="false" />.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.ResolveTranslationAsync(System.String,System.Int32)">
             <summary>
                 Resolves a gimmick-hint translation without blocking the game UI and
@@ -16531,6 +16572,18 @@
             <returns>
                 <see langword="true" /> when readable text is available; otherwise,
                 <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryReadOriginalPointerText(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">
+            <summary>
+                Tries to read the original game-provided text payload from a gimmick-hint
+                text node even when the visible node text has already been replaced.
+            </summary>
+            <param name="textNode">The text node to inspect.</param>
+            <param name="originalText">Receives the original payload text.</param>
+            <returns>
+                <see langword="true" /> when the original payload can be read;
+                otherwise, <see langword="false" />.
             </returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TextMatches(System.String,System.String)">
@@ -17972,7 +18025,7 @@
             </param>
             <returns>The captured layout snapshot.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
             <summary>
                 Resolves the current wrap width that should be reused for a native text
                 replacement.
@@ -17980,6 +18033,10 @@
             <param name="textNode">The text node being replaced.</param>
             <param name="primaryContainerNode">
                 The main container node that owns the text node.
+            </param>
+            <param name="secondaryContainerNode">
+                An optional secondary background node whose width may better represent
+                the stable visual bounds than the current text-node width.
             </param>
             <returns>The preferred wrap width to preserve.</returns>
         </member>
@@ -18015,6 +18072,16 @@
             <param name="allowWidthGrowth">
                 Whether the helper may grow container widths when the wrapped text width
                 exceeds the original layout.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean)">
+            <summary>
+                Restores a previously captured native text-node layout snapshot after a
+                temporary translated replacement is no longer needed.
+            </summary>
+            <param name="snapshot">The layout snapshot captured before replacement.</param>
+            <param name="originalText">
+                The original text that should be written back into the text node.
             </param>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.TryResolveContainerNodes(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*@,FFXIVClientStructs.FFXIV.Component.GUI.AtkNineGridNode*@)">
@@ -18086,6 +18153,17 @@
                 The first nested nine-grid node, or <see langword="null" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveBoundedContainerWidth(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
+            <summary>
+                Resolves the widest stable visual width exposed by the surrounding
+                container nodes so repeated native replacements do not fall back to a
+                narrow internal wrapper when a larger background already represents the
+                intended visual balloon or panel width.
+            </summary>
+            <param name="primaryContainerNode">The primary owning container.</param>
+            <param name="secondaryContainerNode">An optional secondary background node.</param>
+            <returns>The widest non-zero container width available.</returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.FindFirstNineGridNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
             <summary>
                 Resolves the first nine-grid node reachable from a node.
@@ -18106,6 +18184,13 @@
                 The top-most wrapper to include in the captured chain.
             </param>
         </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.TryRestoreHorizontalCentering(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot)">
+            <summary>
+                Re-centers the text node within its immediate wrapper when the original
+                layout was centered and width growth changed the wrapper size.
+            </summary>
+            <param name="snapshot">The captured layout snapshot.</param>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot">
             <summary>
                 Captures the text and container sizing observed before native replacement.
@@ -18113,12 +18198,24 @@
             <param name="textWidth">The original text-node width.</param>
             <param name="textHeight">The original text-node height.</param>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.#ctor(System.UInt16,System.UInt16)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.#ctor(System.IntPtr,System.UInt16,System.UInt16,System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Byte,System.Int16,System.Int16)">
             <summary>
-                Captures the text and container sizing observed before native replacement.
+                Initializes a new instance of the <see cref="T:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot" /> class.
             </summary>
-            <param name="textWidth">The original text-node width.</param>
-            <param name="textHeight">The original text-node height.</param>
+            <param name="textNodeAddress">The address of the mutated text node.</param>
+            <param name="textWidth">The original measured text width.</param>
+            <param name="textHeight">The original measured text height.</param>
+            <param name="textNodeWidth">The original text-node width.</param>
+            <param name="textNodeHeight">The original text-node height.</param>
+            <param name="textNodeTextFlags">The original text-node flags.</param>
+            <param name="textNodeFontSize">The original text-node font size.</param>
+            <param name="textNodeOriginalX">The original text-node X position.</param>
+            <param name="textNodeOriginalY">The original text-node Y position.</param>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeAddress">
+            <summary>
+                Gets the native address of the mutated text node.
+            </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextWidth">
             <summary>
@@ -18130,10 +18227,51 @@
                 Gets the original text-node height.
             </summary>
         </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeWidth">
+            <summary>
+                Gets the original width assigned to the text node itself.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeHeight">
+            <summary>
+                Gets the original height assigned to the text node itself.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeTextFlags">
+            <summary>
+                Gets the original text-node flags.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeFontSize">
+            <summary>
+                Gets the original text-node font size.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeOriginalX">
+            <summary>
+                Gets the original X position assigned to the text node itself.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeOriginalY">
+            <summary>
+                Gets the original Y position assigned to the text node itself.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.TextNodeWasHorizontallyCentered">
+            <summary>
+                Gets or sets a value indicating whether the text node was originally
+                centered inside its immediate parent.
+            </summary>
+        </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AncestorChain">
             <summary>
                 Gets the wrapper chain that should be resized after a native text
                 replacement.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.SecondaryContainerAddress">
+            <summary>
+                Gets or sets the native address of the secondary container node.
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.SecondaryContainerWidth">
@@ -18146,10 +18284,30 @@
                 Gets or sets the secondary container height.
             </summary>
         </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.SecondaryContainerOriginalX">
+            <summary>
+                Gets or sets the original X position of the secondary container.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.SecondaryContainerOriginalY">
+            <summary>
+                Gets or sets the original Y position of the secondary container.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AnchoredXNodeAddress">
+            <summary>
+                Gets or sets the native address of the anchored X node.
+            </summary>
+        </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AnchoredXOffset">
             <summary>
                 Gets or sets the X offset between an anchored sibling node and the text
                 width.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AnchoredXOriginal">
+            <summary>
+                Gets or sets the original X position of the anchored sibling node.
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.SecondaryHorizontalPadding">
@@ -18191,6 +18349,8 @@
             <param name="NodeAddress">The native address of the wrapper node.</param>
             <param name="Width">The original wrapper width.</param>
             <param name="Height">The original wrapper height.</param>
+            <param name="OriginalX">The original X position of the wrapper node.</param>
+            <param name="OriginalY">The original Y position of the wrapper node.</param>
             <param name="HorizontalPadding">
                 The original horizontal padding between this wrapper and its child.
             </param>
@@ -18198,13 +18358,15 @@
                 The original vertical padding between this wrapper and its child.
             </param>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeAncestorSnapshot.#ctor(System.IntPtr,System.UInt16,System.UInt16,System.Int32,System.Int32)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeAncestorSnapshot.#ctor(System.IntPtr,System.UInt16,System.UInt16,System.Int16,System.Int16,System.Int32,System.Int32)">
             <summary>
                 Captures one ancestor wrapper in a text-node layout chain.
             </summary>
             <param name="NodeAddress">The native address of the wrapper node.</param>
             <param name="Width">The original wrapper width.</param>
             <param name="Height">The original wrapper height.</param>
+            <param name="OriginalX">The original X position of the wrapper node.</param>
+            <param name="OriginalY">The original Y position of the wrapper node.</param>
             <param name="HorizontalPadding">
                 The original horizontal padding between this wrapper and its child.
             </param>
@@ -18220,6 +18382,12 @@
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeAncestorSnapshot.Height">
             <summary>The original wrapper height.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeAncestorSnapshot.OriginalX">
+            <summary>The original X position of the wrapper node.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeAncestorSnapshot.OriginalY">
+            <summary>The original Y position of the wrapper node.</summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeAncestorSnapshot.HorizontalPadding">
             <summary>
@@ -21567,6 +21735,51 @@
             </summary>
         </member>
         <member name="P:Echoglossian.Properties.Resources.CouldNotFetchOllamaModels">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeNoActiveWatch">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeStopped">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeUsage">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeInvalidDurationFormat">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeStartedFormat">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeDurationMinuteFormat">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeDurationMinutesFormat">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeDurationSecondFormat">
+            <summary>
+              Looks up a localized string.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.AddonProbeDurationSecondsFormat">
             <summary>
               Looks up a localized string.
             </summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2064,8 +2064,17 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
+                Hosts debug-only automatic addon-probe watches that start on login for
+                selected addons with early hidden-state value.
+            </summary>
+            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
+            </summary>
+            <summary>
+                Handles the quest probe command used to inspect the complete quest data
+                shape from Lumina, the live quest progress resolver, and the current
+                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -2586,6 +2595,11 @@
             Holds the database editor window instance.
             </summary>
         </member>
+        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
+            <summary>
+            Holds the currently active addon structure probe watch, if any.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -2698,6 +2712,11 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
+            <summary>
+                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -2871,6 +2890,17 @@
                 chars.
             </param>
             <returns>Cleand text.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryCreateNativeReplacementTextNormalizer(Echoglossian.Config)">
+            <summary>
+                Creates the shared normalizer used by non-quest native replacement
+                flows when the global diacritics-removal toggle is active.
+            </summary>
+            <param name="config">The current plugin configuration.</param>
+            <returns>
+                A normalization callback when the feature is active and the plugin
+                instance is available; otherwise <see langword="null" />.
+            </returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.GetGameVersion">
             <summary>
@@ -4047,6 +4077,109 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
+        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
+            <summary>
+                Ticks manual and automatic addon-probe watches, including the
+                debug-only login bootstrap for the default watch set.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
+            <summary>
+                Gets how many addon-probe watches are currently active across manual
+                and managed watch sets.
+            </summary>
+            <returns>The active probe-watch count.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
+            <summary>
+                Stops every active addon-probe watch known to the plugin.
+            </summary>
+            <param name="suppressAutoUntilLogout">
+                Whether the current login session should suppress the default
+                automatic watch set after the stop completes.
+            </param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
+            <summary>
+                Ticks the currently active manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
+            <summary>
+                Ticks every managed addon-probe watch and prunes the disposed ones.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic addon-probe watch set when the player
+                logs in, then resets the gate on logout.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic watch set used to capture early
+                structural state for pooled dialogue addons.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
+            <summary>
+                Starts one managed addon-probe watch and tracks it for later stop or
+                pruning.
+            </summary>
+            <param name="addonName">The addon name to watch.</param>
+            <param name="index">The addon instance index.</param>
+            <param name="duration">How long the watch should stay alive.</param>
+            <param name="reason">The debug log reason attached to the startup.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
+            <summary>
+                Stops the current manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
+            <summary>
+                Stops every managed automatic addon-probe watch.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
+            <summary>
+            Dumps a recursive probe of the requested addon to the log so we can
+            inspect its live node tree, component roots, and likely overlay anchors.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
+            <summary>
+            Parses the addon probe command arguments into an addon name, optional index,
+            and optional watch duration.
+            </summary>
+            <param name="args">The raw command arguments.</param>
+            <returns>The addon name, index, and duration to probe.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
+            <summary>
+            Parses one addon-probe duration token such as "90s" or "15m".
+            </summary>
+            <param name="token">The raw duration token.</param>
+            <param name="duration">Receives the parsed duration.</param>
+            <returns><see langword="true"/> when the token parsed successfully.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
+            <summary>
+            Determines whether a token looks like an addon-probe duration even when the
+            value is outside the accepted range.
+            </summary>
+            <param name="token">The token to inspect.</param>
+            <returns><see langword="true"/> when the token resembles a duration.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
+            <summary>
+            Formats one addon-probe watch duration for chat feedback.
+            </summary>
+            <param name="duration">The duration to format.</param>
+            <returns>The human-readable duration string.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -4315,6 +4448,102 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
+            <summary>
+                Handles the quest probe command.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
+            <summary>
+                Tries to resolve the quest probe target from either a quest id or a
+                quest name.
+            </summary>
+            <param name="input">The command argument.</param>
+            <param name="questIdText">The resolved quest id as text.</param>
+            <param name="questName">The resolved quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>True when the quest could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the quest data structure for inspection.
+            </summary>
+            <param name="questIdText">The quest id as text.</param>
+            <param name="questName">The quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the raw Lumina quest row properties.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs all rows from the quest text sheet, not just the live todo
+                entries, so we can inspect the full structure of the quest sheet.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
+            <summary>
+                Logs the QuestPlate rows currently stored for the quest.
+            </summary>
+            <param name="questIdText">The quest id text.</param>
+            <param name="questName">The quest name.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Logs the resolved live quest progression snapshot.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves a human-readable quest name from a quest row.
+            </summary>
+            <param name="questRow">The quest row.</param>
+            <returns>The resolved quest name, if available.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
+            <summary>
+                Converts quest text to a readable string for probe output.
+            </summary>
+            <param name="text">The quest text.</param>
+            <returns>The evaluated text string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
+            <summary>
+                Formats a probe value for log output.
+            </summary>
+            <param name="value">The value to format.</param>
+            <returns>A human-readable value string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Builds the raw quest sheet name used by the game files.
+            </summary>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>The quest text sheet name, if it can be derived.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest row id as text through reflection so the probe
+                stays compatible with generated sheet shapes.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest row id as text, or an empty string if unavailable.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest sheet identifier used to mount the quest text
+                sheet path.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -11814,6 +12043,17 @@
             <param name="translatedPayload">The translated payload.</param>
             <param name="payloadKey">The stable payload key.</param>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowAddonHandler.NormalizeTranslatedPayloadForDisplayMode(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,Echoglossian.JournalTranslationDisplayMode)">
+            <summary>
+                Normalizes one translated payload only when the current display mode
+                will actually write the translated text into the native UI.
+            </summary>
+            <param name="translatedPayload">The translated payload to normalize.</param>
+            <param name="displayMode">The active display mode.</param>
+            <returns>
+                The translated payload that should be applied for this display mode.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowAddonHandler.RestoreOriginalPayloadIfNeeded">
             <summary>
                 Restores the original payload if this runtime mutated the addon.
@@ -12412,6 +12652,15 @@
                 the main command menu reprocesses its <c>AtkValue</c>s.
             </summary>
             <param name="args">The lifecycle arguments for the refresh event.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.MainMenu.MainCommandHandler.NormalizeTranslatedPayloadForDisplayMode(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,Echoglossian.JournalTranslationDisplayMode)">
+            <summary>
+                Normalizes one translated main-command payload only when the active
+                display mode will write the text into the native UI.
+            </summary>
+            <param name="translatedPayload">The translated payload to normalize.</param>
+            <param name="displayMode">The active display mode.</param>
+            <returns>The payload to use for refresh apply and hover state.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.MainMenu.MainCommandHandler.CaptureRefreshPayload(FFXIVClientStructs.FFXIV.Component.GUI.AtkValue*,System.UInt32)">
             <summary>
@@ -17529,6 +17778,46 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
+            <summary>
+                Encapsulates the login-session gating rules for debug-only automatic
+                addon-probe watches.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
+            <summary>
+                Determines whether the current login session should start the default
+                automatic addon-probe watch set.
+            </summary>
+            <param name="isLoggedIn">Whether the client is currently logged in.</param>
+            <param name="hasStartedForCurrentLogin">
+                Whether the current login session already started its automatic probe
+                set.
+            </param>
+            <param name="isSuppressedUntilLogout">
+                Whether the user explicitly suppressed the automatic probe set until
+                the next logout.
+            </param>
+            <param name="activeManagedWatchCount">
+                How many managed automatic probe watches are currently alive.
+            </param>
+            <returns>
+                <see langword="true" /> when the automatic probe set should start.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
+            <summary>
+                Determines whether the automatic login-session gate should reset
+                because the player logged out.
+            </summary>
+            <param name="wasLoggedIn">
+                Whether the client was logged in on the previous tick.
+            </param>
+            <param name="isLoggedIn">Whether the client is logged in now.</param>
+            <returns>
+                <see langword="true" /> when the automatic probe gate should reset.
+            </returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -18639,6 +18928,47 @@
             <param name="title">The title line.</param>
             <param name="body">The body text.</param>
             <returns>The combined tooltip text.</returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.NativeReplacementTextNormalizationHelper">
+            <summary>
+                Normalizes translated payload text for native replacement-only flows.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeReplacementTextNormalizationHelper.NormalizePayload(Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowPayload,System.Func{System.String,System.String})">
+            <summary>
+                Applies one text normalizer to every translated value that can be
+                written back into one native addon payload.
+            </summary>
+            <param name="payload">The translated payload to normalize.</param>
+            <param name="normalizeText">
+                The per-string normalization callback.
+            </param>
+            <returns>
+                The normalized payload. When no value changes, the original payload
+                instance is returned unchanged.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeReplacementTextNormalizationHelper.NormalizeMap(System.Collections.Generic.SortedDictionary{System.Int32,System.String},System.Func{System.String,System.String},System.Boolean@)">
+            <summary>
+                Applies one text normalizer to one numeric-keyed payload map.
+            </summary>
+            <param name="sourceValues">The source values.</param>
+            <param name="normalizeText">The per-string normalization callback.</param>
+            <param name="changed">
+                Tracks whether any normalized value differed from the source value.
+            </param>
+            <returns>The normalized payload map.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeReplacementTextNormalizationHelper.NormalizeMap(System.Collections.Generic.SortedDictionary{System.String,System.String},System.Func{System.String,System.String},System.Boolean@)">
+            <summary>
+                Applies one text normalizer to one text-node payload map.
+            </summary>
+            <param name="sourceValues">The source values.</param>
+            <param name="normalizeText">The per-string normalization callback.</param>
+            <param name="changed">
+                Tracks whether any normalized value differed from the source value.
+            </param>
+            <returns>The normalized payload map.</returns>
         </member>
         <member name="T:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper">
             <summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -14529,6 +14529,15 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ResolveMiniTalkAdditionalWrapWidth(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
+            <summary>
+                Resolves a small amount of extra wrap width from the live MiniTalk node
+                padding so translated lines can gain a bit of horizontal room without
+                relying on fixed pixel constants.
+            </summary>
+            <param name="textNode">The live MiniTalk text node.</param>
+            <returns>The additional wrap width suggested by the current bubble layout.</returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryGetCurrentResolvedTranslation(System.IntPtr,System.String@,System.String@,System.String@)">
             <summary>
                 Returns the active resolved translation currently held by the handler
@@ -18289,7 +18298,7 @@
             </param>
             <returns>The measured size after the text replacement.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResizeFromSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,Echoglossian.NativeUI.Helpers.NativeTextNodeResizeResult,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResizeFromSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,Echoglossian.NativeUI.Helpers.NativeTextNodeResizeResult,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean,System.Boolean)">
             <summary>
                 Resizes the supplied container nodes using the text delta captured in a
                 pre-replacement layout snapshot.
@@ -18311,7 +18320,7 @@
                 exceeds the original layout.
             </param>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean,System.Boolean)">
             <summary>
                 Restores a previously captured native text-node layout snapshot after a
                 temporary translated replacement is no longer needed.
@@ -18339,7 +18348,7 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.Boolean)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.Boolean,System.Boolean,System.UInt16)">
             <summary>
                 Applies translated text to a node and grows its wrapper chain plus the
                 nearest nine-grid background using inferred padding from the current

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -18755,6 +18755,31 @@
                 insufficient.
             </param>
         </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveMinimumSecondaryWidthForAnchoredNode(System.Int16,System.UInt16,System.Int16,System.UInt16,System.Int32)">
+            <summary>
+                Resolves the minimum secondary-container width required to keep an
+                anchored sibling node covered by the same background after reflow.
+            </summary>
+            <param name="secondaryContainerX">
+                The live X position of the secondary container.
+            </param>
+            <param name="currentSecondaryWidth">
+                The current width of the secondary container before adjustment.
+            </param>
+            <param name="anchoredNodeX">
+                The live X position of the anchored sibling node.
+            </param>
+            <param name="anchoredNodeWidth">The current width of the anchored node.</param>
+            <param name="preferredRightPadding">
+                The original right padding between the secondary container and the
+                anchored node. Negative values are treated as zero so coverage still
+                extends to the anchored node edge.
+            </param>
+            <returns>
+                The minimum width that keeps the anchored node inside the secondary
+                background.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.TryMeasureTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.UInt16@,System.UInt16@)">
             <summary>
                 Measures the current node size using the live node dimensions first and
@@ -18947,6 +18972,17 @@
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AnchoredXOriginal">
             <summary>
                 Gets or sets the original X position of the anchored sibling node.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AnchoredXWidth">
+            <summary>
+                Gets or sets the original width of the anchored sibling node.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.AnchoredXRightPaddingFromSecondary">
+            <summary>
+                Gets or sets the original right padding between the anchored sibling
+                node and the secondary container.
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot.SecondaryHorizontalPadding">

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2891,6 +2891,13 @@
             </param>
             <returns>Cleand text.</returns>
         </member>
+        <member name="M:Echoglossian.Echoglossian.EnsureConfigDefaultsPersistedForMissingKeys">
+            <summary>
+                Ensures newly introduced config fields are materialized in the
+                persisted JSON after an update by saving once when any known field is
+                missing from disk.
+            </summary>
+        </member>
         <member name="M:Echoglossian.Echoglossian.TryCreateNativeReplacementTextNormalizer(Echoglossian.Config)">
             <summary>
                 Creates the shared normalizer used by non-quest native replacement

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -1862,6 +1862,13 @@
                 handlers see the live nodes.
             </summary>
         </member>
+        <member name="F:Echoglossian.Config.EnableDebugLoginAddonProbe">
+            <summary>
+                Enables debug-only automatic login probes for `_BattleTalk` and
+                `_MiniTalk` so their earliest addon state can be captured without
+                manually issuing the probe command after login.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Config.TranslateToDoList">
             <summary>Translate To-Do List entries.</summary>
         </member>

--- a/GeneralHelpers/RuntimeConfigurationRefresh.cs
+++ b/GeneralHelpers/RuntimeConfigurationRefresh.cs
@@ -181,7 +181,6 @@ public partial class Echoglossian
           this.configuration.TranslateAreaToast,
           this.configuration.TranslateClassChangeToast,
           this.configuration.TranslateTextGimmickHint,
-          this.configuration.UseToastGuiRuntimeForSupportedToasts,
         });
   }
 

--- a/GeneralHelpers/RuntimeConfigurationRefresh.cs
+++ b/GeneralHelpers/RuntimeConfigurationRefresh.cs
@@ -55,7 +55,7 @@ public partial class Echoglossian
     {
       this.RebuildTranslationServiceSafely();
       this.RebuildQueuedTranslationBroker();
-      this.RebuildQuestToastRuntime();
+      this.RebuildToastGuiRuntimes();
       this.translationRuntimeSignature = translationSignature;
       this.addonHandlerRegistrationSignature = null;
     }
@@ -181,6 +181,7 @@ public partial class Echoglossian
           this.configuration.TranslateAreaToast,
           this.configuration.TranslateClassChangeToast,
           this.configuration.TranslateTextGimmickHint,
+          this.configuration.UseToastGuiRuntimeForSupportedToasts,
         });
   }
 
@@ -200,11 +201,17 @@ public partial class Echoglossian
   ///     Recreates and re-registers the quest-toast runtime so it uses the
   ///     current translation service.
   /// </summary>
-  private void RebuildQuestToastRuntime()
+  private void RebuildToastGuiRuntimes()
   {
     this.UnregisterQuestToastRuntime();
+    this.UnregisterToastGuiSupportedToastRuntime();
+    this.UnregisterToastGuiCaptureRuntime();
     this.questToastRuntime = this.CreateQuestToastRuntime();
+    this.toastGuiSupportedToastRuntime = this.CreateToastGuiSupportedToastRuntime();
+    this.toastGuiCaptureRuntime = this.CreateToastGuiCaptureRuntime();
     this.RegisterQuestToastRuntime();
+    this.RegisterToastGuiSupportedToastRuntime();
+    this.RegisterToastGuiCaptureRuntime();
   }
 
   /// <summary>

--- a/GeneralHelpers/Utils.cs
+++ b/GeneralHelpers/Utils.cs
@@ -922,6 +922,46 @@ public partial class Echoglossian
   }
 
   /// <summary>
+  ///     Ensures newly introduced config fields are materialized in the
+  ///     persisted JSON after an update by saving once when any known field is
+  ///     missing from disk.
+  /// </summary>
+  private void EnsureConfigDefaultsPersistedForMissingKeys()
+  {
+    if (!File.Exists(PluginInterface.ConfigFile.FullName))
+    {
+      return;
+    }
+
+    try
+    {
+      var persistedConfig = Newtonsoft.Json.Linq.JObject.Parse(
+          File.ReadAllText(PluginInterface.ConfigFile.FullName));
+      var runtimeConfig = Newtonsoft.Json.Linq.JObject.FromObject(
+          this.configuration);
+
+      foreach (var property in runtimeConfig.Properties())
+      {
+        if (persistedConfig.Property(
+                property.Name,
+                StringComparison.Ordinal) != null)
+        {
+          continue;
+        }
+
+        SaveConfig(this.configuration);
+        return;
+      }
+    }
+    catch (Exception ex)
+    {
+      PluginRuntimeLog.Warning(
+          "Config",
+          $"Failed to verify persisted config defaults: {ex.Message}");
+    }
+  }
+
+  /// <summary>
   ///     Creates the shared normalizer used by non-quest native replacement
   ///     flows when the global diacritics-removal toggle is active.
   /// </summary>

--- a/GeneralHelpers/Utils.cs
+++ b/GeneralHelpers/Utils.cs
@@ -922,6 +922,34 @@ public partial class Echoglossian
   }
 
   /// <summary>
+  ///     Creates the shared normalizer used by non-quest native replacement
+  ///     flows when the global diacritics-removal toggle is active.
+  /// </summary>
+  /// <param name="config">The current plugin configuration.</param>
+  /// <returns>
+  ///     A normalization callback when the feature is active and the plugin
+  ///     instance is available; otherwise <see langword="null" />.
+  /// </returns>
+  internal static Func<string, string>? TryCreateNativeReplacementTextNormalizer(
+      Config config)
+  {
+    if (!config.RemoveDiacriticsWhenUsingReplacementTalkBTalk)
+    {
+      return null;
+    }
+
+    var instance = activeInstance;
+    if (instance == null)
+    {
+      return null;
+    }
+
+    return text => instance.RemoveDiacritics(
+        text,
+        instance.SpecialCharsSupportedByGameFont);
+  }
+
+  /// <summary>
   ///     Gets the game version from the framework.
   /// </summary>
   /// <returns>Game version as a string.</returns>

--- a/NativeUI/AddonHandlers/Common/DbFirstGameWindowAddonHandler.cs
+++ b/NativeUI/AddonHandlers/Common/DbFirstGameWindowAddonHandler.cs
@@ -1998,11 +1998,16 @@ public abstract unsafe class DbFirstGameWindowAddonHandler
         string payloadKey,
         JournalTranslationDisplayMode displayMode)
     {
+        var translatedPayloadToApply =
+            this.NormalizeTranslatedPayloadForDisplayMode(
+                translatedPayload,
+                displayMode);
+
         if (TranslationDisplayModeHelper.WritesNativeTranslation(displayMode) &&
             this.useAtkValues &&
             addon->AtkValues != null)
         {
-            foreach (var (index, translatedText) in translatedPayload.AtkValues)
+            foreach (var (index, translatedText) in translatedPayloadToApply.AtkValues)
             {
                 if ((uint)index >= addon->AtkValuesCount)
                 {
@@ -2033,14 +2038,16 @@ public abstract unsafe class DbFirstGameWindowAddonHandler
 
         if (TranslationDisplayModeHelper.WritesNativeTranslation(displayMode) &&
             this.useTextNodes &&
-            translatedPayload.TextNodes.Count > 0)
+            translatedPayloadToApply.TextNodes.Count > 0)
         {
             if (!this.TryApplyCustomTextNodePayload(
                     addon,
                     originalPayload,
-                    translatedPayload))
+                    translatedPayloadToApply))
             {
-                this.ApplyTranslatedTextNodes(addon, translatedPayload.TextNodes);
+                this.ApplyTranslatedTextNodes(
+                    addon,
+                    translatedPayloadToApply.TextNodes);
             }
         }
 
@@ -2054,7 +2061,7 @@ public abstract unsafe class DbFirstGameWindowAddonHandler
                 this.ShouldWriteStringArrayValues(
                     stringArrayData->SubscribedAddonsCount))
             {
-                foreach (var (index, translatedText) in translatedPayload
+                foreach (var (index, translatedText) in translatedPayloadToApply
                              .StringArrayValues)
                 {
                     if ((uint)index >= stringArrayData->Size)
@@ -2097,7 +2104,7 @@ public abstract unsafe class DbFirstGameWindowAddonHandler
             this.RegisterHoverTooltips(
                 addon,
                 originalPayload,
-                translatedPayload,
+                translatedPayloadToApply,
                 displayMode);
         }
         else
@@ -2108,14 +2115,14 @@ public abstract unsafe class DbFirstGameWindowAddonHandler
         this.lastResolvedState = new DbFirstGameWindowRuntimeState(
             payloadKey,
             originalPayload,
-            translatedPayload);
+            translatedPayloadToApply);
 
         if (TranslationDisplayModeHelper.WritesNativeTranslation(displayMode))
         {
             this.runtimeState = new DbFirstGameWindowRuntimeState(
                 payloadKey,
                 originalPayload,
-                translatedPayload);
+                translatedPayloadToApply);
         }
         else
         {
@@ -2123,6 +2130,36 @@ public abstract unsafe class DbFirstGameWindowAddonHandler
         }
 
         this.lastAppliedDisplayMode = displayMode;
+    }
+
+    /// <summary>
+    ///     Normalizes one translated payload only when the current display mode
+    ///     will actually write the translated text into the native UI.
+    /// </summary>
+    /// <param name="translatedPayload">The translated payload to normalize.</param>
+    /// <param name="displayMode">The active display mode.</param>
+    /// <returns>
+    ///     The translated payload that should be applied for this display mode.
+    /// </returns>
+    private DbFirstGameWindowPayload NormalizeTranslatedPayloadForDisplayMode(
+        DbFirstGameWindowPayload translatedPayload,
+        JournalTranslationDisplayMode displayMode)
+    {
+        if (!TranslationDisplayModeHelper.WritesNativeTranslation(displayMode))
+        {
+            return translatedPayload;
+        }
+
+        var normalizeText =
+            Echoglossian.TryCreateNativeReplacementTextNormalizer(this.config);
+        if (normalizeText == null)
+        {
+            return translatedPayload;
+        }
+
+        return NativeReplacementTextNormalizationHelper.NormalizePayload(
+            translatedPayload,
+            normalizeText);
     }
 
     /// <summary>

--- a/NativeUI/AddonHandlers/MainMenu/MainCommandHandler.cs
+++ b/NativeUI/AddonHandlers/MainMenu/MainCommandHandler.cs
@@ -189,6 +189,9 @@ public unsafe class MainCommandHandler : DbFirstGameWindowAddonHandler
         var displayMode = TranslationDisplayModeHelper.GetEffectiveDisplayMode(
             this.config.GameMainMenuWindowTranslationDisplayMode,
             this.config.OverlayOnlyLanguage);
+        translatedPayload = this.NormalizeTranslatedPayloadForDisplayMode(
+            translatedPayload,
+            displayMode);
 
         if (TranslationDisplayModeHelper.WritesNativeTranslation(displayMode))
         {
@@ -214,6 +217,34 @@ public unsafe class MainCommandHandler : DbFirstGameWindowAddonHandler
             originalPayload,
             translatedPayload,
             displayMode);
+    }
+
+    /// <summary>
+    ///     Normalizes one translated main-command payload only when the active
+    ///     display mode will write the text into the native UI.
+    /// </summary>
+    /// <param name="translatedPayload">The translated payload to normalize.</param>
+    /// <param name="displayMode">The active display mode.</param>
+    /// <returns>The payload to use for refresh apply and hover state.</returns>
+    private DbFirstGameWindowPayload NormalizeTranslatedPayloadForDisplayMode(
+        DbFirstGameWindowPayload translatedPayload,
+        JournalTranslationDisplayMode displayMode)
+    {
+        if (!TranslationDisplayModeHelper.WritesNativeTranslation(displayMode))
+        {
+            return translatedPayload;
+        }
+
+        var normalizeText =
+            Echoglossian.TryCreateNativeReplacementTextNormalizer(this.config);
+        if (normalizeText == null)
+        {
+            return translatedPayload;
+        }
+
+        return NativeReplacementTextNormalizationHelper.NormalizePayload(
+            translatedPayload,
+            normalizeText);
     }
 
     /// <summary>

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -284,6 +284,37 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
   }
 
   /// <summary>
+  ///     Restores the tracked native MiniTalk layout for the current bubble even
+  ///     when the source line has not changed, so repeated native apply passes
+  ///     always restart from the original bubble geometry instead of stacking
+  ///     width and height growth from the prior frame.
+  /// </summary>
+  /// <param name="bubbleKey">The stable bubble key.</param>
+  /// <param name="originalText">The original source line currently assigned to the bubble.</param>
+  private void PrepareTrackedBubbleLayoutForReapply(
+      nint bubbleKey,
+      string originalText)
+  {
+    NativeTextNodeLayoutSnapshot? snapshot = null;
+
+    lock (this.stateGate)
+    {
+      if (!this.bubbleStates.TryGetValue(bubbleKey, out var state) ||
+          state.NativeLayoutSnapshot == null ||
+          !this.TextMatches(state.NativeLayoutOriginalText, originalText))
+      {
+        return;
+      }
+
+      snapshot = state.NativeLayoutSnapshot;
+      state.NativeLayoutSnapshot = null;
+      state.NativeLayoutOriginalText = string.Empty;
+    }
+
+    this.TryRestoreNativeLayout(snapshot, originalText);
+  }
+
+  /// <summary>
   ///     Restores one tracked native MiniTalk layout snapshot back to the
   ///     original game state.
   /// </summary>
@@ -462,11 +493,15 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
         continue;
       }
 
+      this.PrepareTrackedBubbleLayoutForReapply(
+          bubbleNodeAddress,
+          resolvedOriginalText);
+
       var layoutSnapshot = NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
           addon,
           textNode,
           replacementText,
-          allowWidthGrowth: true);
+          allowWidthGrowth: false);
       if (layoutSnapshot != null)
       {
         lock (this.stateGate)

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -311,7 +311,10 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       state.NativeLayoutOriginalText = string.Empty;
     }
 
-    this.TryRestoreNativeLayout(snapshot, originalText);
+    this.TryRestoreNativeLayout(
+        snapshot,
+        originalText,
+        restoreText: false);
   }
 
   /// <summary>
@@ -1081,9 +1084,14 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
     if (this.ShouldApplyNativeText())
     {
       if (this.TryReadOriginalPointerText(textNode, out var originalPointerText) &&
-          !this.TextMatches(originalPointerText, visibleText))
+          !this.TextMatches(originalPointerText, visibleText) &&
+          this.TryConfirmOriginalPointerMatchesVisible(
+              bubbleKey,
+              originalPointerText,
+              visibleText,
+              out var confirmedOriginalText))
       {
-        originalText = originalPointerText;
+        originalText = confirmedOriginalText;
         return true;
       }
 
@@ -1096,6 +1104,69 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
 
     originalText = visibleText;
     return true;
+  }
+
+  /// <summary>
+  ///     Confirms that a MiniTalk node's original-text pointer really belongs to
+  ///     the currently visible bubble text before the handler trusts it as the
+  ///     logical source line.
+  /// </summary>
+  /// <param name="bubbleKey">The stable bubble key.</param>
+  /// <param name="originalPointerText">The text read from <c>OriginalTextPointer</c>.</param>
+  /// <param name="visibleText">The text currently visible in the node.</param>
+  /// <param name="originalText">Receives the confirmed original text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the pointer text can be proven to explain
+  ///     the visible replacement inside MiniTalk; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool TryConfirmOriginalPointerMatchesVisible(
+      nint bubbleKey,
+      string originalPointerText,
+      string visibleText,
+      out string originalText)
+  {
+    lock (this.stateGate)
+    {
+      if (this.TryGetBubbleState(bubbleKey, out var state) &&
+          this.TextMatches(state.CurrentOriginalText, originalPointerText) &&
+          this.TextMatches(visibleText, state.CurrentReplacementText))
+      {
+        originalText = originalPointerText;
+        return true;
+      }
+
+      foreach (var bubbleState in this.bubbleStates.Values)
+      {
+        if (!this.TextMatches(
+                bubbleState.CurrentOriginalText,
+                originalPointerText))
+        {
+          continue;
+        }
+
+        if (this.TextMatches(
+                visibleText,
+                bubbleState.CurrentReplacementText))
+        {
+          originalText = originalPointerText;
+          return true;
+        }
+      }
+    }
+
+    if (this.TryLoadStoredTranslation(
+            originalPointerText,
+            out _,
+            out var replacementText) &&
+        this.TextMatches(visibleText, replacementText))
+    {
+      originalText = originalPointerText;
+      return true;
+    }
+
+    originalText = string.Empty;
+    return false;
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -336,7 +336,8 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
     NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
         snapshot,
         originalText,
-        restoreText);
+        restoreText,
+        restorePositions: false);
   }
 
   /// <summary>
@@ -504,7 +505,8 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
           addon,
           textNode,
           replacementText,
-          allowWidthGrowth: false);
+          allowWidthGrowth: true,
+          additionalWrapWidth: this.ResolveMiniTalkAdditionalWrapWidth(textNode));
       if (layoutSnapshot != null)
       {
         lock (this.stateGate)
@@ -691,6 +693,36 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
     translatedText = lookup.TranslatedMiniTalkMessage!;
     replacementText = this.NormalizeForReplacement(translatedText);
     return true;
+  }
+
+  /// <summary>
+  ///     Resolves a small amount of extra wrap width from the live MiniTalk node
+  ///     padding so translated lines can gain a bit of horizontal room without
+  ///     relying on fixed pixel constants.
+  /// </summary>
+  /// <param name="textNode">The live MiniTalk text node.</param>
+  /// <returns>The additional wrap width suggested by the current bubble layout.</returns>
+  private unsafe ushort ResolveMiniTalkAdditionalWrapWidth(AtkTextNode* textNode)
+  {
+    if (textNode == null)
+    {
+      return 0;
+    }
+
+    var parentNode = textNode->AtkResNode.ParentNode;
+    var leftPadding = Math.Max(0, (int)textNode->AtkResNode.GetXShort());
+    if (parentNode == null)
+    {
+      return (ushort)Math.Min(ushort.MaxValue, leftPadding);
+    }
+
+    var currentWidth = textNode->GetWidth();
+    var rightPadding = Math.Max(
+        0,
+        parentNode->GetWidth() - leftPadding - currentWidth);
+    return (ushort)Math.Min(
+        ushort.MaxValue,
+        Math.Max(leftPadding, rightPadding));
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -78,6 +78,10 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
   {
     public int ActiveRequestId;
 
+    public NativeTextNodeLayoutSnapshot? NativeLayoutSnapshot { get; set; }
+
+    public string NativeLayoutOriginalText { get; set; } = string.Empty;
+
     public string CurrentOriginalText { get; set; } = string.Empty;
 
     public string CurrentReplacementText { get; set; } = string.Empty;
@@ -217,18 +221,88 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
   /// <param name="activeBubbleKeys">The bubble keys seen in this frame.</param>
   private void PruneHiddenMiniTalkBubbles(HashSet<nint> activeBubbleKeys)
   {
-    List<nint> hiddenBubbleKeys;
+    List<KeyValuePair<nint, BubbleState>> hiddenBubbleStates;
     lock (this.stateGate)
     {
-      hiddenBubbleKeys = this.bubbleStates.Keys
-          .Where(bubbleKey => !activeBubbleKeys.Contains(bubbleKey))
+      hiddenBubbleStates = this.bubbleStates
+          .Where(kvp => !activeBubbleKeys.Contains(kvp.Key))
           .ToList();
+
+      foreach (var hiddenBubbleState in hiddenBubbleStates)
+      {
+        this.bubbleStates.Remove(hiddenBubbleState.Key);
+      }
     }
 
-    foreach (var bubbleKey in hiddenBubbleKeys)
+    foreach (var hiddenBubbleState in hiddenBubbleStates)
     {
-      this.clearOverlay(bubbleKey, false);
+      this.TryRestoreNativeLayout(
+          hiddenBubbleState.Value.NativeLayoutSnapshot,
+          hiddenBubbleState.Value.NativeLayoutOriginalText);
+      this.clearOverlay(hiddenBubbleState.Key, false);
     }
+  }
+
+  /// <summary>
+  ///     Restores any native MiniTalk mutation currently tracked for the bubble
+  ///     when the source text changes or native mode is left.
+  /// </summary>
+  /// <param name="bubbleKey">The stable bubble key.</param>
+  /// <param name="nextOriginalText">
+  ///     The next original source text expected for the bubble, or an empty value
+  ///     when the current mutation should always be restored.
+  /// </param>
+  private void RestoreTrackedBubbleLayoutIfNeeded(
+      nint bubbleKey,
+      string? nextOriginalText = null)
+  {
+    NativeTextNodeLayoutSnapshot? snapshot = null;
+    string originalText = string.Empty;
+    var restoreText = string.IsNullOrWhiteSpace(nextOriginalText);
+
+    lock (this.stateGate)
+    {
+      if (!this.bubbleStates.TryGetValue(bubbleKey, out var state) ||
+          state.NativeLayoutSnapshot == null)
+      {
+        return;
+      }
+
+      if (!string.IsNullOrWhiteSpace(nextOriginalText) &&
+          this.TextMatches(state.NativeLayoutOriginalText, nextOriginalText))
+      {
+        return;
+      }
+
+      snapshot = state.NativeLayoutSnapshot;
+      originalText = state.NativeLayoutOriginalText;
+      state.NativeLayoutSnapshot = null;
+      state.NativeLayoutOriginalText = string.Empty;
+    }
+
+    this.TryRestoreNativeLayout(snapshot, originalText, restoreText);
+  }
+
+  /// <summary>
+  ///     Restores one tracked native MiniTalk layout snapshot back to the
+  ///     original game state.
+  /// </summary>
+  /// <param name="snapshot">The captured layout snapshot.</param>
+  /// <param name="originalText">The original text to write back.</param>
+  private void TryRestoreNativeLayout(
+      NativeTextNodeLayoutSnapshot? snapshot,
+      string originalText,
+      bool restoreText = true)
+  {
+    if (snapshot == null)
+    {
+      return;
+    }
+
+    NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
+        snapshot,
+        originalText,
+        restoreText);
   }
 
   /// <summary>
@@ -317,7 +391,20 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       }
 
       activeBubbleKeys.Add(bubbleNodeAddress);
+      if (!this.TryReadCurrentSource(bubbleNodeAddress, textNode, out var visibleOriginalText))
+      {
+        continue;
+      }
+
       this.updateOverlayBounds(bubbleNodeAddress, addon, textNode);
+
+      if (this.TryHandleVisibleSourceChange(
+              bubbleNodeAddress,
+              visibleOriginalText,
+              $"{type}-visible-reconcile"))
+      {
+        continue;
+      }
 
       // PluginRuntimeLog.Debug(
       //     $"[MiniTalk] trigger={type} addon=0x{((nint)addon):X} bubble=0x{bubbleNodeAddress:X} visible-update overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeText()} swap={this.ShouldSwapTexts()}");
@@ -328,21 +415,12 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
               out var translatedText,
               out var replacementText))
       {
-        if (this.TryReadCurrentSource(bubbleNodeAddress, textNode, out var visibleOriginalText))
+        if (this.TryCaptureOrQueueMiniTalkSource(
+                bubbleNodeAddress,
+                visibleOriginalText,
+                $"{type}-visible-fallback"))
         {
-          this.updateOverlayBounds(bubbleNodeAddress, addon, textNode);
-          if (this.TryCaptureOrQueueMiniTalkSource(
-                  bubbleNodeAddress,
-                  visibleOriginalText,
-                  $"{type}-visible-fallback"))
-          {
-            continue;
-          }
-        }
-        else
-        {
-          // PluginRuntimeLog.Debug(
-          //     $"[MiniTalk] trigger={type} addon=0x{((nint)addon):X} readable text unavailable {this.DescribeMiniTalkTextNode(textNode)}");
+          continue;
         }
 
         continue;
@@ -363,8 +441,13 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
 
       if (!this.ShouldApplyNativeText())
       {
+        this.RestoreTrackedBubbleLayoutIfNeeded(bubbleNodeAddress);
         continue;
       }
+
+      this.RestoreTrackedBubbleLayoutIfNeeded(
+          bubbleNodeAddress,
+          resolvedOriginalText);
 
       if (textNode == null)
       {
@@ -379,10 +462,23 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
         continue;
       }
 
-      NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
+      var layoutSnapshot = NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
           addon,
           textNode,
-          replacementText);
+          replacementText,
+          allowWidthGrowth: true);
+      if (layoutSnapshot != null)
+      {
+        lock (this.stateGate)
+        {
+          if (this.bubbleStates.TryGetValue(bubbleNodeAddress, out var state))
+          {
+            state.NativeLayoutSnapshot = layoutSnapshot;
+            state.NativeLayoutOriginalText = resolvedOriginalText;
+          }
+        }
+      }
+
       this.updateOverlayBounds(bubbleNodeAddress, addon, textNode);
     }
 
@@ -398,16 +494,19 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
   {
     // PluginRuntimeLog.Debug($"[MiniTalk] trigger={type} resetting mini talk state");
 
-    List<nint> bubbleKeys;
+    List<KeyValuePair<nint, BubbleState>> bubbleStates;
     lock (this.stateGate)
     {
-      bubbleKeys = this.bubbleStates.Keys.ToList();
+      bubbleStates = this.bubbleStates.ToList();
       this.bubbleStates.Clear();
     }
 
-    foreach (var bubbleKey in bubbleKeys)
+    foreach (var bubbleState in bubbleStates)
     {
-      this.clearOverlay(bubbleKey, true);
+      this.TryRestoreNativeLayout(
+          bubbleState.Value.NativeLayoutSnapshot,
+          bubbleState.Value.NativeLayoutOriginalText);
+      this.clearOverlay(bubbleState.Key, true);
     }
   }
 
@@ -879,6 +978,17 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       return false;
     }
 
+    if (NativeTextNodeLayoutHelper.TryResolveContainerNodes(
+            addon: null,
+            textNode,
+            out var containerNode,
+            out _) &&
+        containerNode != null &&
+        !containerNode->IsVisible())
+    {
+      return false;
+    }
+
     var viewport = ImGui.GetMainViewport();
     var left = textNode->ScreenX;
     var top = textNode->ScreenY;
@@ -933,8 +1043,135 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       }
     }
 
+    if (this.ShouldApplyNativeText())
+    {
+      if (this.TryReadOriginalPointerText(textNode, out var originalPointerText) &&
+          !this.TextMatches(originalPointerText, visibleText))
+      {
+        originalText = originalPointerText;
+        return true;
+      }
+
+      if (this.TryMapVisibleReplacementToKnownOriginal(visibleText, out var mappedOriginalText))
+      {
+        originalText = mappedOriginalText;
+        return true;
+      }
+    }
+
     originalText = visibleText;
     return true;
+  }
+
+  /// <summary>
+  ///     Tries to read the original game-provided text payload from a MiniTalk
+  ///     text node even when the visible node text has already been replaced.
+  /// </summary>
+  /// <param name="textNode">The text node to inspect.</param>
+  /// <param name="originalText">Receives the original payload text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the original payload can be read;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  private unsafe bool TryReadOriginalPointerText(
+      AtkTextNode* textNode,
+      out string originalText)
+  {
+    originalText = string.Empty;
+    if (textNode == null)
+    {
+      return false;
+    }
+
+    try
+    {
+      originalText = textNode->OriginalTextPointer.AsReadOnlySeStringSpan().ExtractText();
+      return !string.IsNullOrWhiteSpace(originalText);
+    }
+    catch
+    {
+      return false;
+    }
+  }
+
+  /// <summary>
+  ///     Tries to resolve a visible translated MiniTalk line back to an original
+  ///     source line already known to another tracked bubble state.
+  /// </summary>
+  /// <param name="visibleText">The visible text currently rendered by the node.</param>
+  /// <param name="originalText">Receives the matched original source line.</param>
+  /// <returns>
+  ///     <see langword="true" /> when a tracked replacement matches the visible
+  ///     line; otherwise, <see langword="false" />.
+  /// </returns>
+  private bool TryMapVisibleReplacementToKnownOriginal(
+      string visibleText,
+      out string originalText)
+  {
+    lock (this.stateGate)
+    {
+      foreach (var state in this.bubbleStates.Values)
+      {
+        if (string.IsNullOrWhiteSpace(state.CurrentOriginalText) ||
+            string.IsNullOrWhiteSpace(state.CurrentReplacementText))
+        {
+          continue;
+        }
+
+        if (this.TextMatches(visibleText, state.CurrentReplacementText))
+        {
+          originalText = state.CurrentOriginalText;
+          return true;
+        }
+      }
+    }
+
+    originalText = string.Empty;
+    return false;
+  }
+
+  /// <summary>
+  ///     Reconciles a visible MiniTalk source line against the tracked bubble
+  ///     state so recycled bubble slots do not keep using a stale translation or
+  ///     a stale native layout snapshot from the prior occupant.
+  /// </summary>
+  /// <param name="bubbleKey">The stable bubble key.</param>
+  /// <param name="visibleOriginalText">The current visible source line.</param>
+  /// <param name="trigger">The trigger label used for capture/queue routing.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the visible source changed and the new
+  ///     source was captured, restored, or queued; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool TryHandleVisibleSourceChange(
+      nint bubbleKey,
+      string visibleOriginalText,
+      string trigger)
+  {
+    var shouldReconcile = false;
+
+    lock (this.stateGate)
+    {
+      if (this.TryGetBubbleState(bubbleKey, out var state) &&
+          !string.IsNullOrWhiteSpace(state.CurrentOriginalText) &&
+          !this.TextMatches(state.CurrentOriginalText, visibleOriginalText))
+      {
+        shouldReconcile = true;
+      }
+    }
+
+    if (!shouldReconcile)
+    {
+      return false;
+    }
+
+    this.RestoreTrackedBubbleLayoutIfNeeded(
+        bubbleKey,
+        visibleOriginalText);
+    return this.TryCaptureOrQueueMiniTalkSource(
+        bubbleKey,
+        visibleOriginalText,
+        trigger);
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -378,6 +378,45 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
   }
 
   /// <summary>
+  ///     Restores the tracked native BattleTalk layout even when the visible
+  ///     source line has not changed, so a repeat native apply pass starts from
+  ///     the original addon geometry instead of stacking height and width
+  ///     mutations from the previous frame.
+  /// </summary>
+  /// <param name="originalName">The original sender name for the active line.</param>
+  /// <param name="originalText">The original source text for the active line.</param>
+  private void PrepareTrackedNativeLayoutForReapply(
+      string originalName,
+      string originalText)
+  {
+    NativeTextNodeLayoutSnapshot? layoutSnapshot = null;
+    string layoutOriginalName = string.Empty;
+    string layoutOriginalText = string.Empty;
+
+    lock (this.stateGate)
+    {
+      if (this.nativeLayoutSnapshot == null ||
+          this.nativeLayoutOriginalName != originalName ||
+          this.nativeLayoutOriginalText != originalText)
+      {
+        return;
+      }
+
+      layoutSnapshot = this.nativeLayoutSnapshot;
+      layoutOriginalName = this.nativeLayoutOriginalName;
+      layoutOriginalText = this.nativeLayoutOriginalText;
+      this.nativeLayoutSnapshot = null;
+      this.nativeLayoutOriginalName = string.Empty;
+      this.nativeLayoutOriginalText = string.Empty;
+    }
+
+    this.TryRestoreNativeLayout(
+        layoutSnapshot,
+        layoutOriginalName,
+        layoutOriginalText);
+  }
+
+  /// <summary>
   ///     Restores one tracked native BattleTalk layout snapshot back to the
   ///     original game state.
   /// </summary>
@@ -1231,10 +1270,10 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
         (nint)textNode->NodeText.StringPtr.Value);
 
     if (!string.IsNullOrWhiteSpace(replacementText) &&
-        visibleText == replacementText &&
+        this.TextMatchesForSourceMapping(visibleText, replacementText) &&
         (!this.ShouldTranslateBattleTalkNpcNames() ||
          string.IsNullOrWhiteSpace(replacementName) ||
-         visibleName == replacementName))
+         this.TextMatchesForSourceMapping(visibleName, replacementName)))
     {
       return;
     }
@@ -1242,10 +1281,14 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
     if (this.ShouldTranslateBattleTalkNpcNames() &&
         nameNode != null &&
         !string.IsNullOrWhiteSpace(translatedName) &&
-        visibleName != replacementName)
+        !this.TextMatchesForSourceMapping(visibleName, replacementName))
     {
       nameNode->SetText(replacementName);
     }
+
+    this.PrepareTrackedNativeLayoutForReapply(
+        originalName,
+        originalText);
 
     var backgroundNode = nineGridNode != null ? (AtkResNode*)nineGridNode : null;
     var layoutSnapshot = NativeTextNodeLayoutHelper.CaptureLayoutSnapshot(
@@ -1267,7 +1310,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
         parentNode,
         backgroundNode,
         timerNode,
-        allowWidthGrowth: true);
+        allowWidthGrowth: false);
 
     lock (this.stateGate)
     {

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -44,6 +44,9 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
   private string lastResolvedOriginalText = string.Empty;
   private string lastResolvedReplacementName = string.Empty;
   private string lastResolvedReplacementText = string.Empty;
+  private NativeTextNodeLayoutSnapshot? nativeLayoutSnapshot;
+  private string nativeLayoutOriginalName = string.Empty;
+  private string nativeLayoutOriginalText = string.Empty;
   private bool translationInFlight;
 
   /// <summary>
@@ -198,15 +201,25 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
 
       if (this.ShouldApplyNativeBattleTalkText())
       {
+        this.RestoreTrackedNativeLayoutIfNeeded(
+            originalName,
+            originalText);
         this.ApplyTranslatedNodes(
             battleTalkAddon,
+            originalName,
+            originalText,
             translatedName,
             replacementName,
             replacementText);
       }
+      else
+      {
+        this.RestoreTrackedNativeLayoutIfNeeded();
+      }
     }
     else
     {
+      this.RestoreTrackedNativeLayoutIfNeeded();
       this.ShowPendingSwapOverlayIfNeeded(originalName, originalText);
     }
 
@@ -234,6 +247,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
     {
       return;
     }
+
+    this.RestoreTrackedNativeLayoutIfNeeded();
 
     int scheduledGeneration;
     lock (this.stateGate)
@@ -271,6 +286,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
       return;
     }
 
+    this.RestoreTrackedNativeLayoutIfNeeded();
+
     lock (this.stateGate)
     {
       this.hideResetGeneration++;
@@ -306,7 +323,92 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
     this.currentTranslatedText = string.Empty;
     this.failedOriginalName = string.Empty;
     this.failedOriginalText = string.Empty;
+    this.nativeLayoutSnapshot = null;
+    this.nativeLayoutOriginalName = string.Empty;
+    this.nativeLayoutOriginalText = string.Empty;
     this.translationInFlight = false;
+  }
+
+  /// <summary>
+  ///     Restores any tracked native BattleTalk mutation when the source changes
+  ///     or native mode is left.
+  /// </summary>
+  /// <param name="nextOriginalName">
+  ///     The next original sender name expected for the addon, or an empty value
+  ///     when the current mutation should always be restored.
+  /// </param>
+  /// <param name="nextOriginalText">
+  ///     The next original source text expected for the addon, or an empty value
+  ///     when the current mutation should always be restored.
+  /// </param>
+  private void RestoreTrackedNativeLayoutIfNeeded(
+      string? nextOriginalName = null,
+      string? nextOriginalText = null)
+  {
+    NativeTextNodeLayoutSnapshot? layoutSnapshot = null;
+    string layoutOriginalName = string.Empty;
+    string layoutOriginalText = string.Empty;
+
+    lock (this.stateGate)
+    {
+      if (this.nativeLayoutSnapshot == null)
+      {
+        return;
+      }
+
+      if (!string.IsNullOrWhiteSpace(nextOriginalText) &&
+          this.nativeLayoutOriginalName == nextOriginalName &&
+          this.nativeLayoutOriginalText == nextOriginalText)
+      {
+        return;
+      }
+
+      layoutSnapshot = this.nativeLayoutSnapshot;
+      layoutOriginalName = this.nativeLayoutOriginalName;
+      layoutOriginalText = this.nativeLayoutOriginalText;
+      this.nativeLayoutSnapshot = null;
+      this.nativeLayoutOriginalName = string.Empty;
+      this.nativeLayoutOriginalText = string.Empty;
+    }
+
+    this.TryRestoreNativeLayout(
+        layoutSnapshot,
+        layoutOriginalName,
+        layoutOriginalText);
+  }
+
+  /// <summary>
+  ///     Restores one tracked native BattleTalk layout snapshot back to the
+  ///     original game state.
+  /// </summary>
+  /// <param name="layoutSnapshot">The captured layout snapshot.</param>
+  /// <param name="originalName">The original sender name to write back.</param>
+  /// <param name="originalText">The original text to write back.</param>
+  private unsafe void TryRestoreNativeLayout(
+      NativeTextNodeLayoutSnapshot? layoutSnapshot,
+      string originalName,
+      string originalText)
+  {
+    if (layoutSnapshot == null)
+    {
+      return;
+    }
+
+    var addonPtr = GameGuiInterface.GetAddonByName(BattleTalkAddonName);
+    if (addonPtr.Address != IntPtr.Zero)
+    {
+      var battleTalkAddon = (AtkUnitBase*)addonPtr.Address;
+      if (battleTalkAddon != null)
+      {
+        var nameNode = battleTalkAddon->GetTextNodeById(NameNodeId);
+        if (nameNode != null && !string.IsNullOrWhiteSpace(originalName))
+        {
+          nameNode->SetText(originalName);
+        }
+      }
+    }
+
+    NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(layoutSnapshot, originalText);
   }
 
   /// <summary>
@@ -1102,6 +1204,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
   /// </param>
   private unsafe void ApplyTranslatedNodes(
       AtkUnitBase* battleTalkAddon,
+      string originalName,
+      string originalText,
       string translatedName,
       string replacementName,
       string replacementText)
@@ -1151,7 +1255,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
         timerNode);
     var preferredWrapWidth = NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(
         textNode,
-        parentNode);
+        parentNode,
+        backgroundNode);
     var resizeResult = NativeTextNodeLayoutHelper.ApplyWrappedTextAndMeasure(
         textNode,
         replacementText,
@@ -1161,7 +1266,15 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
         resizeResult,
         parentNode,
         backgroundNode,
-        timerNode);
+        timerNode,
+        allowWidthGrowth: true);
+
+    lock (this.stateGate)
+    {
+      this.nativeLayoutSnapshot = layoutSnapshot;
+      this.nativeLayoutOriginalName = originalName;
+      this.nativeLayoutOriginalText = originalText;
+    }
   }
 }
 

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -413,7 +413,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
     this.TryRestoreNativeLayout(
         layoutSnapshot,
         layoutOriginalName,
-        layoutOriginalText);
+        layoutOriginalText,
+        restoreText: false);
   }
 
   /// <summary>
@@ -426,7 +427,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
   private unsafe void TryRestoreNativeLayout(
       NativeTextNodeLayoutSnapshot? layoutSnapshot,
       string originalName,
-      string originalText)
+      string originalText,
+      bool restoreText = true)
   {
     if (layoutSnapshot == null)
     {
@@ -440,14 +442,19 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler
       if (battleTalkAddon != null)
       {
         var nameNode = battleTalkAddon->GetTextNodeById(NameNodeId);
-        if (nameNode != null && !string.IsNullOrWhiteSpace(originalName))
+        if (restoreText &&
+            nameNode != null &&
+            !string.IsNullOrWhiteSpace(originalName))
         {
           nameNode->SetText(originalName);
         }
       }
     }
 
-    NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(layoutSnapshot, originalText);
+    NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
+        layoutSnapshot,
+        originalText,
+        restoreText);
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/AddonTextNodeResolvers.cs
+++ b/NativeUI/AddonHandlers/Toasts/AddonTextNodeResolvers.cs
@@ -87,11 +87,42 @@ internal static unsafe class AddonTextNodeResolvers
     }
 
     var seen = new HashSet<nint>();
-    CollectReadableTextNodes(
-        addon->UldManager.NodeList,
-        (int)addon->UldManager.NodeListCount,
-        bubbleNodes,
-        seen);
+    var nodeList = addon->UldManager.NodeList;
+    var nodeCount = (int)addon->UldManager.NodeListCount;
+    for (var i = 0; i < nodeCount; i++)
+    {
+      var node = nodeList[i];
+      if (node == null || !node->IsVisible())
+      {
+        continue;
+      }
+
+      if ((ushort)node->Type < 1000)
+      {
+        continue;
+      }
+
+      var componentNode = (AtkComponentNode*)node;
+      if (componentNode->Component == null)
+      {
+        continue;
+      }
+
+      var readableTextNode = ResolveFirstReadableTextNode(
+          componentNode->Component->UldManager.NodeList,
+          (int)componentNode->Component->UldManager.NodeListCount);
+      if (readableTextNode == null)
+      {
+        continue;
+      }
+
+      var textNodeAddress = (nint)readableTextNode;
+      if (seen.Add(textNodeAddress))
+      {
+        bubbleNodes.Add(textNodeAddress);
+      }
+    }
+
     return bubbleNodes;
   }
 

--- a/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs
@@ -645,14 +645,63 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
 
     if (this.ShouldApplyNativeToastText() &&
         this.TryReadOriginalPointerText(textNode, out var originalPointerText) &&
-        !this.TextMatches(originalPointerText, visibleText))
+        !this.TextMatches(originalPointerText, visibleText) &&
+        this.TryConfirmOriginalPointerMatchesVisible(
+            originalPointerText,
+            visibleText,
+            out var confirmedOriginalText))
     {
-      originalText = originalPointerText;
+      originalText = confirmedOriginalText;
       return true;
     }
 
     originalText = visibleText;
     return true;
+  }
+
+  /// <summary>
+  ///     Confirms that a toast node's original-text pointer really belongs to
+  ///     the currently visible toast text before the handler trusts it as the
+  ///     logical source line.
+  /// </summary>
+  /// <param name="originalPointerText">The text read from <c>OriginalTextPointer</c>.</param>
+  /// <param name="visibleText">The text currently visible in the node.</param>
+  /// <param name="originalText">Receives the confirmed original toast text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the pointer text can be proven to explain
+  ///     the visible replacement inside the same toast surface; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  protected bool TryConfirmOriginalPointerMatchesVisible(
+      string originalPointerText,
+      string visibleText,
+      out string originalText)
+  {
+    lock (this.stateGate)
+    {
+      if (this.TextMatches(this.currentOriginalText, originalPointerText) &&
+          this.TextMatches(visibleText, this.currentReplacementText))
+      {
+        originalText = originalPointerText;
+        return true;
+      }
+    }
+
+    var lookupToast = this.findToastMessage(
+        this.BuildLookupMessage(originalPointerText));
+    if (this.IsStoredTranslationUsable(lookupToast, originalPointerText))
+    {
+      var replacementText = this.NormalizeForReplacement(
+          lookupToast!.TranslatedToastMessage!);
+      if (this.TextMatches(visibleText, replacementText))
+      {
+        originalText = originalPointerText;
+        return true;
+      }
+    }
+
+    originalText = string.Empty;
+    return false;
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs
@@ -51,6 +51,8 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
   private string currentReplacementText = string.Empty;
   private string currentTranslatedText = string.Empty;
   private string lastFailedOriginalText = string.Empty;
+  private NativeTextNodeLayoutSnapshot? nativeLayoutSnapshot;
+  private string nativeLayoutOriginalText = string.Empty;
   private int overlayPublicationVersion;
   private bool translationInFlight;
 
@@ -206,30 +208,34 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
     }
 
     var textNode = this.resolveToastTextNode(addon);
+    if (!this.TryReadCurrentSource(textNode, out var visibleOriginalText))
+    {
+      return;
+    }
+
     this.updateOverlayBounds(addon, textNode);
     // PluginRuntimeLog.Debug(
     //     $"[{this.addonName}] trigger={type} visible-update " +
     //     $"overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeToastText()} " +
     //     $"swap={this.ShouldSwapTexts()}");
 
+    if (this.TryHandleVisibleSourceChange(
+            visibleOriginalText,
+            $"{type}-visible-reconcile"))
+    {
+      return;
+    }
+
     if (!this.TryGetCurrentResolvedTranslation(
             out var resolvedOriginalText,
             out var translatedText,
             out var replacementText))
     {
-      if (this.TryReadCurrentSource(textNode, out var visibleOriginalText))
+      if (this.TryCaptureOrQueueToastSource(
+              visibleOriginalText,
+              $"{type}-visible-fallback"))
       {
-        this.updateOverlayBounds(addon, textNode);
-        // PluginRuntimeLog.Debug(
-        //     $"[{this.addonName}] trigger={type} visible-capture source='{visibleOriginalText}' " +
-        //     $"overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeToastText()} " +
-        //     $"swap={this.ShouldSwapTexts()}");
-        if (this.TryCaptureOrQueueToastSource(
-                visibleOriginalText,
-                $"{type}-visible-fallback"))
-        {
-          return;
-        }
+        return;
       }
 
       return;
@@ -248,8 +254,11 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
 
     if (!this.ShouldApplyNativeToastText())
     {
+      this.RestoreTrackedNativeLayoutIfNeeded();
       return;
     }
+
+    this.RestoreTrackedNativeLayoutIfNeeded(resolvedOriginalText);
 
     if (textNode == null || textNode->NodeText.IsEmpty)
     {
@@ -264,10 +273,20 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
 
     // PluginRuntimeLog.Debug(
     //     $"[{this.addonName}] trigger={type} applying native replacement");
-    NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
+    var layoutSnapshot = NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
         addon,
         textNode,
-        replacementText);
+        replacementText,
+        allowWidthGrowth: true);
+    if (layoutSnapshot != null)
+    {
+      lock (this.stateGate)
+      {
+        this.nativeLayoutSnapshot = layoutSnapshot;
+        this.nativeLayoutOriginalText = resolvedOriginalText;
+      }
+    }
+
     this.updateOverlayBounds(addon, textNode);
   }
 
@@ -338,6 +357,8 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
     var shouldDelayOverlayClear = this.ShouldUseOverlay();
     var resetRequestId = 0;
     var publicationVersion = 0;
+    NativeTextNodeLayoutSnapshot? layoutSnapshot = null;
+    string layoutOriginalText = string.Empty;
 
     lock (this.stateGate)
     {
@@ -347,9 +368,15 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
       this.currentReplacementText = string.Empty;
       this.translationInFlight = false;
       this.lastFailedOriginalText = string.Empty;
+      layoutSnapshot = this.nativeLayoutSnapshot;
+      layoutOriginalText = this.nativeLayoutOriginalText;
+      this.nativeLayoutSnapshot = null;
+      this.nativeLayoutOriginalText = string.Empty;
       resetRequestId = this.activeRequestId;
       publicationVersion = this.overlayPublicationVersion;
     }
+
+    this.TryRestoreNativeLayout(layoutSnapshot, layoutOriginalText);
 
     if (shouldDelayOverlayClear)
     {
@@ -358,6 +385,104 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
     }
 
     this.clearOverlay();
+  }
+
+  /// <summary>
+  ///     Restores any tracked native toast mutation when the source changes or
+  ///     native mode is left.
+  /// </summary>
+  /// <param name="nextOriginalText">
+  ///     The next original source text expected for the toast, or an empty value
+  ///     when the current mutation should always be restored.
+  /// </param>
+  protected void RestoreTrackedNativeLayoutIfNeeded(string? nextOriginalText = null)
+  {
+    NativeTextNodeLayoutSnapshot? layoutSnapshot = null;
+    string layoutOriginalText = string.Empty;
+    var restoreText = string.IsNullOrWhiteSpace(nextOriginalText);
+
+    lock (this.stateGate)
+    {
+      if (this.nativeLayoutSnapshot == null)
+      {
+        return;
+      }
+
+      if (!string.IsNullOrWhiteSpace(nextOriginalText) &&
+          this.TextMatches(this.nativeLayoutOriginalText, nextOriginalText))
+      {
+        return;
+      }
+
+      layoutSnapshot = this.nativeLayoutSnapshot;
+      layoutOriginalText = this.nativeLayoutOriginalText;
+      this.nativeLayoutSnapshot = null;
+      this.nativeLayoutOriginalText = string.Empty;
+    }
+
+    this.TryRestoreNativeLayout(
+        layoutSnapshot,
+        layoutOriginalText,
+        restoreText);
+  }
+
+  /// <summary>
+  ///     Restores one tracked native toast layout snapshot back to the original
+  ///     game state.
+  /// </summary>
+  /// <param name="layoutSnapshot">The captured layout snapshot.</param>
+  /// <param name="originalText">The original text to write back.</param>
+  protected void TryRestoreNativeLayout(
+      NativeTextNodeLayoutSnapshot? layoutSnapshot,
+      string originalText,
+      bool restoreText = true)
+  {
+    if (layoutSnapshot == null)
+    {
+      return;
+    }
+
+    NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
+        layoutSnapshot,
+        originalText,
+        restoreText);
+  }
+
+  /// <summary>
+  ///     Reconciles the visible toast source against the tracked state so a
+  ///     recycled toast slot does not keep a stale translated line or a stale
+  ///     native layout snapshot from the prior source.
+  /// </summary>
+  /// <param name="visibleOriginalText">The currently visible toast source.</param>
+  /// <param name="trigger">The trigger label used for capture or queueing.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the source changed and the new source was
+  ///     handled immediately; otherwise, <see langword="false" />.
+  /// </returns>
+  protected bool TryHandleVisibleSourceChange(
+      string visibleOriginalText,
+      string trigger)
+  {
+    var shouldReconcile = false;
+
+    lock (this.stateGate)
+    {
+      if (!string.IsNullOrWhiteSpace(this.currentOriginalText) &&
+          !this.TextMatches(this.currentOriginalText, visibleOriginalText))
+      {
+        shouldReconcile = true;
+      }
+    }
+
+    if (!shouldReconcile)
+    {
+      return false;
+    }
+
+    this.RestoreTrackedNativeLayoutIfNeeded(visibleOriginalText);
+    return this.TryCaptureOrQueueToastSource(
+        visibleOriginalText,
+        trigger);
   }
 
   /// <summary>
@@ -518,8 +643,47 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
       }
     }
 
+    if (this.ShouldApplyNativeToastText() &&
+        this.TryReadOriginalPointerText(textNode, out var originalPointerText) &&
+        !this.TextMatches(originalPointerText, visibleText))
+    {
+      originalText = originalPointerText;
+      return true;
+    }
+
     originalText = visibleText;
     return true;
+  }
+
+  /// <summary>
+  ///     Tries to read the original game-provided text payload from a toast text
+  ///     node even when the visible node text has already been replaced.
+  /// </summary>
+  /// <param name="textNode">The text node to inspect.</param>
+  /// <param name="originalText">Receives the original payload text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the original payload can be read;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  protected unsafe bool TryReadOriginalPointerText(
+      AtkTextNode* textNode,
+      out string originalText)
+  {
+    originalText = string.Empty;
+    if (textNode == null)
+    {
+      return false;
+    }
+
+    try
+    {
+      originalText = textNode->OriginalTextPointer.AsReadOnlySeStringSpan().ExtractText();
+      return !string.IsNullOrWhiteSpace(originalText);
+    }
+    catch
+    {
+      return false;
+    }
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs
@@ -277,7 +277,8 @@ internal class AddonTextToastHandler : IAddonTranslationHandler
         addon,
         textNode,
         replacementText,
-        allowWidthGrowth: true);
+        allowWidthGrowth: true,
+        restoreHorizontalCentering: false);
     if (layoutSnapshot != null)
     {
       lock (this.stateGate)

--- a/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
@@ -35,6 +35,8 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
   private string currentReplacementText = string.Empty;
   private string currentTranslatedText = string.Empty;
   private string lastFailedOriginalText = string.Empty;
+  private NativeTextNodeLayoutSnapshot? nativeLayoutSnapshot;
+  private string nativeLayoutOriginalText = string.Empty;
   private bool translationInFlight;
 
   /// <summary>
@@ -150,46 +152,7 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
     //     $"[{TextGimmickHintAddonName}] trigger={type} captured source='{originalText}' " +
     //     $"overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeText()} " +
     //     $"swap={this.ShouldSwapTexts()}");
-
-    if (this.TryGetCachedTranslation(
-            originalText,
-            out var translatedText,
-            out _))
-    {
-      // PluginRuntimeLog.Debug(
-      //     $"[{TextGimmickHintAddonName}] trigger={type} cache-hit -> overlay publish");
-      this.SetResolvedState(
-          originalText,
-          translatedText,
-          this.NormalizeForReplacement(translatedText));
-      this.PublishOverlay(originalText, translatedText, type.ToString());
-      return;
-    }
-
-    var lookupToast = this.BuildLookupMessage(originalText);
-    var storedToast = this.findTextGimmickHintMessage(lookupToast);
-    if (this.IsStoredTranslationUsable(storedToast, originalText))
-    {
-      // PluginRuntimeLog.Debug(
-      //     $"[{TextGimmickHintAddonName}] trigger={type} db-hit -> overlay publish");
-      this.SetResolvedState(
-          originalText,
-          storedToast!.TranslatedText!,
-          this.NormalizeForReplacement(storedToast.TranslatedText!));
-      this.PublishOverlay(
-          originalText,
-          storedToast.TranslatedText!,
-          type.ToString());
-      return;
-    }
-
-    if (this.TryQueueTranslation(originalText, out var requestId))
-    {
-      // PluginRuntimeLog.Debug(
-      //     $"[{TextGimmickHintAddonName}] trigger={type} cache-miss -> queued translation request #{requestId}");
-      this.PublishOverlay(originalText, string.Empty, type.ToString());
-      Task.Run(() => this.ResolveTranslationAsync(originalText, requestId));
-    }
+    this.TryCaptureOrQueueSource(originalText, type.ToString());
   }
 
   /// <summary>
@@ -206,17 +169,36 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
     }
 
     var textNode = this.resolveToastTextNode(addon);
+    if (!this.TryReadCurrentSource(textNode, out var visibleOriginalText))
+    {
+      return;
+    }
+
     this.updateOverlayBounds(addon, textNode);
     // PluginRuntimeLog.Debug(
     //     $"[{TextGimmickHintAddonName}] trigger={type} visible-update " +
     //     $"overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeText()} " +
     //     $"swap={this.ShouldSwapTexts()}");
 
+    if (this.TryHandleVisibleSourceChange(
+            visibleOriginalText,
+            $"{type}-visible-reconcile"))
+    {
+      return;
+    }
+
     if (!this.TryGetCurrentResolvedTranslation(
             out var resolvedOriginalText,
             out var translatedText,
             out var replacementText))
     {
+      if (this.TryCaptureOrQueueSource(
+              visibleOriginalText,
+              $"{type}-visible-fallback"))
+      {
+        return;
+      }
+
       return;
     }
 
@@ -236,8 +218,11 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
 
     if (!this.ShouldApplyNativeText())
     {
+      this.RestoreTrackedNativeLayoutIfNeeded();
       return;
     }
+
+    this.RestoreTrackedNativeLayoutIfNeeded(resolvedOriginalText);
 
     if (textNode == null || textNode->NodeText.IsEmpty)
     {
@@ -252,10 +237,20 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
 
     // PluginRuntimeLog.Debug(
     //     $"[{TextGimmickHintAddonName}] trigger={type} applying native replacement");
-    NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
+    var layoutSnapshot = NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
         addon,
         textNode,
-        replacementText);
+        replacementText,
+        allowWidthGrowth: true);
+    if (layoutSnapshot != null)
+    {
+      lock (this.stateGate)
+      {
+        this.nativeLayoutSnapshot = layoutSnapshot;
+        this.nativeLayoutOriginalText = resolvedOriginalText;
+      }
+    }
+
     this.updateOverlayBounds(addon, textNode);
   }
 
@@ -267,6 +262,8 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
   private void OnResetState(AddonEvent type, AddonArgs args)
   {
     // PluginRuntimeLog.Debug($"[{TextGimmickHintAddonName}] trigger={type} resetting toast state");
+    NativeTextNodeLayoutSnapshot? layoutSnapshot = null;
+    string layoutOriginalText = string.Empty;
     lock (this.stateGate)
     {
       this.activeRequestId++;
@@ -275,9 +272,164 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
       this.currentReplacementText = string.Empty;
       this.translationInFlight = false;
       this.lastFailedOriginalText = string.Empty;
+      layoutSnapshot = this.nativeLayoutSnapshot;
+      layoutOriginalText = this.nativeLayoutOriginalText;
+      this.nativeLayoutSnapshot = null;
+      this.nativeLayoutOriginalText = string.Empty;
     }
 
+    this.TryRestoreNativeLayout(layoutSnapshot, layoutOriginalText);
     this.clearOverlay();
+  }
+
+  /// <summary>
+  ///     Restores any tracked native gimmick-hint mutation when the source
+  ///     changes or native mode is left.
+  /// </summary>
+  /// <param name="nextOriginalText">
+  ///     The next original source text expected for the hint, or an empty value
+  ///     when the current mutation should always be restored.
+  /// </param>
+  private void RestoreTrackedNativeLayoutIfNeeded(string? nextOriginalText = null)
+  {
+    NativeTextNodeLayoutSnapshot? layoutSnapshot = null;
+    string layoutOriginalText = string.Empty;
+    var restoreText = string.IsNullOrWhiteSpace(nextOriginalText);
+
+    lock (this.stateGate)
+    {
+      if (this.nativeLayoutSnapshot == null)
+      {
+        return;
+      }
+
+      if (!string.IsNullOrWhiteSpace(nextOriginalText) &&
+          this.TextMatches(this.nativeLayoutOriginalText, nextOriginalText))
+      {
+        return;
+      }
+
+      layoutSnapshot = this.nativeLayoutSnapshot;
+      layoutOriginalText = this.nativeLayoutOriginalText;
+      this.nativeLayoutSnapshot = null;
+      this.nativeLayoutOriginalText = string.Empty;
+    }
+
+    this.TryRestoreNativeLayout(
+        layoutSnapshot,
+        layoutOriginalText,
+        restoreText);
+  }
+
+  /// <summary>
+  ///     Restores one tracked native gimmick-hint layout snapshot back to the
+  ///     original game state.
+  /// </summary>
+  /// <param name="layoutSnapshot">The captured layout snapshot.</param>
+  /// <param name="originalText">The original text to write back.</param>
+  private void TryRestoreNativeLayout(
+      NativeTextNodeLayoutSnapshot? layoutSnapshot,
+      string originalText,
+      bool restoreText = true)
+  {
+    if (layoutSnapshot == null)
+    {
+      return;
+    }
+
+    NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
+        layoutSnapshot,
+        originalText,
+        restoreText);
+  }
+
+  /// <summary>
+  ///     Reconciles the visible gimmick-hint source against the tracked state so
+  ///     a recycled slot does not keep a stale translated line or a stale native
+  ///     layout snapshot from the prior source.
+  /// </summary>
+  /// <param name="visibleOriginalText">The currently visible source line.</param>
+  /// <param name="trigger">The trigger label used for capture or queueing.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the source changed and the new source was
+  ///     handled immediately; otherwise, <see langword="false" />.
+  /// </returns>
+  private bool TryHandleVisibleSourceChange(
+      string visibleOriginalText,
+      string trigger)
+  {
+    var shouldReconcile = false;
+
+    lock (this.stateGate)
+    {
+      if (!string.IsNullOrWhiteSpace(this.currentOriginalText) &&
+          !this.TextMatches(this.currentOriginalText, visibleOriginalText))
+      {
+        shouldReconcile = true;
+      }
+    }
+
+    if (!shouldReconcile)
+    {
+      return false;
+    }
+
+    this.RestoreTrackedNativeLayoutIfNeeded(visibleOriginalText);
+    return this.TryCaptureOrQueueSource(
+        visibleOriginalText,
+        trigger);
+  }
+
+  /// <summary>
+  ///     Resolves the visible TextGimmickHint source line against cache,
+  ///     database, or background translation work without blocking the game UI.
+  /// </summary>
+  /// <param name="originalText">The current visible source line.</param>
+  /// <param name="trigger">The trigger label associated with the call.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the source was handled immediately;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  private bool TryCaptureOrQueueSource(
+      string originalText,
+      string trigger)
+  {
+    if (this.TryGetCachedTranslation(
+            originalText,
+            out var translatedText,
+            out _))
+    {
+      this.SetResolvedState(
+          originalText,
+          translatedText,
+          this.NormalizeForReplacement(translatedText));
+      this.PublishOverlay(originalText, translatedText, trigger);
+      return true;
+    }
+
+    var lookupToast = this.BuildLookupMessage(originalText);
+    var storedToast = this.findTextGimmickHintMessage(lookupToast);
+    if (this.IsStoredTranslationUsable(storedToast, originalText))
+    {
+      this.SetResolvedState(
+          originalText,
+          storedToast!.TranslatedText!,
+          this.NormalizeForReplacement(storedToast.TranslatedText!));
+      this.PublishOverlay(
+          originalText,
+          storedToast.TranslatedText!,
+          trigger);
+      return true;
+    }
+
+    if (this.TryQueueTranslation(originalText, out var requestId))
+    {
+      this.PublishOverlay(originalText, string.Empty, trigger);
+      Task.Run(() => this.ResolveTranslationAsync(originalText, requestId));
+      return true;
+    }
+
+    return false;
   }
 
   /// <summary>
@@ -733,8 +885,47 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
       }
     }
 
+    if (this.ShouldApplyNativeText() &&
+        this.TryReadOriginalPointerText(textNode, out var originalPointerText) &&
+        !this.TextMatches(originalPointerText, visibleText))
+    {
+      originalText = originalPointerText;
+      return true;
+    }
+
     originalText = visibleText;
     return true;
+  }
+
+  /// <summary>
+  ///     Tries to read the original game-provided text payload from a gimmick-hint
+  ///     text node even when the visible node text has already been replaced.
+  /// </summary>
+  /// <param name="textNode">The text node to inspect.</param>
+  /// <param name="originalText">Receives the original payload text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the original payload can be read;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  private unsafe bool TryReadOriginalPointerText(
+      AtkTextNode* textNode,
+      out string originalText)
+  {
+    originalText = string.Empty;
+    if (textNode == null)
+    {
+      return false;
+    }
+
+    try
+    {
+      originalText = textNode->OriginalTextPointer.AsReadOnlySeStringSpan().ExtractText();
+      return !string.IsNullOrWhiteSpace(originalText);
+    }
+    catch
+    {
+      return false;
+    }
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
@@ -887,14 +887,60 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
 
     if (this.ShouldApplyNativeText() &&
         this.TryReadOriginalPointerText(textNode, out var originalPointerText) &&
-        !this.TextMatches(originalPointerText, visibleText))
+        !this.TextMatches(originalPointerText, visibleText) &&
+        this.TryConfirmOriginalPointerMatchesVisible(
+            originalPointerText,
+            visibleText,
+            out var confirmedOriginalText))
     {
-      originalText = originalPointerText;
+      originalText = confirmedOriginalText;
       return true;
     }
 
     originalText = visibleText;
     return true;
+  }
+
+  /// <summary>
+  ///     Confirms that a gimmick-hint node's original-text pointer really
+  ///     belongs to the currently visible text before the handler trusts it as
+  ///     the logical source line.
+  /// </summary>
+  /// <param name="originalPointerText">The text read from <c>OriginalTextPointer</c>.</param>
+  /// <param name="visibleText">The text currently visible in the node.</param>
+  /// <param name="originalText">Receives the confirmed original text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the pointer text can be proven to explain
+  ///     the visible replacement inside the same gimmick-hint surface;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  private bool TryConfirmOriginalPointerMatchesVisible(
+      string originalPointerText,
+      string visibleText,
+      out string originalText)
+  {
+    lock (this.stateGate)
+    {
+      if (this.TextMatches(this.currentOriginalText, originalPointerText) &&
+          this.TextMatches(visibleText, this.currentReplacementText))
+      {
+        originalText = originalPointerText;
+        return true;
+      }
+    }
+
+    if (this.TryLoadStoredTranslation(
+            originalPointerText,
+            out _,
+            out var replacementText) &&
+        this.TextMatches(visibleText, replacementText))
+    {
+      originalText = originalPointerText;
+      return true;
+    }
+
+    originalText = string.Empty;
+    return false;
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
@@ -241,7 +241,8 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
         addon,
         textNode,
         replacementText,
-        allowWidthGrowth: true);
+        allowWidthGrowth: true,
+        restoreHorizontalCentering: false);
     if (layoutSnapshot != null)
     {
       lock (this.stateGate)

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs
@@ -1,0 +1,313 @@
+// <copyright file="ToastGuiCaptureRuntime.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
+
+/// <summary>
+///     Uses Dalamud's <see cref="IToastGui" /> callbacks to capture supported
+///     normal and error toast source payloads before the addon-node handlers
+///     read the live UI.
+/// </summary>
+/// <remarks>
+///     This runtime is intentionally conservative. It does not replace the
+///     addon-handler presentation path, and it does not publish overlays or
+///     mutate native nodes. It only prefetches translations into the existing
+///     toast persistence path so the addon handlers can later reuse the same
+///     cache/DB semantics with lower latency and less dependence on reading a
+///     live node that may already be mutated.
+/// </remarks>
+internal sealed class ToastGuiCaptureRuntime
+{
+  private const string ErrorToastType = "Error";
+  private const string NonErrorToastType = "NonError";
+
+  private readonly Config config;
+  private readonly Func<ToastMessage, ToastMessage?> findToastMessage;
+  private readonly object stateGate = new();
+  private readonly Func<ToastMessage, Task<string>> insertToastMessageAsync;
+  private readonly HashSet<string> inFlightKeys = [];
+  private readonly TranslationService translationService;
+
+  /// <summary>
+  ///     Initializes a new instance of the
+  ///     <see cref="ToastGuiCaptureRuntime" /> class.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <param name="translationService">The shared translation service.</param>
+  /// <param name="findToastMessage">
+  ///     Delegate used to look up previously translated toast rows.
+  /// </param>
+  /// <param name="insertToastMessageAsync">
+  ///     Delegate used to persist translated toast rows.
+  /// </param>
+  public ToastGuiCaptureRuntime(
+      Config config,
+      TranslationService translationService,
+      Func<ToastMessage, ToastMessage?> findToastMessage,
+      Func<ToastMessage, Task<string>> insertToastMessageAsync)
+  {
+    this.config = config;
+    this.translationService = translationService;
+    this.findToastMessage = findToastMessage;
+    this.insertToastMessageAsync = insertToastMessageAsync;
+  }
+
+  /// <summary>
+  ///     Handles generic normal-toast callbacks from Dalamud and opportunistically
+  ///     prefetches translations for supported addon-backed toast surfaces.
+  /// </summary>
+  /// <param name="message">The toast payload.</param>
+  /// <param name="options">The generic toast options.</param>
+  /// <param name="isHandled">
+  ///     Whether another callback already consumed the toast.
+  /// </param>
+  public void HandleNormalToast(
+      ref SeString message,
+      ref ToastOptions options,
+      ref bool isHandled)
+  {
+    if (!this.ShouldCaptureNormalToasts())
+    {
+      return;
+    }
+
+    this.TryPrefetchToast(
+        NonErrorToastType,
+        message.TextValue);
+  }
+
+  /// <summary>
+  ///     Handles error-toast callbacks from Dalamud and opportunistically
+  ///     prefetches translations for the native error-toast addon.
+  /// </summary>
+  /// <param name="message">The toast payload.</param>
+  /// <param name="isHandled">
+  ///     Whether another callback already consumed the toast.
+  /// </param>
+  public void HandleErrorToast(
+      ref SeString message,
+      ref bool isHandled)
+  {
+    if (!this.ShouldCaptureErrorToasts())
+    {
+      return;
+    }
+
+    this.TryPrefetchToast(
+        ErrorToastType,
+        message.TextValue);
+  }
+
+  /// <summary>
+  ///     Determines whether the experimental ToastGui-assisted capture path
+  ///     should run for normal toasts.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when supported normal toasts should be
+  ///     prefetched from ToastGui; otherwise, <see langword="false" />.
+  /// </returns>
+  private bool ShouldCaptureNormalToasts()
+  {
+    return this.config.TranslateToast &&
+           this.config.UseToastGuiCaptureForSupportedToasts &&
+           (this.config.TranslateWideTextToast ||
+            this.config.TranslateAreaToast ||
+            this.config.TranslateClassChangeToast);
+  }
+
+  /// <summary>
+  ///     Determines whether the experimental ToastGui-assisted capture path
+  ///     should run for error toasts.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when error toasts should be prefetched from
+  ///     ToastGui; otherwise, <see langword="false" />.
+  /// </returns>
+  private bool ShouldCaptureErrorToasts()
+  {
+    return this.config.TranslateToast &&
+           this.config.UseToastGuiCaptureForSupportedToasts &&
+           this.config.TranslateErrorToast;
+  }
+
+  /// <summary>
+  ///     Prefetches one toast source line into the existing translation
+  ///     persistence path when no usable translated row already exists.
+  /// </summary>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <param name="originalText">The original toast text.</param>
+  private void TryPrefetchToast(
+      string toastType,
+      string originalText)
+  {
+    if (string.IsNullOrWhiteSpace(originalText))
+    {
+      return;
+    }
+
+    var lookupToast = this.BuildLookupMessage(
+        toastType,
+        originalText);
+    var storedToast = this.findToastMessage(lookupToast);
+    if (this.IsStoredTranslationUsable(
+            storedToast,
+            originalText,
+            toastType))
+    {
+      return;
+    }
+
+    if (!this.TryBeginPrefetch(
+            toastType,
+            originalText,
+            out var inFlightKey))
+    {
+      return;
+    }
+
+    Task.Run(() => this.ResolveTranslationAsync(
+        toastType,
+        originalText,
+        inFlightKey));
+  }
+
+  /// <summary>
+  ///     Starts one background prefetch request when the same toast line is not
+  ///     already being resolved.
+  /// </summary>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="inFlightKey">
+  ///     Receives the unique in-flight key for the request.
+  /// </param>
+  /// <returns>
+  ///     <see langword="true" /> when a new request should be queued;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  private bool TryBeginPrefetch(
+      string toastType,
+      string originalText,
+      out string inFlightKey)
+  {
+    inFlightKey = this.BuildInFlightKey(
+        toastType,
+        originalText);
+
+    lock (this.stateGate)
+    {
+      return this.inFlightKeys.Add(inFlightKey);
+    }
+  }
+
+  /// <summary>
+  ///     Resolves one toast translation asynchronously and persists it into the
+  ///     existing toast history tables when successful.
+  /// </summary>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="inFlightKey">The key representing the queued request.</param>
+  /// <returns>A task that completes when the translation attempt finishes.</returns>
+  private async Task ResolveTranslationAsync(
+      string toastType,
+      string originalText,
+      string inFlightKey)
+  {
+    try
+    {
+      var translatedText = await this.translationService.TranslateAsync(
+          originalText,
+          ClientStateInterface.ClientLanguage.Humanize(),
+          LangDict[LanguageInt].Code) ?? string.Empty;
+      if (string.IsNullOrWhiteSpace(translatedText))
+      {
+        return;
+      }
+
+      await this.insertToastMessageAsync(
+          new ToastMessage(
+              toastType,
+              originalText,
+              ClientStateInterface.ClientLanguage.Humanize(),
+              translatedText,
+              LangDict[LanguageInt].Code,
+              this.config.ChosenTransEngine,
+              DateTime.Now,
+              DateTime.Now));
+    }
+    finally
+    {
+      lock (this.stateGate)
+      {
+        this.inFlightKeys.Remove(inFlightKey);
+      }
+    }
+  }
+
+  /// <summary>
+  ///     Builds a lookup entity matching the historical toast schema already
+  ///     used by the plugin database.
+  /// </summary>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <returns>A formatted <see cref="ToastMessage" /> for DB lookup.</returns>
+  private ToastMessage BuildLookupMessage(
+      string toastType,
+      string originalText)
+  {
+    return new ToastMessage(
+        toastType,
+        originalText,
+        ClientStateInterface.ClientLanguage.Humanize(),
+        string.Empty,
+        LangDict[LanguageInt].Code,
+        this.config.ChosenTransEngine,
+        DateTime.Now,
+        DateTime.Now);
+  }
+
+  /// <summary>
+  ///     Determines whether a stored toast row already contains a usable
+  ///     translation for the observed callback payload.
+  /// </summary>
+  /// <param name="toastMessage">The stored row to validate.</param>
+  /// <param name="originalText">The expected original toast text.</param>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the stored row can be reused; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool IsStoredTranslationUsable(
+      ToastMessage? toastMessage,
+      string originalText,
+      string toastType)
+  {
+    return toastMessage != null &&
+           string.Equals(
+               toastMessage.ToastType,
+               toastType,
+               StringComparison.OrdinalIgnoreCase) &&
+           string.Equals(
+               toastMessage.OriginalToastMessage,
+               originalText,
+               StringComparison.Ordinal) &&
+           !string.IsNullOrWhiteSpace(
+               toastMessage.TranslatedToastMessage);
+  }
+
+  /// <summary>
+  ///     Builds the in-flight key used to deduplicate concurrent callback
+  ///     prefetch requests.
+  /// </summary>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <returns>The stable in-flight dedupe key.</returns>
+  private string BuildInFlightKey(
+      string toastType,
+      string originalText)
+  {
+    return
+        $"{toastType}|{ClientStateInterface.ClientLanguage.Humanize()}|{LangDict[LanguageInt].Code}|{this.config.ChosenTransEngine}|{originalText}";
+  }
+}

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs
@@ -110,11 +110,8 @@ internal sealed class ToastGuiCaptureRuntime
   /// </returns>
   private bool ShouldCaptureNormalToasts()
   {
-    return this.config.TranslateToast &&
-           this.config.UseToastGuiCaptureForSupportedToasts &&
-           (this.config.TranslateWideTextToast ||
-            this.config.TranslateAreaToast ||
-            this.config.TranslateClassChangeToast);
+    return ToastGuiSupportedToastPolicy.UseLegacyNormalToastCapturePrefetch(
+        this.config);
   }
 
   /// <summary>
@@ -127,9 +124,8 @@ internal sealed class ToastGuiCaptureRuntime
   /// </returns>
   private bool ShouldCaptureErrorToasts()
   {
-    return this.config.TranslateToast &&
-           this.config.UseToastGuiCaptureForSupportedToasts &&
-           this.config.TranslateErrorToast;
+    return ToastGuiSupportedToastPolicy.UseLegacyErrorToastCapturePrefetch(
+        this.config);
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiRouteState.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiRouteState.cs
@@ -1,0 +1,28 @@
+// <copyright file="ToastGuiRouteState.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
+
+/// <summary>
+///     Describes which family-level route currently owns one supported toast
+///     path at runtime.
+/// </summary>
+internal enum ToastGuiRouteState
+{
+  /// <summary>
+  ///     The legacy addon-handler route remains active.
+  /// </summary>
+  LegacyAddonHandlers,
+
+  /// <summary>
+  ///     The legacy ToastGui capture-only prefetch path is active.
+  /// </summary>
+  ToastGuiCapturePrefetch,
+
+  /// <summary>
+  ///     The alternate full ToastGui runtime owns the route.
+  /// </summary>
+  ToastGuiFullRuntime,
+}

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs
@@ -1,0 +1,111 @@
+// <copyright file="ToastGuiSupportedToastPolicy.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
+
+/// <summary>
+///     Centralizes the family-level routing rules for the alternate
+///     ToastGui-owned runtime path. Under that route, supported normal toasts
+///     are intentionally treated as one unified logical family rather than as
+///     addon-specific subtypes.
+/// </summary>
+internal static class ToastGuiSupportedToastPolicy
+{
+  /// <summary>
+  ///     Gets whether the alternate callback-owned ToastGui route is enabled at
+  ///     all.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the alternate ToastGui route is enabled;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  public static bool UseSupportedToastGuiRuntime(Config config)
+  {
+    return config.TranslateToast &&
+           config.UseToastGuiRuntimeForSupportedToasts;
+  }
+
+  /// <summary>
+  ///     Gets whether the alternate callback-owned ToastGui route should own
+  ///     the unified normal-toast family.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the alternate route should own the
+  ///     supported non-error toast family; otherwise, <see langword="false" />.
+  /// </returns>
+  public static bool UseSupportedNormalToastRuntime(Config config)
+  {
+    return UseSupportedToastGuiRuntime(config);
+  }
+
+  /// <summary>
+  ///     Gets whether the alternate callback-owned ToastGui route should own
+  ///     error toasts.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the alternate route should own error
+  ///     toasts; otherwise, <see langword="false" />.
+  /// </returns>
+  public static bool UseSupportedErrorToastRuntime(Config config)
+  {
+    return UseSupportedToastGuiRuntime(config) &&
+           config.TranslateErrorToast;
+  }
+
+  /// <summary>
+  ///     Gets the canonical family-level display mode used by the alternate
+  ///     callback-owned runtime for the unified normal-toast family.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>
+  ///     The effective family-level display mode for supported non-error
+  ///     toasts, currently sourced from the wide-text toast config.
+  /// </returns>
+  public static JournalTranslationDisplayMode GetNormalToastDisplayMode(
+      Config config)
+  {
+    return config.WideTextToastTranslationDisplayMode;
+  }
+
+  /// <summary>
+  ///     Gets whether the legacy ToastGui prefetch-only path should stay active
+  ///     for supported normal toasts.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the capture-only path should remain
+  ///     active; otherwise, <see langword="false" />.
+  /// </returns>
+  public static bool UseLegacyNormalToastCapturePrefetch(Config config)
+  {
+    return config.TranslateToast &&
+           config.UseToastGuiCaptureForSupportedToasts &&
+           !UseSupportedNormalToastRuntime(config) &&
+           (config.TranslateWideTextToast ||
+            config.TranslateAreaToast ||
+            config.TranslateClassChangeToast);
+  }
+
+  /// <summary>
+  ///     Gets whether the legacy ToastGui prefetch-only path should stay active
+  ///     for error toasts.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the capture-only error-toast path should
+  ///     remain active; otherwise, <see langword="false" />.
+  /// </returns>
+  public static bool UseLegacyErrorToastCapturePrefetch(Config config)
+  {
+    return config.TranslateToast &&
+           config.UseToastGuiCaptureForSupportedToasts &&
+           !UseSupportedErrorToastRuntime(config) &&
+           config.TranslateErrorToast;
+  }
+
+}

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs
@@ -14,6 +14,48 @@ namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
 internal static class ToastGuiSupportedToastPolicy
 {
   /// <summary>
+  ///     Gets the effective route state for the supported normal-toast family.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>The effective route state for supported normal toasts.</returns>
+  public static ToastGuiRouteState GetSupportedNormalToastRouteState(
+      Config config)
+  {
+    if (UseSupportedNormalToastRuntime(config))
+    {
+      return ToastGuiRouteState.ToastGuiFullRuntime;
+    }
+
+    if (UseLegacyNormalToastCapturePrefetch(config))
+    {
+      return ToastGuiRouteState.ToastGuiCapturePrefetch;
+    }
+
+    return ToastGuiRouteState.LegacyAddonHandlers;
+  }
+
+  /// <summary>
+  ///     Gets the effective route state for supported error toasts.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <returns>The effective route state for supported error toasts.</returns>
+  public static ToastGuiRouteState GetSupportedErrorToastRouteState(
+      Config config)
+  {
+    if (UseSupportedErrorToastRuntime(config))
+    {
+      return ToastGuiRouteState.ToastGuiFullRuntime;
+    }
+
+    if (UseLegacyErrorToastCapturePrefetch(config))
+    {
+      return ToastGuiRouteState.ToastGuiCapturePrefetch;
+    }
+
+    return ToastGuiRouteState.LegacyAddonHandlers;
+  }
+
+  /// <summary>
   ///     Gets whether the alternate callback-owned ToastGui route is enabled at
   ///     all.
   /// </summary>

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs
@@ -6,10 +6,9 @@
 namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
 
 /// <summary>
-///     Centralizes the family-level routing rules for the alternate
-///     ToastGui-owned runtime path. Under that route, supported normal toasts
-///     are intentionally treated as one unified logical family rather than as
-///     addon-specific subtypes.
+///     Centralizes the family-level routing rules for the ToastGui-owned
+///     runtime path. Supported normal toasts are intentionally treated as one
+///     unified logical family rather than as addon-specific subtypes.
 /// </summary>
 internal static class ToastGuiSupportedToastPolicy
 {
@@ -56,22 +55,20 @@ internal static class ToastGuiSupportedToastPolicy
   }
 
   /// <summary>
-  ///     Gets whether the alternate callback-owned ToastGui route is enabled at
-  ///     all.
+  ///     Gets whether the callback-owned ToastGui route is enabled at all.
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
   /// <returns>
-  ///     <see langword="true" /> when the alternate ToastGui route is enabled;
+  ///     <see langword="true" /> when the ToastGui route is enabled;
   ///     otherwise, <see langword="false" />.
   /// </returns>
   public static bool UseSupportedToastGuiRuntime(Config config)
   {
-    return config.TranslateToast &&
-           config.UseToastGuiRuntimeForSupportedToasts;
+    return config.TranslateToast;
   }
 
   /// <summary>
-  ///     Gets whether the alternate callback-owned ToastGui route should own
+  ///     Gets whether the callback-owned ToastGui route should own
   ///     the unified normal-toast family.
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
@@ -85,7 +82,7 @@ internal static class ToastGuiSupportedToastPolicy
   }
 
   /// <summary>
-  ///     Gets whether the alternate callback-owned ToastGui route should own
+  ///     Gets whether the callback-owned ToastGui route should own
   ///     error toasts.
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
@@ -100,7 +97,7 @@ internal static class ToastGuiSupportedToastPolicy
   }
 
   /// <summary>
-  ///     Gets the canonical family-level display mode used by the alternate
+  ///     Gets the canonical family-level display mode used by the
   ///     callback-owned runtime for the unified normal-toast family.
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
@@ -115,8 +112,7 @@ internal static class ToastGuiSupportedToastPolicy
   }
 
   /// <summary>
-  ///     Gets whether the legacy ToastGui prefetch-only path should stay active
-  ///     for supported normal toasts.
+  ///     Gets whether the legacy ToastGui prefetch-only path should stay active.
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
   /// <returns>
@@ -125,12 +121,8 @@ internal static class ToastGuiSupportedToastPolicy
   /// </returns>
   public static bool UseLegacyNormalToastCapturePrefetch(Config config)
   {
-    return config.TranslateToast &&
-           config.UseToastGuiCaptureForSupportedToasts &&
-           !UseSupportedNormalToastRuntime(config) &&
-           (config.TranslateWideTextToast ||
-            config.TranslateAreaToast ||
-            config.TranslateClassChangeToast);
+    _ = config;
+    return false;
   }
 
   /// <summary>
@@ -144,10 +136,8 @@ internal static class ToastGuiSupportedToastPolicy
   /// </returns>
   public static bool UseLegacyErrorToastCapturePrefetch(Config config)
   {
-    return config.TranslateToast &&
-           config.UseToastGuiCaptureForSupportedToasts &&
-           !UseSupportedErrorToastRuntime(config) &&
-           config.TranslateErrorToast;
+    _ = config;
+    return false;
   }
 
 }

--- a/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastRuntime.cs
+++ b/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastRuntime.cs
@@ -1,0 +1,803 @@
+// <copyright file="ToastGuiSupportedToastRuntime.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
+
+/// <summary>
+///     Owns the alternate callback-driven ToastGui route for supported normal
+///     and error toasts. Under this path, supported normal toasts are treated
+///     as one logical family and no longer rely on addon-specific native
+///     mutation or overlay anchoring.
+/// </summary>
+internal sealed class ToastGuiSupportedToastRuntime
+{
+  private const string ErrorToastType = "Error";
+  private const string NormalToastType = "NonError";
+  private const int ErrorOverlayLifetimeMs = 5000;
+  private const int FastNormalOverlayLifetimeMs = 3500;
+  private const int SlowNormalOverlayLifetimeMs = 5500;
+
+  private readonly Action clearErrorOverlay;
+  private readonly Action clearNormalOverlay;
+  private readonly Config config;
+  private readonly Func<ToastMessage, ToastMessage?> findToastMessage;
+  private readonly Func<ToastMessage, Task<string>> insertToastMessageAsync;
+  private readonly Func<string, string> normalizeReplacementText;
+  private readonly object stateGate = new();
+  private readonly TranslationService translationService;
+  private readonly Action<string, string, string> updateErrorOverlay;
+  private readonly Action<string, string, string> updateNormalOverlay;
+
+  private int activeErrorRequestId;
+  private int activeNormalRequestId;
+  private string currentErrorOriginalText = string.Empty;
+  private string currentNormalOriginalText = string.Empty;
+  private ToastPosition currentNormalToastPosition = ToastPosition.Top;
+  private ToastSpeed currentNormalToastSpeed = ToastSpeed.Fast;
+
+  /// <summary>
+  ///     Initializes a new instance of the
+  ///     <see cref="ToastGuiSupportedToastRuntime" /> class.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <param name="translationService">The shared translation service.</param>
+  /// <param name="findToastMessage">The shared toast DB lookup delegate.</param>
+  /// <param name="insertToastMessageAsync">
+  ///     The shared toast persistence delegate.
+  /// </param>
+  /// <param name="updateNormalOverlay">
+  ///     Delegate used to publish content into the unified normal-toast
+  ///     overlay.
+  /// </param>
+  /// <param name="clearNormalOverlay">
+  ///     Delegate used to clear the unified normal-toast overlay.
+  /// </param>
+  /// <param name="updateErrorOverlay">
+  ///     Delegate used to publish content into the error-toast overlay.
+  /// </param>
+  /// <param name="clearErrorOverlay">
+  ///     Delegate used to clear the error-toast overlay.
+  /// </param>
+  /// <param name="normalizeReplacementText">
+  ///     Delegate used to normalize text before native replacement when the
+  ///     game font requires it.
+  /// </param>
+  public ToastGuiSupportedToastRuntime(
+      Config config,
+      TranslationService translationService,
+      Func<ToastMessage, ToastMessage?> findToastMessage,
+      Func<ToastMessage, Task<string>> insertToastMessageAsync,
+      Action<string, string, string> updateNormalOverlay,
+      Action clearNormalOverlay,
+      Action<string, string, string> updateErrorOverlay,
+      Action clearErrorOverlay,
+      Func<string, string> normalizeReplacementText)
+  {
+    this.config = config;
+    this.translationService = translationService;
+    this.findToastMessage = findToastMessage;
+    this.insertToastMessageAsync = insertToastMessageAsync;
+    this.updateNormalOverlay = updateNormalOverlay;
+    this.clearNormalOverlay = clearNormalOverlay;
+    this.updateErrorOverlay = updateErrorOverlay;
+    this.clearErrorOverlay = clearErrorOverlay;
+    this.normalizeReplacementText = normalizeReplacementText;
+  }
+
+  /// <summary>
+  ///     Handles generic normal-toast callbacks through the alternate family
+  ///     route.
+  /// </summary>
+  /// <param name="message">The toast payload.</param>
+  /// <param name="options">The toast options supplied by Dalamud.</param>
+  /// <param name="isHandled">Whether another callback consumed the toast.</param>
+  public void HandleNormalToast(
+      ref SeString message,
+      ref ToastOptions options,
+      ref bool isHandled)
+  {
+    if (!ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+            this.config))
+    {
+      return;
+    }
+
+    var originalText = message.TextValue;
+    if (string.IsNullOrWhiteSpace(originalText))
+    {
+      return;
+    }
+
+    var requestId = this.BeginNormalRequest(originalText, options);
+    var storedToast = this.findToastMessage(
+        this.BuildLookupMessage(
+            NormalToastType,
+            originalText));
+    if (this.IsStoredTranslationUsable(
+            storedToast,
+            originalText,
+            NormalToastType))
+    {
+      this.ApplyResolvedNormalToast(
+          ref message,
+          originalText,
+          storedToast!.TranslatedToastMessage!,
+          requestId);
+      return;
+    }
+
+    this.PublishNormalOverlay(originalText, string.Empty, "IToastGui.Toast");
+    Task.Run(() => this.ResolveNormalTranslationAsync(originalText, requestId));
+  }
+
+  /// <summary>
+  ///     Handles error-toast callbacks through the alternate callback-owned
+  ///     route.
+  /// </summary>
+  /// <param name="message">The error-toast payload.</param>
+  /// <param name="isHandled">Whether another callback consumed the toast.</param>
+  public void HandleErrorToast(
+      ref SeString message,
+      ref bool isHandled)
+  {
+    if (!ToastGuiSupportedToastPolicy.UseSupportedErrorToastRuntime(
+            this.config))
+    {
+      return;
+    }
+
+    var originalText = message.TextValue;
+    if (string.IsNullOrWhiteSpace(originalText))
+    {
+      return;
+    }
+
+    var requestId = this.BeginErrorRequest(originalText);
+    var storedToast = this.findToastMessage(
+        this.BuildLookupMessage(
+            ErrorToastType,
+            originalText));
+    if (this.IsStoredTranslationUsable(
+            storedToast,
+            originalText,
+            ErrorToastType))
+    {
+      this.ApplyResolvedErrorToast(
+          ref message,
+          originalText,
+          storedToast!.TranslatedToastMessage!,
+          requestId);
+      return;
+    }
+
+    this.PublishErrorOverlay(originalText, string.Empty, "IToastGui.ErrorToast");
+    Task.Run(() => this.ResolveErrorTranslationAsync(originalText, requestId));
+  }
+
+  /// <summary>
+  ///     Synchronizes the unified normal-toast overlay to a stable viewport
+  ///     anchor based on the last callback-reported toast position.
+  /// </summary>
+  /// <param name="overlay">The overlay to synchronize.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the overlay currently has visible
+  ///     content; otherwise, <see langword="false" />.
+  /// </returns>
+  public bool TrySyncNormalToastOverlayToViewport(TranslationOverlay overlay)
+  {
+    overlay.Semaphore.Wait();
+    var shouldDisplay = overlay.Display;
+    overlay.Semaphore.Release();
+    if (!shouldDisplay)
+    {
+      return false;
+    }
+
+    ToastPosition toastPosition;
+    lock (this.stateGate)
+    {
+      toastPosition = this.currentNormalToastPosition;
+    }
+
+    var viewport = ImGui.GetMainViewport();
+    var width = viewport.Size.X * 0.35f;
+    var height = 56f;
+    var positionY = toastPosition == ToastPosition.Bottom
+        ? viewport.Pos.Y + (viewport.Size.Y * 0.84f)
+        : viewport.Pos.Y + (viewport.Size.Y * 0.14f);
+
+    overlay.Position = new Vector2(
+        viewport.Pos.X + ((viewport.Size.X - width) * 0.5f),
+        positionY);
+    overlay.Dimensions = new Vector2(width, height);
+    return true;
+  }
+
+  /// <summary>
+  ///     Synchronizes the error-toast overlay to a stable top-center viewport
+  ///     anchor.
+  /// </summary>
+  /// <param name="overlay">The overlay to synchronize.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the overlay currently has visible
+  ///     content; otherwise, <see langword="false" />.
+  /// </returns>
+  public bool TrySyncErrorToastOverlayToViewport(TranslationOverlay overlay)
+  {
+    overlay.Semaphore.Wait();
+    var shouldDisplay = overlay.Display;
+    overlay.Semaphore.Release();
+    if (!shouldDisplay)
+    {
+      return false;
+    }
+
+    var viewport = ImGui.GetMainViewport();
+    overlay.Position = new Vector2(
+        viewport.Pos.X + (viewport.Size.X * 0.325f),
+        viewport.Pos.Y + (viewport.Size.Y * 0.18f));
+    overlay.Dimensions = new Vector2(
+        viewport.Size.X * 0.35f,
+        56f);
+    return true;
+  }
+
+  /// <summary>
+  ///     Applies one cache-hit normal toast immediately to the current callback.
+  /// </summary>
+  /// <param name="message">The live callback payload.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="translatedText">The translated toast text.</param>
+  /// <param name="requestId">The active request identifier.</param>
+  private void ApplyResolvedNormalToast(
+      ref SeString message,
+      string originalText,
+      string translatedText,
+      int requestId)
+  {
+    if (this.ShouldUseNormalOverlay())
+    {
+      this.PublishNormalOverlay(originalText, translatedText, "IToastGui.Toast");
+      _ = this.ScheduleNormalOverlayClearAsync(requestId);
+      if (!this.ShouldSwapNormalTexts())
+      {
+        return;
+      }
+    }
+
+    if (!this.ShouldApplyNativeNormalText())
+    {
+      return;
+    }
+
+    if (!this.ShouldUseNormalOverlay())
+    {
+      this.clearNormalOverlay();
+    }
+
+    message = this.NormalizeForReplacement(translatedText);
+  }
+
+  /// <summary>
+  ///     Applies one cache-hit error toast immediately to the current callback.
+  /// </summary>
+  /// <param name="message">The live callback payload.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="translatedText">The translated toast text.</param>
+  /// <param name="requestId">The active request identifier.</param>
+  private void ApplyResolvedErrorToast(
+      ref SeString message,
+      string originalText,
+      string translatedText,
+      int requestId)
+  {
+    if (this.ShouldUseErrorOverlay())
+    {
+      this.PublishErrorOverlay(originalText, translatedText, "IToastGui.ErrorToast");
+      _ = this.ScheduleErrorOverlayClearAsync(requestId);
+      if (!this.ShouldSwapErrorTexts())
+      {
+        return;
+      }
+    }
+
+    if (!this.ShouldApplyNativeErrorText())
+    {
+      return;
+    }
+
+    if (!this.ShouldUseErrorOverlay())
+    {
+      this.clearErrorOverlay();
+    }
+
+    message = this.NormalizeForReplacement(translatedText);
+  }
+
+  /// <summary>
+  ///     Resolves one supported normal-toast line asynchronously.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="requestId">The active request identifier.</param>
+  /// <returns>A task that completes after the translation attempt.</returns>
+  private async Task ResolveNormalTranslationAsync(
+      string originalText,
+      int requestId)
+  {
+    string translatedText;
+    try
+    {
+      translatedText = await this.translationService.TranslateAsync(
+          originalText,
+          ClientStateInterface.ClientLanguage.Humanize(),
+          LangDict[LanguageInt].Code) ?? string.Empty;
+    }
+    catch
+    {
+      return;
+    }
+
+    if (string.IsNullOrWhiteSpace(translatedText))
+    {
+      return;
+    }
+
+    await this.insertToastMessageAsync(
+        new ToastMessage(
+            NormalToastType,
+            originalText,
+            ClientStateInterface.ClientLanguage.Humanize(),
+            translatedText,
+            LangDict[LanguageInt].Code,
+            this.config.ChosenTransEngine,
+            DateTime.Now,
+            DateTime.Now));
+
+    if (!this.IsCurrentNormalRequest(requestId, originalText))
+    {
+      return;
+    }
+
+    if (!this.ShouldUseNormalOverlay())
+    {
+      return;
+    }
+
+    this.PublishNormalOverlay(originalText, translatedText, "async-resolve");
+    _ = this.ScheduleNormalOverlayClearAsync(requestId);
+  }
+
+  /// <summary>
+  ///     Resolves one supported error-toast line asynchronously.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="requestId">The active request identifier.</param>
+  /// <returns>A task that completes after the translation attempt.</returns>
+  private async Task ResolveErrorTranslationAsync(
+      string originalText,
+      int requestId)
+  {
+    string translatedText;
+    try
+    {
+      translatedText = await this.translationService.TranslateAsync(
+          originalText,
+          ClientStateInterface.ClientLanguage.Humanize(),
+          LangDict[LanguageInt].Code) ?? string.Empty;
+    }
+    catch
+    {
+      return;
+    }
+
+    if (string.IsNullOrWhiteSpace(translatedText))
+    {
+      return;
+    }
+
+    await this.insertToastMessageAsync(
+        new ToastMessage(
+            ErrorToastType,
+            originalText,
+            ClientStateInterface.ClientLanguage.Humanize(),
+            translatedText,
+            LangDict[LanguageInt].Code,
+            this.config.ChosenTransEngine,
+            DateTime.Now,
+            DateTime.Now));
+
+    if (!this.IsCurrentErrorRequest(requestId, originalText))
+    {
+      return;
+    }
+
+    if (!this.ShouldUseErrorOverlay())
+    {
+      return;
+    }
+
+    this.PublishErrorOverlay(originalText, translatedText, "async-resolve");
+    _ = this.ScheduleErrorOverlayClearAsync(requestId);
+  }
+
+  /// <summary>
+  ///     Starts one supported normal-toast request.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="options">The current toast options.</param>
+  /// <returns>The active request identifier.</returns>
+  private int BeginNormalRequest(
+      string originalText,
+      ToastOptions options)
+  {
+    lock (this.stateGate)
+    {
+      this.activeNormalRequestId++;
+      this.currentNormalOriginalText = originalText;
+      this.currentNormalToastPosition = options.Position;
+      this.currentNormalToastSpeed = options.Speed;
+      return this.activeNormalRequestId;
+    }
+  }
+
+  /// <summary>
+  ///     Starts one error-toast request.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <returns>The active request identifier.</returns>
+  private int BeginErrorRequest(string originalText)
+  {
+    lock (this.stateGate)
+    {
+      this.activeErrorRequestId++;
+      this.currentErrorOriginalText = originalText;
+      return this.activeErrorRequestId;
+    }
+  }
+
+  /// <summary>
+  ///     Delays clearing the unified normal-toast overlay so the overlay
+  ///     lifetime roughly matches the transient toast lifetime.
+  /// </summary>
+  /// <param name="requestId">The owning request identifier.</param>
+  /// <returns>A task that completes after the clear delay.</returns>
+  private async Task ScheduleNormalOverlayClearAsync(int requestId)
+  {
+    await Task.Delay(this.GetNormalOverlayLifetimeMs());
+
+    lock (this.stateGate)
+    {
+      if (requestId != this.activeNormalRequestId)
+      {
+        return;
+      }
+
+      this.currentNormalOriginalText = string.Empty;
+    }
+
+    this.clearNormalOverlay();
+  }
+
+  /// <summary>
+  ///     Delays clearing the error-toast overlay so the overlay lifetime roughly
+  ///     matches the transient toast lifetime.
+  /// </summary>
+  /// <param name="requestId">The owning request identifier.</param>
+  /// <returns>A task that completes after the clear delay.</returns>
+  private async Task ScheduleErrorOverlayClearAsync(int requestId)
+  {
+    await Task.Delay(ErrorOverlayLifetimeMs);
+
+    lock (this.stateGate)
+    {
+      if (requestId != this.activeErrorRequestId)
+      {
+        return;
+      }
+
+      this.currentErrorOriginalText = string.Empty;
+    }
+
+    this.clearErrorOverlay();
+  }
+
+  /// <summary>
+  ///     Gets the overlay lifetime for the current supported normal-toast
+  ///     request.
+  /// </summary>
+  /// <returns>The overlay clear delay in milliseconds.</returns>
+  private int GetNormalOverlayLifetimeMs()
+  {
+    lock (this.stateGate)
+    {
+      return this.currentNormalToastSpeed == ToastSpeed.Fast
+          ? FastNormalOverlayLifetimeMs
+          : SlowNormalOverlayLifetimeMs;
+    }
+  }
+
+  /// <summary>
+  ///     Determines whether the specified request still belongs to the current
+  ///     supported normal-toast line.
+  /// </summary>
+  /// <param name="requestId">The request identifier to validate.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the request is still current; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool IsCurrentNormalRequest(
+      int requestId,
+      string originalText)
+  {
+    lock (this.stateGate)
+    {
+      return requestId == this.activeNormalRequestId &&
+             string.Equals(
+                 this.currentNormalOriginalText,
+                 originalText,
+                 StringComparison.Ordinal);
+    }
+  }
+
+  /// <summary>
+  ///     Determines whether the specified request still belongs to the current
+  ///     error-toast line.
+  /// </summary>
+  /// <param name="requestId">The request identifier to validate.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the request is still current; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool IsCurrentErrorRequest(
+      int requestId,
+      string originalText)
+  {
+    lock (this.stateGate)
+    {
+      return requestId == this.activeErrorRequestId &&
+             string.Equals(
+                 this.currentErrorOriginalText,
+                 originalText,
+                 StringComparison.Ordinal);
+    }
+  }
+
+  /// <summary>
+  ///     Gets whether the unified normal-toast family should publish overlay
+  ///     text.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when the unified normal-toast overlay is
+  ///     active; otherwise, <see langword="false" />.
+  /// </returns>
+  private bool ShouldUseNormalOverlay()
+  {
+    return TranslationDisplayModeHelper.UsesOverlayPresentation(
+        ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(this.config),
+        this.config.OverlayOnlyLanguage);
+  }
+
+  /// <summary>
+  ///     Gets whether the unified normal-toast family should write translated
+  ///     text into the native toast callback payload.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when native replacement is active; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool ShouldApplyNativeNormalText()
+  {
+    return TranslationDisplayModeHelper.WritesNativeTranslation(
+        ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(this.config),
+        this.config.OverlayOnlyLanguage);
+  }
+
+  /// <summary>
+  ///     Gets whether the unified normal-toast overlay should show original text
+  ///     while the native toast displays the translation.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when swap mode is active; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool ShouldSwapNormalTexts()
+  {
+    return TranslationDisplayModeHelper.ShowsOriginalOverlayText(
+        ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(this.config),
+        this.config.OverlayOnlyLanguage);
+  }
+
+  /// <summary>
+  ///     Gets whether error toasts should publish overlay text.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when the error-toast overlay is active;
+  ///     otherwise, <see langword="false" />.
+  /// </returns>
+  private bool ShouldUseErrorOverlay()
+  {
+    return TranslationDisplayModeHelper.UsesOverlayPresentation(
+        this.config.ErrorToastTranslationDisplayMode,
+        this.config.OverlayOnlyLanguage);
+  }
+
+  /// <summary>
+  ///     Gets whether error toasts should write translated text into the native
+  ///     callback payload.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when native replacement is active; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool ShouldApplyNativeErrorText()
+  {
+    return TranslationDisplayModeHelper.WritesNativeTranslation(
+        this.config.ErrorToastTranslationDisplayMode,
+        this.config.OverlayOnlyLanguage);
+  }
+
+  /// <summary>
+  ///     Gets whether the error-toast overlay should show the original text
+  ///     while the native error toast displays the translation.
+  /// </summary>
+  /// <returns>
+  ///     <see langword="true" /> when swap mode is active; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool ShouldSwapErrorTexts()
+  {
+    return TranslationDisplayModeHelper.ShowsOriginalOverlayText(
+        this.config.ErrorToastTranslationDisplayMode,
+        this.config.OverlayOnlyLanguage);
+  }
+
+  /// <summary>
+  ///     Publishes content into the unified normal-toast overlay.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="translatedText">The translated toast text.</param>
+  /// <param name="trigger">The trigger label associated with the call.</param>
+  private void PublishNormalOverlay(
+      string originalText,
+      string translatedText,
+      string trigger)
+  {
+    if (!this.ShouldUseNormalOverlay())
+    {
+      this.clearNormalOverlay();
+      return;
+    }
+
+    var overlayText = this.SelectOverlayText(
+        originalText,
+        translatedText,
+        this.ShouldSwapNormalTexts());
+    if (string.IsNullOrWhiteSpace(overlayText))
+    {
+      this.clearNormalOverlay();
+      return;
+    }
+
+    this.updateNormalOverlay(string.Empty, overlayText, string.Empty);
+  }
+
+  /// <summary>
+  ///     Publishes content into the error-toast overlay.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="translatedText">The translated toast text.</param>
+  /// <param name="trigger">The trigger label associated with the call.</param>
+  private void PublishErrorOverlay(
+      string originalText,
+      string translatedText,
+      string trigger)
+  {
+    if (!this.ShouldUseErrorOverlay())
+    {
+      this.clearErrorOverlay();
+      return;
+    }
+
+    var overlayText = this.SelectOverlayText(
+        originalText,
+        translatedText,
+        this.ShouldSwapErrorTexts());
+    if (string.IsNullOrWhiteSpace(overlayText))
+    {
+      this.clearErrorOverlay();
+      return;
+    }
+
+    this.updateErrorOverlay(string.Empty, overlayText, string.Empty);
+  }
+
+  /// <summary>
+  ///     Selects the overlay text for one callback-owned toast route.
+  /// </summary>
+  /// <param name="originalText">The original toast text.</param>
+  /// <param name="translatedText">The translated toast text.</param>
+  /// <param name="showOriginalOverlayText">
+  ///     Whether the overlay should show the original text.
+  /// </param>
+  /// <returns>The overlay text to display.</returns>
+  private string SelectOverlayText(
+      string originalText,
+      string translatedText,
+      bool showOriginalOverlayText)
+  {
+    if (showOriginalOverlayText &&
+        !string.IsNullOrWhiteSpace(originalText))
+    {
+      return originalText;
+    }
+
+    return translatedText;
+  }
+
+  /// <summary>
+  ///     Builds one toast DB lookup entity using the plugin's existing toast
+  ///     persistence schema.
+  /// </summary>
+  /// <param name="toastType">The persisted toast type.</param>
+  /// <param name="originalText">The original toast text.</param>
+  /// <returns>A lookup <see cref="ToastMessage" />.</returns>
+  private ToastMessage BuildLookupMessage(
+      string toastType,
+      string originalText)
+  {
+    return new ToastMessage(
+        toastType,
+        originalText,
+        ClientStateInterface.ClientLanguage.Humanize(),
+        string.Empty,
+        LangDict[LanguageInt].Code,
+        this.config.ChosenTransEngine,
+        DateTime.Now,
+        DateTime.Now);
+  }
+
+  /// <summary>
+  ///     Determines whether one stored toast row contains a usable translation
+  ///     for the requested source line and toast type.
+  /// </summary>
+  /// <param name="toastMessage">The stored row to validate.</param>
+  /// <param name="originalText">The expected original text.</param>
+  /// <param name="toastType">The expected toast type.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the stored row is usable; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool IsStoredTranslationUsable(
+      ToastMessage? toastMessage,
+      string originalText,
+      string toastType)
+  {
+    return toastMessage != null &&
+           string.Equals(
+               toastMessage.ToastType,
+               toastType,
+               StringComparison.Ordinal) &&
+           string.Equals(
+               toastMessage.OriginalToastMessage,
+               originalText,
+               StringComparison.Ordinal) &&
+           !string.IsNullOrWhiteSpace(toastMessage.TranslatedToastMessage);
+  }
+
+  /// <summary>
+  ///     Normalizes translated text before native replacement when the game font
+  ///     requires it.
+  /// </summary>
+  /// <param name="translatedText">The translated text to normalize.</param>
+  /// <returns>The text that should be written back into the callback payload.</returns>
+  private string NormalizeForReplacement(string translatedText)
+  {
+    return this.config.RemoveDiacriticsWhenUsingReplacementTalkBTalk
+        ? this.normalizeReplacementText(translatedText)
+        : translatedText;
+  }
+}

--- a/NativeUI/Helpers/AddonHandlerWiring.cs
+++ b/NativeUI/Helpers/AddonHandlerWiring.cs
@@ -266,7 +266,9 @@ public partial class Echoglossian
               Handler: new ScenarioTreeHandler(questAddonDependencies)));
     }
 
-    if (this.configuration.TranslateToast &&
+    if (!NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+            this.configuration) &&
+        this.configuration.TranslateToast &&
         this.configuration.TranslateWideTextToast)
     {
       this.registeredAddonHandlers.Add(
@@ -290,7 +292,9 @@ public partial class Echoglossian
                       this.SpecialCharsSupportedByGameFont))));
     }
 
-    if (this.configuration.TranslateToast &&
+    if (!NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedErrorToastRuntime(
+            this.configuration) &&
+        this.configuration.TranslateToast &&
         this.configuration.TranslateErrorToast)
     {
       this.registeredAddonHandlers.Add(
@@ -316,7 +320,9 @@ public partial class Echoglossian
                       this.SpecialCharsSupportedByGameFont))));
     }
 
-    if (this.configuration.TranslateToast &&
+    if (!NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+            this.configuration) &&
+        this.configuration.TranslateToast &&
         this.configuration.TranslateAreaToast)
     {
       this.registeredAddonHandlers.Add(
@@ -342,7 +348,9 @@ public partial class Echoglossian
                       this.SpecialCharsSupportedByGameFont))));
     }
 
-    if (this.configuration.TranslateToast &&
+    if (!NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+            this.configuration) &&
+        this.configuration.TranslateToast &&
         this.configuration.TranslateClassChangeToast)
     {
       this.registeredAddonHandlers.Add(

--- a/NativeUI/Helpers/AddonProbeAutoWatchHelpers.cs
+++ b/NativeUI/Helpers/AddonProbeAutoWatchHelpers.cs
@@ -1,0 +1,190 @@
+// <copyright file="AddonProbeAutoWatchHelpers.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+
+namespace Echoglossian;
+
+#if DEBUG
+/// <summary>
+///     Hosts debug-only automatic addon-probe watches that start on login for
+///     selected addons with early hidden-state value.
+/// </summary>
+public partial class Echoglossian
+{
+  private static readonly TimeSpan DefaultAutoAddonProbeDuration =
+      TimeSpan.FromMinutes(15);
+
+  private static readonly (string AddonName, int Index)[] DefaultAutoAddonProbeTargets =
+  [
+      ("_BattleTalk", 0),
+      ("_MiniTalk", 0),
+  ];
+
+  /// <summary>
+  ///     Ticks manual and automatic addon-probe watches, including the
+  ///     debug-only login bootstrap for the default watch set.
+  /// </summary>
+  private void TickAddonProbeInfrastructure()
+  {
+    this.TickManualAddonProbeWatch();
+    this.TickManagedAddonProbeWatches();
+    this.TickAutoAddonProbeWatches();
+  }
+
+  /// <summary>
+  ///     Gets how many addon-probe watches are currently active across manual
+  ///     and managed watch sets.
+  /// </summary>
+  /// <returns>The active probe-watch count.</returns>
+  private int GetActiveAddonProbeWatchCount()
+  {
+    return (this.addonProbeWatch is null ? 0 : 1) +
+           this.addonManagedProbeWatches.Count;
+  }
+
+  /// <summary>
+  ///     Stops every active addon-probe watch known to the plugin.
+  /// </summary>
+  /// <param name="suppressAutoUntilLogout">
+  ///     Whether the current login session should suppress the default
+  ///     automatic watch set after the stop completes.
+  /// </param>
+  private void StopAllAddonProbeWatches(bool suppressAutoUntilLogout = false)
+  {
+    this.StopManualAddonProbeWatch();
+    this.StopManagedAddonProbeWatches();
+
+    if (suppressAutoUntilLogout)
+    {
+      this.autoAddonProbeSuppressedUntilLogout = true;
+      this.autoAddonProbeStartedForCurrentLogin = true;
+    }
+  }
+
+  /// <summary>
+  ///     Ticks the currently active manual addon-probe watch, if any.
+  /// </summary>
+  private void TickManualAddonProbeWatch()
+  {
+    this.addonProbeWatch?.Tick();
+    if (this.addonProbeWatch?.IsDisposed == true)
+    {
+      this.addonProbeWatch = null;
+    }
+  }
+
+  /// <summary>
+  ///     Ticks every managed addon-probe watch and prunes the disposed ones.
+  /// </summary>
+  private void TickManagedAddonProbeWatches()
+  {
+    for (var index = this.addonManagedProbeWatches.Count - 1; index >= 0; index--)
+    {
+      var watch = this.addonManagedProbeWatches[index];
+      watch.Tick();
+      if (watch.IsDisposed)
+      {
+        this.addonManagedProbeWatches.RemoveAt(index);
+      }
+    }
+  }
+
+  /// <summary>
+  ///     Starts the default automatic addon-probe watch set when the player
+  ///     logs in, then resets the gate on logout.
+  /// </summary>
+  private void TickAutoAddonProbeWatches()
+  {
+    var isLoggedIn = ClientStateInterface.IsLoggedIn;
+    if (AddonProbeAutoWatchPolicy.ShouldResetForLogout(
+            this.autoAddonProbeWasLoggedIn,
+            isLoggedIn))
+    {
+      this.StopManagedAddonProbeWatches();
+      this.autoAddonProbeStartedForCurrentLogin = false;
+      this.autoAddonProbeSuppressedUntilLogout = false;
+    }
+
+    this.autoAddonProbeWasLoggedIn = isLoggedIn;
+
+    if (!AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(
+            isLoggedIn,
+            this.autoAddonProbeStartedForCurrentLogin,
+            this.autoAddonProbeSuppressedUntilLogout,
+            this.addonManagedProbeWatches.Count))
+    {
+      return;
+    }
+
+    this.StartDefaultAutoAddonProbeWatches();
+    this.autoAddonProbeStartedForCurrentLogin = true;
+  }
+
+  /// <summary>
+  ///     Starts the default automatic watch set used to capture early
+  ///     structural state for pooled dialogue addons.
+  /// </summary>
+  private void StartDefaultAutoAddonProbeWatches()
+  {
+    foreach (var (addonName, index) in DefaultAutoAddonProbeTargets)
+    {
+      this.StartManagedAddonProbeWatch(
+          addonName,
+          index,
+          DefaultAutoAddonProbeDuration,
+          "login-auto-start");
+    }
+  }
+
+  /// <summary>
+  ///     Starts one managed addon-probe watch and tracks it for later stop or
+  ///     pruning.
+  /// </summary>
+  /// <param name="addonName">The addon name to watch.</param>
+  /// <param name="index">The addon instance index.</param>
+  /// <param name="duration">How long the watch should stay alive.</param>
+  /// <param name="reason">The debug log reason attached to the startup.</param>
+  private void StartManagedAddonProbeWatch(
+      string addonName,
+      int index,
+      TimeSpan duration,
+      string reason)
+  {
+    var watch = AddonStructureProbe.StartWatch(
+        GameGuiInterface,
+        PluginLog,
+        addonName,
+        index,
+        duration);
+    this.addonManagedProbeWatches.Add(watch);
+
+    PluginRuntimeLog.Information(
+        $"[AddonProbe] started managed watch addon='{addonName}' index={index} reason='{reason}' duration={(int)duration.TotalSeconds}s");
+  }
+
+  /// <summary>
+  ///     Stops the current manual addon-probe watch, if any.
+  /// </summary>
+  private void StopManualAddonProbeWatch()
+  {
+    this.addonProbeWatch?.Stop();
+    this.addonProbeWatch = null;
+  }
+
+  /// <summary>
+  ///     Stops every managed automatic addon-probe watch.
+  /// </summary>
+  private void StopManagedAddonProbeWatches()
+  {
+    foreach (var watch in this.addonManagedProbeWatches)
+    {
+      watch.Stop();
+    }
+
+    this.addonManagedProbeWatches.Clear();
+  }
+}
+#endif

--- a/NativeUI/Helpers/AddonProbeAutoWatchHelpers.cs
+++ b/NativeUI/Helpers/AddonProbeAutoWatchHelpers.cs
@@ -98,6 +98,14 @@ public partial class Echoglossian
   /// </summary>
   private void TickAutoAddonProbeWatches()
   {
+    if (!this.configuration.EnableDebugLoginAddonProbe)
+    {
+      this.StopManagedAddonProbeWatches();
+      this.autoAddonProbeStartedForCurrentLogin = false;
+      this.autoAddonProbeWasLoggedIn = ClientStateInterface.IsLoggedIn;
+      return;
+    }
+
     var isLoggedIn = ClientStateInterface.IsLoggedIn;
     if (AddonProbeAutoWatchPolicy.ShouldResetForLogout(
             this.autoAddonProbeWasLoggedIn,

--- a/NativeUI/Helpers/AddonProbeAutoWatchPolicy.cs
+++ b/NativeUI/Helpers/AddonProbeAutoWatchPolicy.cs
@@ -1,0 +1,62 @@
+// <copyright file="AddonProbeAutoWatchPolicy.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+#if DEBUG
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Encapsulates the login-session gating rules for debug-only automatic
+///     addon-probe watches.
+/// </summary>
+internal static class AddonProbeAutoWatchPolicy
+{
+  /// <summary>
+  ///     Determines whether the current login session should start the default
+  ///     automatic addon-probe watch set.
+  /// </summary>
+  /// <param name="isLoggedIn">Whether the client is currently logged in.</param>
+  /// <param name="hasStartedForCurrentLogin">
+  ///     Whether the current login session already started its automatic probe
+  ///     set.
+  /// </param>
+  /// <param name="isSuppressedUntilLogout">
+  ///     Whether the user explicitly suppressed the automatic probe set until
+  ///     the next logout.
+  /// </param>
+  /// <param name="activeManagedWatchCount">
+  ///     How many managed automatic probe watches are currently alive.
+  /// </param>
+  /// <returns>
+  ///     <see langword="true" /> when the automatic probe set should start.
+  /// </returns>
+  public static bool ShouldStartForCurrentLogin(
+      bool isLoggedIn,
+      bool hasStartedForCurrentLogin,
+      bool isSuppressedUntilLogout,
+      int activeManagedWatchCount)
+  {
+    return isLoggedIn &&
+           !hasStartedForCurrentLogin &&
+           !isSuppressedUntilLogout &&
+           activeManagedWatchCount <= 0;
+  }
+
+  /// <summary>
+  ///     Determines whether the automatic login-session gate should reset
+  ///     because the player logged out.
+  /// </summary>
+  /// <param name="wasLoggedIn">
+  ///     Whether the client was logged in on the previous tick.
+  /// </param>
+  /// <param name="isLoggedIn">Whether the client is logged in now.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the automatic probe gate should reset.
+  /// </returns>
+  public static bool ShouldResetForLogout(bool wasLoggedIn, bool isLoggedIn)
+  {
+    return wasLoggedIn && !isLoggedIn;
+  }
+}
+#endif

--- a/NativeUI/Helpers/AddonProbeCommandHelpers.cs
+++ b/NativeUI/Helpers/AddonProbeCommandHelpers.cs
@@ -8,6 +8,8 @@ namespace Echoglossian;
 #if DEBUG
 public partial class Echoglossian
 {
+  private static readonly TimeSpan MaxAddonProbeWatchDuration = TimeSpan.FromMinutes(30);
+
   /// <summary>
   /// Dumps a recursive probe of the requested addon to the log so we can
   /// inspect its live node tree, component roots, and likely overlay anchors.
@@ -22,22 +24,31 @@ public partial class Echoglossian
     {
       if (this.addonProbeWatch == null)
       {
-        ChatGuiInterface.Print("No active addon probe watch to stop.");
+        ChatGuiInterface.Print(Resources.AddonProbeNoActiveWatch);
         return;
       }
 
       this.addonProbeWatch.Stop();
       this.addonProbeWatch = null;
 
-      ChatGuiInterface.Print("Addon probe watch stopped.");
+      ChatGuiInterface.Print(Resources.AddonProbeStopped);
       return;
     }
 
-    var (addonName, addonIndex) = this.ParseAddonProbeArguments(args);
-    if (string.IsNullOrWhiteSpace(addonName))
+    var (addonName, addonIndex, duration, hasInvalidDuration) =
+        this.ParseAddonProbeArguments(args);
+    if (hasInvalidDuration)
     {
       ChatGuiInterface.Print(
-          "Usage: /egloaddonprobe <addon name> [index] or /egloaddonprobe stop");
+          string.Format(
+              Resources.AddonProbeInvalidDurationFormat,
+              (int)MaxAddonProbeWatchDuration.TotalMinutes));
+      return;
+    }
+
+    if (string.IsNullOrWhiteSpace(addonName))
+    {
+      ChatGuiInterface.Print(Resources.AddonProbeUsage);
       return;
     }
 
@@ -46,37 +57,143 @@ public partial class Echoglossian
         GameGuiInterface,
         PluginLog,
         addonName,
-        addonIndex);
+        addonIndex,
+        duration);
 
     ChatGuiInterface.Print(
-        $"Addon probe watch started for '{addonName}'[{addonIndex}] for 60 seconds. Check the Dalamud log for event and tree dumps.");
+        string.Format(
+            Resources.AddonProbeStartedFormat,
+            addonName,
+            addonIndex,
+            this.FormatAddonProbeDuration(duration ?? TimeSpan.FromMinutes(1))));
   }
 
   /// <summary>
-  /// Parses the addon probe command arguments into an addon name and optional index.
+  /// Parses the addon probe command arguments into an addon name, optional index,
+  /// and optional watch duration.
   /// </summary>
   /// <param name="args">The raw command arguments.</param>
-  /// <returns>The addon name and index to probe.</returns>
-  private (string AddonName, int Index) ParseAddonProbeArguments(string args)
+  /// <returns>The addon name, index, and duration to probe.</returns>
+  private (string AddonName, int Index, TimeSpan? Duration, bool HasInvalidDuration)
+      ParseAddonProbeArguments(string args)
   {
     var trimmedArgs = args.Trim();
     if (trimmedArgs.Length == 0)
     {
-      return (string.Empty, 0);
+      return (string.Empty, 0, null, false);
     }
 
-    var lastSpace = trimmedArgs.LastIndexOf(' ');
-    if (lastSpace > 0 &&
-        int.TryParse(trimmedArgs[(lastSpace + 1)..], out var parsedIndex))
+    var parts = trimmedArgs.Split(
+        ' ',
+        StringSplitOptions.RemoveEmptyEntries);
+    if (parts.Length == 0)
     {
-      var parsedName = trimmedArgs[..lastSpace].Trim();
-      if (parsedName.Length > 0)
-      {
-        return (parsedName, parsedIndex);
-      }
+      return (string.Empty, 0, null, false);
     }
 
-    return (trimmedArgs, 0);
+    var partCount = parts.Length;
+    TimeSpan? duration = null;
+
+    if (TryParseAddonProbeDuration(parts[partCount - 1], out var parsedDuration))
+    {
+      duration = parsedDuration;
+      partCount--;
+    }
+    else if (LooksLikeAddonProbeDuration(parts[partCount - 1]))
+    {
+      return (string.Empty, 0, null, true);
+    }
+
+    var index = 0;
+    if (partCount > 1 &&
+        int.TryParse(parts[partCount - 1], out var parsedIndex))
+    {
+      index = parsedIndex;
+      partCount--;
+    }
+
+    var addonName = string.Join(" ", parts.Take(partCount)).Trim();
+    return (addonName, index, duration, false);
+  }
+
+  /// <summary>
+  /// Parses one addon-probe duration token such as "90s" or "15m".
+  /// </summary>
+  /// <param name="token">The raw duration token.</param>
+  /// <param name="duration">Receives the parsed duration.</param>
+  /// <returns><see langword="true"/> when the token parsed successfully.</returns>
+  private static bool TryParseAddonProbeDuration(
+      string token,
+      out TimeSpan duration)
+  {
+    duration = default;
+    if (string.IsNullOrWhiteSpace(token) || token.Length < 2)
+    {
+      return false;
+    }
+
+    var unit = char.ToLowerInvariant(token[^1]);
+    var numberText = token[..^1];
+    if (!int.TryParse(numberText, out var value) || value <= 0)
+    {
+      return false;
+    }
+
+    duration = unit switch
+    {
+      's' => TimeSpan.FromSeconds(value),
+      'm' => TimeSpan.FromMinutes(value),
+      _ => default,
+    };
+
+    return duration > TimeSpan.Zero &&
+           duration <= MaxAddonProbeWatchDuration;
+  }
+
+  /// <summary>
+  /// Determines whether a token looks like an addon-probe duration even when the
+  /// value is outside the accepted range.
+  /// </summary>
+  /// <param name="token">The token to inspect.</param>
+  /// <returns><see langword="true"/> when the token resembles a duration.</returns>
+  private static bool LooksLikeAddonProbeDuration(string token)
+  {
+    if (string.IsNullOrWhiteSpace(token) || token.Length < 2)
+    {
+      return false;
+    }
+
+    var unit = char.ToLowerInvariant(token[^1]);
+    if (unit != 's' && unit != 'm')
+    {
+      return false;
+    }
+
+    return int.TryParse(token[..^1], out _);
+  }
+
+  /// <summary>
+  /// Formats one addon-probe watch duration for chat feedback.
+  /// </summary>
+  /// <param name="duration">The duration to format.</param>
+  /// <returns>The human-readable duration string.</returns>
+  private string FormatAddonProbeDuration(TimeSpan duration)
+  {
+    if (duration.TotalMinutes >= 1 &&
+        Math.Abs(duration.TotalMinutes - Math.Round(duration.TotalMinutes)) < 0.001d)
+    {
+      return string.Format(
+          duration.TotalMinutes == 1
+              ? Resources.AddonProbeDurationMinuteFormat
+              : Resources.AddonProbeDurationMinutesFormat,
+          (int)Math.Round(duration.TotalMinutes));
+    }
+
+    return string.Format(
+        duration.TotalSeconds == 1
+            ? Resources.AddonProbeDurationSecondFormat
+            : Resources.AddonProbeDurationSecondsFormat,
+        (int)Math.Round(duration.TotalSeconds));
   }
 }
 #endif

--- a/NativeUI/Helpers/AddonProbeCommandHelpers.cs
+++ b/NativeUI/Helpers/AddonProbeCommandHelpers.cs
@@ -22,14 +22,13 @@ public partial class Echoglossian
     if (trimmedArgs.Equals("stop", StringComparison.OrdinalIgnoreCase) ||
         trimmedArgs.Equals("cancel", StringComparison.OrdinalIgnoreCase))
     {
-      if (this.addonProbeWatch == null)
+      if (this.GetActiveAddonProbeWatchCount() == 0)
       {
         ChatGuiInterface.Print(Resources.AddonProbeNoActiveWatch);
         return;
       }
 
-      this.addonProbeWatch.Stop();
-      this.addonProbeWatch = null;
+      this.StopAllAddonProbeWatches(suppressAutoUntilLogout: true);
 
       ChatGuiInterface.Print(Resources.AddonProbeStopped);
       return;

--- a/NativeUI/Helpers/NativeReplacementTextNormalizationHelper.cs
+++ b/NativeUI/Helpers/NativeReplacementTextNormalizationHelper.cs
@@ -1,0 +1,129 @@
+// <copyright file="NativeReplacementTextNormalizationHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.AddonHandlers.Common;
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Normalizes translated payload text for native replacement-only flows.
+/// </summary>
+internal static class NativeReplacementTextNormalizationHelper
+{
+    /// <summary>
+    ///     Applies one text normalizer to every translated value that can be
+    ///     written back into one native addon payload.
+    /// </summary>
+    /// <param name="payload">The translated payload to normalize.</param>
+    /// <param name="normalizeText">
+    ///     The per-string normalization callback.
+    /// </param>
+    /// <returns>
+    ///     The normalized payload. When no value changes, the original payload
+    ///     instance is returned unchanged.
+    /// </returns>
+    public static DbFirstGameWindowPayload NormalizePayload(
+        DbFirstGameWindowPayload payload,
+        Func<string, string> normalizeText)
+    {
+        var atkValuesChanged = false;
+        var stringArrayValuesChanged = false;
+        var textNodesChanged = false;
+
+        var normalizedAtkValues = NormalizeMap(
+            payload.AtkValues,
+            normalizeText,
+            ref atkValuesChanged);
+        var normalizedStringArrayValues = NormalizeMap(
+            payload.StringArrayValues,
+            normalizeText,
+            ref stringArrayValuesChanged);
+        var normalizedTextNodes = NormalizeMap(
+            payload.TextNodes,
+            normalizeText,
+            ref textNodesChanged);
+
+        if (!atkValuesChanged &&
+            !stringArrayValuesChanged &&
+            !textNodesChanged)
+        {
+            return payload;
+        }
+
+        return new DbFirstGameWindowPayload(
+            normalizedAtkValues,
+            normalizedStringArrayValues,
+            normalizedTextNodes);
+    }
+
+    /// <summary>
+    ///     Applies one text normalizer to one numeric-keyed payload map.
+    /// </summary>
+    /// <param name="sourceValues">The source values.</param>
+    /// <param name="normalizeText">The per-string normalization callback.</param>
+    /// <param name="changed">
+    ///     Tracks whether any normalized value differed from the source value.
+    /// </param>
+    /// <returns>The normalized payload map.</returns>
+    private static SortedDictionary<int, string> NormalizeMap(
+        SortedDictionary<int, string> sourceValues,
+        Func<string, string> normalizeText,
+        ref bool changed)
+    {
+        var normalizedValues = new SortedDictionary<int, string>();
+
+        foreach (var (key, sourceValue) in sourceValues)
+        {
+            var normalizedValue = normalizeText(sourceValue);
+            if (!changed &&
+                !string.Equals(
+                    sourceValue,
+                    normalizedValue,
+                    StringComparison.Ordinal))
+            {
+                changed = true;
+            }
+
+            normalizedValues[key] = normalizedValue;
+        }
+
+        return normalizedValues;
+    }
+
+    /// <summary>
+    ///     Applies one text normalizer to one text-node payload map.
+    /// </summary>
+    /// <param name="sourceValues">The source values.</param>
+    /// <param name="normalizeText">The per-string normalization callback.</param>
+    /// <param name="changed">
+    ///     Tracks whether any normalized value differed from the source value.
+    /// </param>
+    /// <returns>The normalized payload map.</returns>
+    private static SortedDictionary<string, string> NormalizeMap(
+        SortedDictionary<string, string> sourceValues,
+        Func<string, string> normalizeText,
+        ref bool changed)
+    {
+        var normalizedValues = new SortedDictionary<string, string>(
+            StringComparer.Ordinal);
+
+        foreach (var (key, sourceValue) in sourceValues)
+        {
+            var normalizedValue = normalizeText(sourceValue);
+            if (!changed &&
+                !string.Equals(
+                    sourceValue,
+                    normalizedValue,
+                    StringComparison.Ordinal))
+            {
+                changed = true;
+            }
+
+            normalizedValues[key] = normalizedValue;
+        }
+
+        return normalizedValues;
+    }
+}

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -56,6 +56,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
           : 0,
       AnchoredXNodeAddress = anchoredXNode != null ? (nint)anchoredXNode : 0,
       AnchoredXOriginal = anchoredXNode != null ? anchoredXNode->GetXShort() : (short)0,
+      AnchoredXWidth = anchoredXNode != null ? anchoredXNode->GetWidth() : (ushort)0,
+      AnchoredXRightPaddingFromSecondary = secondaryContainerNode != null && anchoredXNode != null
+          ? ((secondaryContainerNode->GetXShort() + secondaryContainerNode->GetWidth())
+             - (anchoredXNode->GetXShort() + anchoredXNode->GetWidth()))
+          : 0,
     };
 
     if (secondaryContainerNode != null)
@@ -255,6 +260,22 @@ internal static unsafe class NativeTextNodeLayoutHelper
           (short)Math.Max(short.MinValue, Math.Min(
               short.MaxValue,
               childWidth + snapshot.AnchoredXOffset)));
+    }
+
+    if (secondaryContainerNode != null &&
+        anchoredXNode != null &&
+        snapshot.AnchoredXWidth > 0)
+    {
+      var minimumSecondaryWidth = ResolveMinimumSecondaryWidthForAnchoredNode(
+          secondaryContainerNode->GetXShort(),
+          secondaryContainerNode->GetWidth(),
+          anchoredXNode->GetXShort(),
+          anchoredXNode->GetWidth(),
+          snapshot.AnchoredXRightPaddingFromSecondary);
+      if (minimumSecondaryWidth > secondaryContainerNode->GetWidth())
+      {
+        secondaryContainerNode->SetWidth(minimumSecondaryWidth);
+      }
     }
 
     if (restoreHorizontalCentering)
@@ -484,6 +505,50 @@ internal static unsafe class NativeTextNodeLayoutHelper
         allowWidthGrowth: allowWidthGrowth,
         restoreHorizontalCentering: restoreHorizontalCentering);
     return snapshot;
+  }
+
+  /// <summary>
+  ///     Resolves the minimum secondary-container width required to keep an
+  ///     anchored sibling node covered by the same background after reflow.
+  /// </summary>
+  /// <param name="secondaryContainerX">
+  ///     The live X position of the secondary container.
+  /// </param>
+  /// <param name="currentSecondaryWidth">
+  ///     The current width of the secondary container before adjustment.
+  /// </param>
+  /// <param name="anchoredNodeX">
+  ///     The live X position of the anchored sibling node.
+  /// </param>
+  /// <param name="anchoredNodeWidth">The current width of the anchored node.</param>
+  /// <param name="preferredRightPadding">
+  ///     The original right padding between the secondary container and the
+  ///     anchored node. Negative values are treated as zero so coverage still
+  ///     extends to the anchored node edge.
+  /// </param>
+  /// <returns>
+  ///     The minimum width that keeps the anchored node inside the secondary
+  ///     background.
+  /// </returns>
+  public static ushort ResolveMinimumSecondaryWidthForAnchoredNode(
+      short secondaryContainerX,
+      ushort currentSecondaryWidth,
+      short anchoredNodeX,
+      ushort anchoredNodeWidth,
+      int preferredRightPadding)
+  {
+    var secondaryLeft = (int)secondaryContainerX;
+    var currentRight = secondaryLeft + currentSecondaryWidth;
+    var anchoredRight = anchoredNodeX + anchoredNodeWidth + Math.Max(0, preferredRightPadding);
+    if (anchoredRight <= currentRight)
+    {
+      return currentSecondaryWidth;
+    }
+
+    var requiredWidth = Math.Max(
+        currentSecondaryWidth,
+        anchoredRight - secondaryLeft);
+    return (ushort)Math.Min(ushort.MaxValue, requiredWidth);
   }
 
   /// <summary>
@@ -902,6 +967,17 @@ internal sealed class NativeTextNodeLayoutSnapshot
   ///     Gets or sets the original X position of the anchored sibling node.
   /// </summary>
   public short AnchoredXOriginal { get; set; }
+
+  /// <summary>
+  ///     Gets or sets the original width of the anchored sibling node.
+  /// </summary>
+  public ushort AnchoredXWidth { get; set; }
+
+  /// <summary>
+  ///     Gets or sets the original right padding between the anchored sibling
+  ///     node and the secondary container.
+  /// </summary>
+  public int AnchoredXRightPaddingFromSecondary { get; set; }
 
   /// <summary>
   ///     Gets the horizontal padding between the text node and the secondary

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -101,7 +101,7 @@ internal static unsafe class NativeTextNodeLayoutHelper
     var boundedContainerWidth = ResolveBoundedContainerWidth(
         primaryContainerNode,
         secondaryContainerNode);
-    if (boundedContainerWidth > 0 && boundedContainerWidth > currentWidth)
+    if (boundedContainerWidth > 0)
     {
       return boundedContainerWidth;
     }
@@ -152,7 +152,18 @@ internal static unsafe class NativeTextNodeLayoutHelper
     textNode->SetText(replacementText);
     textNode->ResizeNodeForCurrentText();
 
+    if (preferredWrapWidth > 0 &&
+        textNode->GetWidth() != preferredWrapWidth)
+    {
+      textNode->SetWidth(preferredWrapWidth);
+    }
+
     TryMeasureTextNode(textNode, out var width, out var height);
+    if (preferredWrapWidth > 0)
+    {
+      width = preferredWrapWidth;
+    }
+
     return new NativeTextNodeResizeResult(width, height);
   }
 

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -34,17 +34,37 @@ internal static unsafe class NativeTextNodeLayoutHelper
       AtkResNode* anchoredXNode = null)
   {
     TryMeasureTextNode(textNode, out var textWidth, out var textHeight);
-    var snapshot = new NativeTextNodeLayoutSnapshot(textWidth, textHeight)
+    var textNodeWidth = textNode != null ? textNode->GetWidth() : (ushort)0;
+    var textNodeHeight = textNode != null ? textNode->GetHeight() : (ushort)0;
+    var textNodeTextFlags = textNode != null ? textNode->TextFlags : default;
+    var textNodeFontSize = textNode != null ? textNode->FontSize : (byte)0;
+    var textNodeOriginalX = textNode != null ? textNode->AtkResNode.GetXShort() : (short)0;
+    var textNodeOriginalY = textNode != null ? textNode->AtkResNode.GetYShort() : (short)0;
+    var snapshot = new NativeTextNodeLayoutSnapshot(
+        textNode != null ? (nint)textNode : 0,
+        textWidth,
+        textHeight,
+        textNodeWidth,
+        textNodeHeight,
+        textNodeTextFlags,
+        textNodeFontSize,
+        textNodeOriginalX,
+        textNodeOriginalY)
     {
       AnchoredXOffset = anchoredXNode != null
           ? anchoredXNode->GetXShort() - textWidth
           : 0,
+      AnchoredXNodeAddress = anchoredXNode != null ? (nint)anchoredXNode : 0,
+      AnchoredXOriginal = anchoredXNode != null ? anchoredXNode->GetXShort() : (short)0,
     };
 
     if (secondaryContainerNode != null)
     {
+      snapshot.SecondaryContainerAddress = (nint)secondaryContainerNode;
       snapshot.SecondaryContainerWidth = secondaryContainerNode->GetWidth();
       snapshot.SecondaryContainerHeight = secondaryContainerNode->GetHeight();
+      snapshot.SecondaryContainerOriginalX = secondaryContainerNode->GetXShort();
+      snapshot.SecondaryContainerOriginalY = secondaryContainerNode->GetYShort();
     }
 
     CaptureAncestorChain(
@@ -62,10 +82,15 @@ internal static unsafe class NativeTextNodeLayoutHelper
   /// <param name="primaryContainerNode">
   ///     The main container node that owns the text node.
   /// </param>
+  /// <param name="secondaryContainerNode">
+  ///     An optional secondary background node whose width may better represent
+  ///     the stable visual bounds than the current text-node width.
+  /// </param>
   /// <returns>The preferred wrap width to preserve.</returns>
   public static ushort ResolvePreferredWrapWidth(
       AtkTextNode* textNode,
-      AtkResNode* primaryContainerNode = null)
+      AtkResNode* primaryContainerNode = null,
+      AtkResNode* secondaryContainerNode = null)
   {
     if (textNode == null)
     {
@@ -73,14 +98,22 @@ internal static unsafe class NativeTextNodeLayoutHelper
     }
 
     var currentWidth = textNode->GetWidth();
+    var boundedContainerWidth = ResolveBoundedContainerWidth(
+        primaryContainerNode,
+        secondaryContainerNode);
+    if (boundedContainerWidth > 0 && boundedContainerWidth > currentWidth)
+    {
+      return boundedContainerWidth;
+    }
+
     if (currentWidth > 0)
     {
       return currentWidth;
     }
 
-    if (primaryContainerNode != null)
+    if (boundedContainerWidth > 0)
     {
-      return primaryContainerNode->GetWidth();
+      return boundedContainerWidth;
     }
 
     var parentNode = textNode->AtkResNode.ParentNode;
@@ -211,6 +244,107 @@ internal static unsafe class NativeTextNodeLayoutHelper
               short.MaxValue,
               childWidth + snapshot.AnchoredXOffset)));
     }
+
+    TryRestoreHorizontalCentering(snapshot);
+  }
+
+  /// <summary>
+  ///     Restores a previously captured native text-node layout snapshot after a
+  ///     temporary translated replacement is no longer needed.
+  /// </summary>
+  /// <param name="snapshot">The layout snapshot captured before replacement.</param>
+  /// <param name="originalText">
+  ///     The original text that should be written back into the text node.
+  /// </param>
+  public static void RestoreLayoutSnapshot(
+      NativeTextNodeLayoutSnapshot snapshot,
+      string originalText,
+      bool restoreText = true)
+  {
+    if (snapshot == null)
+    {
+      return;
+    }
+
+    var textNode = (AtkTextNode*)snapshot.TextNodeAddress;
+    if (textNode != null)
+    {
+      textNode->TextFlags = snapshot.TextNodeTextFlags;
+      if (snapshot.TextNodeFontSize > 0)
+      {
+        textNode->FontSize = snapshot.TextNodeFontSize;
+      }
+
+      if (restoreText &&
+          !string.IsNullOrWhiteSpace(originalText))
+      {
+        textNode->SetText(originalText);
+      }
+
+      if (snapshot.TextNodeWidth > 0)
+      {
+        textNode->SetWidth(snapshot.TextNodeWidth);
+      }
+
+      if (snapshot.TextNodeHeight > 0)
+      {
+        ((AtkResNode*)textNode)->SetHeight(snapshot.TextNodeHeight);
+      }
+
+      ((AtkResNode*)textNode)->SetXShort(snapshot.TextNodeOriginalX);
+      ((AtkResNode*)textNode)->SetYShort(snapshot.TextNodeOriginalY);
+    }
+
+    foreach (var ancestorSnapshot in snapshot.AncestorChain)
+    {
+      var ancestorNode = (AtkResNode*)ancestorSnapshot.NodeAddress;
+      if (ancestorNode == null)
+      {
+        continue;
+      }
+
+      if (ancestorSnapshot.Width > 0)
+      {
+        ancestorNode->SetWidth(ancestorSnapshot.Width);
+      }
+
+      if (ancestorSnapshot.Height > 0)
+      {
+        ancestorNode->SetHeight(ancestorSnapshot.Height);
+      }
+
+      ancestorNode->SetXShort(ancestorSnapshot.OriginalX);
+      ancestorNode->SetYShort(ancestorSnapshot.OriginalY);
+    }
+
+    if (snapshot.SecondaryContainerAddress != 0)
+    {
+      var secondaryContainerNode = (AtkResNode*)snapshot.SecondaryContainerAddress;
+      if (secondaryContainerNode != null)
+      {
+        if (snapshot.SecondaryContainerWidth > 0)
+        {
+          secondaryContainerNode->SetWidth(snapshot.SecondaryContainerWidth);
+        }
+
+        if (snapshot.SecondaryContainerHeight > 0)
+        {
+          secondaryContainerNode->SetHeight(snapshot.SecondaryContainerHeight);
+        }
+
+        secondaryContainerNode->SetXShort(snapshot.SecondaryContainerOriginalX);
+        secondaryContainerNode->SetYShort(snapshot.SecondaryContainerOriginalY);
+      }
+    }
+
+    if (snapshot.AnchoredXNodeAddress != 0)
+    {
+      var anchoredXNode = (AtkResNode*)snapshot.AnchoredXNodeAddress;
+      if (anchoredXNode != null)
+      {
+        anchoredXNode->SetXShort(snapshot.AnchoredXOriginal);
+      }
+    }
   }
 
   /// <summary>
@@ -275,7 +409,7 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     Whether wrapper widths may grow when the current wrap width is
   ///     insufficient.
   /// </param>
-  public static void ApplyTextReplacementWithInferredReflow(
+  public static NativeTextNodeLayoutSnapshot? ApplyTextReplacementWithInferredReflow(
       AtkUnitBase* addon,
       AtkTextNode* textNode,
       string replacementText,
@@ -283,7 +417,7 @@ internal static unsafe class NativeTextNodeLayoutHelper
   {
     if (textNode == null)
     {
-      return;
+      return null;
     }
 
     TryResolveContainerNodes(
@@ -299,7 +433,10 @@ internal static unsafe class NativeTextNodeLayoutHelper
         textNode,
         containerNode,
         backgroundResNode);
-    var preferredWrapWidth = ResolvePreferredWrapWidth(textNode, containerNode);
+    var preferredWrapWidth = ResolvePreferredWrapWidth(
+        textNode,
+        containerNode,
+        backgroundResNode);
     var resizeResult = ApplyWrappedTextAndMeasure(
         textNode,
         replacementText,
@@ -310,6 +447,7 @@ internal static unsafe class NativeTextNodeLayoutHelper
         containerNode,
         backgroundResNode,
         allowWidthGrowth: allowWidthGrowth);
+    return snapshot;
   }
 
   /// <summary>
@@ -423,6 +561,38 @@ internal static unsafe class NativeTextNodeLayoutHelper
   }
 
   /// <summary>
+  ///     Resolves the widest stable visual width exposed by the surrounding
+  ///     container nodes so repeated native replacements do not fall back to a
+  ///     narrow internal wrapper when a larger background already represents the
+  ///     intended visual balloon or panel width.
+  /// </summary>
+  /// <param name="primaryContainerNode">The primary owning container.</param>
+  /// <param name="secondaryContainerNode">An optional secondary background node.</param>
+  /// <returns>The widest non-zero container width available.</returns>
+  private static ushort ResolveBoundedContainerWidth(
+      AtkResNode* primaryContainerNode,
+      AtkResNode* secondaryContainerNode)
+  {
+    ushort width = 0;
+
+    if (primaryContainerNode != null)
+    {
+      width = primaryContainerNode->GetWidth();
+    }
+
+    if (secondaryContainerNode != null)
+    {
+      var secondaryWidth = secondaryContainerNode->GetWidth();
+      if (secondaryWidth > 0 && secondaryWidth > width)
+      {
+        width = secondaryWidth;
+      }
+    }
+
+    return width;
+  }
+
+  /// <summary>
   ///     Resolves the first nine-grid node reachable from a node.
   /// </summary>
   /// <param name="node">The node to inspect.</param>
@@ -487,11 +657,23 @@ internal static unsafe class NativeTextNodeLayoutHelper
     {
       var width = currentNode->GetWidth();
       var height = currentNode->GetHeight();
+      if (snapshot.AncestorChain.Count == 0 && width > 0)
+      {
+        var leftPadding = Math.Max(0, (int)snapshot.TextNodeOriginalX);
+        var rightPadding = Math.Max(
+            0,
+            width - leftPadding - snapshot.TextNodeWidth);
+        snapshot.TextNodeWasHorizontallyCentered =
+            Math.Abs(leftPadding - rightPadding) <= 4;
+      }
+
       snapshot.AncestorChain.Add(
           new NativeTextNodeAncestorSnapshot(
               (nint)currentNode,
               width,
               height,
+              currentNode->GetXShort(),
+              currentNode->GetYShort(),
               Math.Max(0, width - childWidth),
               Math.Max(0, height - childHeight)));
 
@@ -506,6 +688,44 @@ internal static unsafe class NativeTextNodeLayoutHelper
       currentNode = currentNode->ParentNode;
     }
   }
+
+  /// <summary>
+  ///     Re-centers the text node within its immediate wrapper when the original
+  ///     layout was centered and width growth changed the wrapper size.
+  /// </summary>
+  /// <param name="snapshot">The captured layout snapshot.</param>
+  private static void TryRestoreHorizontalCentering(
+      NativeTextNodeLayoutSnapshot snapshot)
+  {
+    if (snapshot == null ||
+        !snapshot.TextNodeWasHorizontallyCentered ||
+        snapshot.TextNodeAddress == 0 ||
+        snapshot.AncestorChain.Count == 0)
+    {
+      return;
+    }
+
+    var textNode = (AtkTextNode*)snapshot.TextNodeAddress;
+    var immediateParent = (AtkResNode*)snapshot.AncestorChain[0].NodeAddress;
+    if (textNode == null || immediateParent == null)
+    {
+      return;
+    }
+
+    var parentWidth = immediateParent->GetWidth();
+    var textWidth = textNode->GetWidth();
+    if (parentWidth == 0 || textWidth == 0 || parentWidth <= textWidth)
+    {
+      return;
+    }
+
+    var centeredX = (short)Math.Max(
+        short.MinValue,
+        Math.Min(
+            short.MaxValue,
+            (parentWidth - textWidth) / 2));
+    ((AtkResNode*)textNode)->SetXShort(centeredX);
+  }
 }
 
 /// <summary>
@@ -513,25 +733,103 @@ internal static unsafe class NativeTextNodeLayoutHelper
 /// </summary>
 /// <param name="textWidth">The original text-node width.</param>
 /// <param name="textHeight">The original text-node height.</param>
-internal sealed class NativeTextNodeLayoutSnapshot(
-    ushort textWidth,
-    ushort textHeight)
+internal sealed class NativeTextNodeLayoutSnapshot
 {
+  /// <summary>
+  ///     Initializes a new instance of the <see cref="NativeTextNodeLayoutSnapshot" /> class.
+  /// </summary>
+  /// <param name="textNodeAddress">The address of the mutated text node.</param>
+  /// <param name="textWidth">The original measured text width.</param>
+  /// <param name="textHeight">The original measured text height.</param>
+  /// <param name="textNodeWidth">The original text-node width.</param>
+  /// <param name="textNodeHeight">The original text-node height.</param>
+  /// <param name="textNodeTextFlags">The original text-node flags.</param>
+  /// <param name="textNodeFontSize">The original text-node font size.</param>
+  /// <param name="textNodeOriginalX">The original text-node X position.</param>
+  /// <param name="textNodeOriginalY">The original text-node Y position.</param>
+  public NativeTextNodeLayoutSnapshot(
+      nint textNodeAddress,
+      ushort textWidth,
+      ushort textHeight,
+      ushort textNodeWidth,
+      ushort textNodeHeight,
+      TextFlags textNodeTextFlags,
+      byte textNodeFontSize,
+      short textNodeOriginalX,
+      short textNodeOriginalY)
+  {
+    this.TextNodeAddress = textNodeAddress;
+    this.TextWidth = textWidth;
+    this.TextHeight = textHeight;
+    this.TextNodeWidth = textNodeWidth;
+    this.TextNodeHeight = textNodeHeight;
+    this.TextNodeTextFlags = textNodeTextFlags;
+    this.TextNodeFontSize = textNodeFontSize;
+    this.TextNodeOriginalX = textNodeOriginalX;
+    this.TextNodeOriginalY = textNodeOriginalY;
+  }
+
+  /// <summary>
+  ///     Gets the native address of the mutated text node.
+  /// </summary>
+  public nint TextNodeAddress { get; }
+
   /// <summary>
   ///     Gets the original text-node width.
   /// </summary>
-  public ushort TextWidth { get; } = textWidth;
+  public ushort TextWidth { get; }
 
   /// <summary>
   ///     Gets the original text-node height.
   /// </summary>
-  public ushort TextHeight { get; } = textHeight;
+  public ushort TextHeight { get; }
+
+  /// <summary>
+  ///     Gets the original width assigned to the text node itself.
+  /// </summary>
+  public ushort TextNodeWidth { get; }
+
+  /// <summary>
+  ///     Gets the original height assigned to the text node itself.
+  /// </summary>
+  public ushort TextNodeHeight { get; }
+
+  /// <summary>
+  ///     Gets the original text-node flags.
+  /// </summary>
+  public TextFlags TextNodeTextFlags { get; }
+
+  /// <summary>
+  ///     Gets the original text-node font size.
+  /// </summary>
+  public byte TextNodeFontSize { get; }
+
+  /// <summary>
+  ///     Gets the original X position assigned to the text node itself.
+  /// </summary>
+  public short TextNodeOriginalX { get; }
+
+  /// <summary>
+  ///     Gets the original Y position assigned to the text node itself.
+  /// </summary>
+  public short TextNodeOriginalY { get; }
+
+  /// <summary>
+  ///     Gets or sets a value indicating whether the text node was originally
+  ///     centered inside its immediate parent.
+  /// </summary>
+  public bool TextNodeWasHorizontallyCentered { get; set; }
 
   /// <summary>
   ///     Gets the wrapper chain that should be resized after a native text
   ///     replacement.
   /// </summary>
   public List<NativeTextNodeAncestorSnapshot> AncestorChain { get; } = [];
+
+  /// <summary>
+  ///     Gets or sets the native address of the secondary container node.
+  /// </summary>
+  public nint SecondaryContainerAddress { get; set; }
 
   /// <summary>
   ///     Gets or sets the secondary container width.
@@ -544,10 +842,30 @@ internal sealed class NativeTextNodeLayoutSnapshot(
   public ushort SecondaryContainerHeight { get; set; }
 
   /// <summary>
+  ///     Gets or sets the original X position of the secondary container.
+  /// </summary>
+  public short SecondaryContainerOriginalX { get; set; }
+
+  /// <summary>
+  ///     Gets or sets the original Y position of the secondary container.
+  /// </summary>
+  public short SecondaryContainerOriginalY { get; set; }
+
+  /// <summary>
+  ///     Gets or sets the native address of the anchored X node.
+  /// </summary>
+  public nint AnchoredXNodeAddress { get; set; }
+
+  /// <summary>
   ///     Gets or sets the X offset between an anchored sibling node and the text
   ///     width.
   /// </summary>
   public int AnchoredXOffset { get; set; }
+
+  /// <summary>
+  ///     Gets or sets the original X position of the anchored sibling node.
+  /// </summary>
+  public short AnchoredXOriginal { get; set; }
 
   /// <summary>
   ///     Gets the horizontal padding between the text node and the secondary
@@ -577,6 +895,8 @@ internal readonly record struct NativeTextNodeResizeResult(
 /// <param name="NodeAddress">The native address of the wrapper node.</param>
 /// <param name="Width">The original wrapper width.</param>
 /// <param name="Height">The original wrapper height.</param>
+/// <param name="OriginalX">The original X position of the wrapper node.</param>
+/// <param name="OriginalY">The original Y position of the wrapper node.</param>
 /// <param name="HorizontalPadding">
 ///     The original horizontal padding between this wrapper and its child.
 /// </param>
@@ -587,5 +907,7 @@ internal readonly record struct NativeTextNodeAncestorSnapshot(
     nint NodeAddress,
     ushort Width,
     ushort Height,
+    short OriginalX,
+    short OriginalY,
     int HorizontalPadding,
     int VerticalPadding);

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -193,7 +193,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
       AtkResNode* primaryContainerNode = null,
       AtkResNode* secondaryContainerNode = null,
       AtkResNode* anchoredXNode = null,
-      bool allowWidthGrowth = false)
+      bool allowWidthGrowth = false,
+      bool restoreHorizontalCentering = true)
   {
     var childWidth = resizeResult.Width;
     var childHeight = resizeResult.Height;
@@ -256,7 +257,10 @@ internal static unsafe class NativeTextNodeLayoutHelper
               childWidth + snapshot.AnchoredXOffset)));
     }
 
-    TryRestoreHorizontalCentering(snapshot);
+    if (restoreHorizontalCentering)
+    {
+      TryRestoreHorizontalCentering(snapshot);
+    }
   }
 
   /// <summary>
@@ -270,7 +274,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
   public static void RestoreLayoutSnapshot(
       NativeTextNodeLayoutSnapshot snapshot,
       string originalText,
-      bool restoreText = true)
+      bool restoreText = true,
+      bool restorePositions = true)
   {
     if (snapshot == null)
     {
@@ -302,8 +307,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
         ((AtkResNode*)textNode)->SetHeight(snapshot.TextNodeHeight);
       }
 
-      ((AtkResNode*)textNode)->SetXShort(snapshot.TextNodeOriginalX);
-      ((AtkResNode*)textNode)->SetYShort(snapshot.TextNodeOriginalY);
+      if (restorePositions)
+      {
+        ((AtkResNode*)textNode)->SetXShort(snapshot.TextNodeOriginalX);
+        ((AtkResNode*)textNode)->SetYShort(snapshot.TextNodeOriginalY);
+      }
     }
 
     foreach (var ancestorSnapshot in snapshot.AncestorChain)
@@ -324,8 +332,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
         ancestorNode->SetHeight(ancestorSnapshot.Height);
       }
 
-      ancestorNode->SetXShort(ancestorSnapshot.OriginalX);
-      ancestorNode->SetYShort(ancestorSnapshot.OriginalY);
+      if (restorePositions)
+      {
+        ancestorNode->SetXShort(ancestorSnapshot.OriginalX);
+        ancestorNode->SetYShort(ancestorSnapshot.OriginalY);
+      }
     }
 
     if (snapshot.SecondaryContainerAddress != 0)
@@ -343,12 +354,16 @@ internal static unsafe class NativeTextNodeLayoutHelper
           secondaryContainerNode->SetHeight(snapshot.SecondaryContainerHeight);
         }
 
-        secondaryContainerNode->SetXShort(snapshot.SecondaryContainerOriginalX);
-        secondaryContainerNode->SetYShort(snapshot.SecondaryContainerOriginalY);
+        if (restorePositions)
+        {
+          secondaryContainerNode->SetXShort(snapshot.SecondaryContainerOriginalX);
+          secondaryContainerNode->SetYShort(snapshot.SecondaryContainerOriginalY);
+        }
       }
     }
 
-    if (snapshot.AnchoredXNodeAddress != 0)
+    if (restorePositions &&
+        snapshot.AnchoredXNodeAddress != 0)
     {
       var anchoredXNode = (AtkResNode*)snapshot.AnchoredXNodeAddress;
       if (anchoredXNode != null)
@@ -424,7 +439,9 @@ internal static unsafe class NativeTextNodeLayoutHelper
       AtkUnitBase* addon,
       AtkTextNode* textNode,
       string replacementText,
-      bool allowWidthGrowth = false)
+      bool allowWidthGrowth = false,
+      bool restoreHorizontalCentering = true,
+      ushort additionalWrapWidth = 0)
   {
     if (textNode == null)
     {
@@ -448,6 +465,13 @@ internal static unsafe class NativeTextNodeLayoutHelper
         textNode,
         containerNode,
         backgroundResNode);
+    if (additionalWrapWidth > 0 && preferredWrapWidth > 0)
+    {
+      preferredWrapWidth = (ushort)Math.Min(
+          ushort.MaxValue,
+          preferredWrapWidth + additionalWrapWidth);
+    }
+
     var resizeResult = ApplyWrappedTextAndMeasure(
         textNode,
         replacementText,
@@ -457,7 +481,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
         resizeResult,
         containerNode,
         backgroundResNode,
-        allowWidthGrowth: allowWidthGrowth);
+        allowWidthGrowth: allowWidthGrowth,
+        restoreHorizontalCentering: restoreHorizontalCentering);
     return snapshot;
   }
 

--- a/NativeUI/Helpers/ToastGuiCaptureRuntimeRegistration.cs
+++ b/NativeUI/Helpers/ToastGuiCaptureRuntimeRegistration.cs
@@ -1,0 +1,47 @@
+// <copyright file="ToastGuiCaptureRuntimeRegistration.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian;
+
+/// <summary>
+///     Handles bootstrap and teardown of the experimental ToastGui-assisted
+///     toast capture runtime for supported normal and error toasts.
+/// </summary>
+public partial class Echoglossian
+{
+  /// <summary>
+  ///     Creates the ToastGui-assisted capture runtime using the same shared
+  ///     toast persistence helpers already used by the addon-handler path.
+  /// </summary>
+  /// <returns>The initialized runtime.</returns>
+  private ToastGuiCaptureRuntime CreateToastGuiCaptureRuntime()
+  {
+    return new ToastGuiCaptureRuntime(
+        this.configuration,
+        TranslationService,
+        this.FindAndReturnToastMessage,
+        toastMessage => Task.Run(() => this.InsertToastMessageData(toastMessage)));
+  }
+
+  /// <summary>
+  ///     Registers the ToastGui-assisted capture runtime with Dalamud's
+  ///     callback surface for supported normal and error toasts.
+  /// </summary>
+  private void RegisterToastGuiCaptureRuntime()
+  {
+    ToastGuiInterface.Toast += this.toastGuiCaptureRuntime.HandleNormalToast;
+    ToastGuiInterface.ErrorToast += this.toastGuiCaptureRuntime.HandleErrorToast;
+  }
+
+  /// <summary>
+  ///     Unregisters the ToastGui-assisted capture runtime from Dalamud's
+  ///     callback surface.
+  /// </summary>
+  private void UnregisterToastGuiCaptureRuntime()
+  {
+    ToastGuiInterface.Toast -= this.toastGuiCaptureRuntime.HandleNormalToast;
+    ToastGuiInterface.ErrorToast -= this.toastGuiCaptureRuntime.HandleErrorToast;
+  }
+}

--- a/NativeUI/Helpers/ToastGuiSupportedToastRuntimeRegistration.cs
+++ b/NativeUI/Helpers/ToastGuiSupportedToastRuntimeRegistration.cs
@@ -1,0 +1,65 @@
+// <copyright file="ToastGuiSupportedToastRuntimeRegistration.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian;
+
+/// <summary>
+///     Handles bootstrap and teardown for the alternate callback-owned
+///     ToastGui route that owns supported normal and error toasts.
+/// </summary>
+public partial class Echoglossian
+{
+  /// <summary>
+  ///     Creates the alternate supported-toast runtime using the same shared
+  ///     toast persistence and overlay helpers already used elsewhere in the
+  ///     plugin.
+  /// </summary>
+  /// <returns>The initialized supported-toast runtime.</returns>
+  private ToastGuiSupportedToastRuntime CreateToastGuiSupportedToastRuntime()
+  {
+    return new ToastGuiSupportedToastRuntime(
+        this.configuration,
+        TranslationService,
+        this.FindAndReturnToastMessage,
+        toastMessage => Task.Run(() => this.InsertToastMessageData(toastMessage)),
+        (translatedName, translatedText, originalName) =>
+            this.UpdateOverlayContent(
+                this.toastOverlay,
+                translatedName,
+                translatedText,
+                originalName),
+        () => this.ClearOverlay(this.toastOverlay, clearText: true),
+        (translatedName, translatedText, originalName) =>
+            this.UpdateOverlayContent(
+                this.errorToastOverlay,
+                translatedName,
+                translatedText,
+                originalName),
+        () => this.ClearOverlay(this.errorToastOverlay, clearText: true),
+        text => this.RemoveDiacritics(
+            text,
+            this.SpecialCharsSupportedByGameFont));
+  }
+
+  /// <summary>
+  ///     Registers the alternate supported-toast runtime with Dalamud's normal
+  ///     and error-toast callbacks.
+  /// </summary>
+  private void RegisterToastGuiSupportedToastRuntime()
+  {
+    ToastGuiInterface.Toast += this.toastGuiSupportedToastRuntime.HandleNormalToast;
+    ToastGuiInterface.ErrorToast += this.toastGuiSupportedToastRuntime.HandleErrorToast;
+  }
+
+  /// <summary>
+  ///     Unregisters the alternate supported-toast runtime from Dalamud's
+  ///     normal and error-toast callbacks.
+  /// </summary>
+  private void UnregisterToastGuiSupportedToastRuntime()
+  {
+    ToastGuiInterface.Toast -= this.toastGuiSupportedToastRuntime.HandleNormalToast;
+    ToastGuiInterface.ErrorToast -= this.toastGuiSupportedToastRuntime.HandleErrorToast;
+  }
+}

--- a/PluginUI/PluginRuntimeUi.cs
+++ b/PluginUI/PluginRuntimeUi.cs
@@ -13,11 +13,7 @@ public partial class Echoglossian
   private void Tick(IFramework tFramework)
   {
 #if DEBUG
-    this.addonProbeWatch?.Tick();
-    if (this.addonProbeWatch?.IsDisposed == true)
-    {
-      this.addonProbeWatch = null;
-    }
+    this.TickAddonProbeInfrastructure();
 #endif
 
     this.ApplyPendingRuntimeConfigurationChanges();

--- a/PluginUI/Tabs/OverlayTab.cs
+++ b/PluginUI/Tabs/OverlayTab.cs
@@ -366,6 +366,12 @@ public static class OverlayTab
     private static bool DrawToastGeneralPage(Config config)
     {
         var changed = false;
+        var normalRouteState =
+            NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy
+                .GetSupportedNormalToastRouteState(config);
+        var errorRouteState =
+            NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy
+                .GetSupportedErrorToastRouteState(config);
 
         ImGui.TextWrapped(Resources.WhichToastsToTranslate);
         ImGui.Spacing();
@@ -374,6 +380,19 @@ public static class OverlayTab
             ref config.UseToastGuiCaptureForSupportedToasts);
         ImGui.TextWrapped(
             Resources.ToastGuiCaptureForSupportedToastsDescription);
+        ImGui.Spacing();
+        ImGui.TextWrapped(
+            Resources.ToastGuiNormalToastRouteStatusLabel + ": " +
+            GetToastGuiRouteStateText(normalRouteState));
+        ImGui.TextWrapped(
+            Resources.ToastGuiErrorToastRouteStatusLabel + ": " +
+            GetToastGuiRouteStateText(errorRouteState));
+        ImGui.TextWrapped(
+            Resources.ToastGuiQuestToastRouteStatusLabel + ": " +
+            Resources.ToastGuiRouteStateFullRuntime);
+        ImGui.TextWrapped(
+            Resources.ToastGuiTextGimmickHintRouteStatusLabel + ": " +
+            Resources.ToastGuiRouteStateAddonHandlerOnly);
         ImGui.Spacing();
 
         changed |= ImGui.Checkbox(
@@ -409,6 +428,25 @@ public static class OverlayTab
         }
 
         return changed;
+    }
+
+    /// <summary>
+    ///     Maps one effective toast route state to the localized UI label used
+    ///     in the toast general page.
+    /// </summary>
+    /// <param name="routeState">The effective route state.</param>
+    /// <returns>The localized UI label for the route state.</returns>
+    private static string GetToastGuiRouteStateText(
+        NativeUI.AddonHandlers.Toasts.ToastGuiRouteState routeState)
+    {
+        return routeState switch
+        {
+            NativeUI.AddonHandlers.Toasts.ToastGuiRouteState.ToastGuiFullRuntime =>
+                Resources.ToastGuiRouteStateFullRuntime,
+            NativeUI.AddonHandlers.Toasts.ToastGuiRouteState.ToastGuiCapturePrefetch =>
+                Resources.ToastGuiRouteStateCapturePrefetch,
+            _ => Resources.ToastGuiRouteStateLegacyAddonHandlers,
+        };
     }
 
     private static bool DrawToastTypePage(

--- a/PluginUI/Tabs/OverlayTab.cs
+++ b/PluginUI/Tabs/OverlayTab.cs
@@ -366,21 +366,16 @@ public static class OverlayTab
     private static bool DrawToastGeneralPage(Config config)
     {
         var changed = false;
+
+        ImGui.TextWrapped(Resources.WhichToastsToTranslate);
+        ImGui.Spacing();
+#if DEBUG
         var normalRouteState =
             NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy
                 .GetSupportedNormalToastRouteState(config);
         var errorRouteState =
             NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy
                 .GetSupportedErrorToastRouteState(config);
-
-        ImGui.TextWrapped(Resources.WhichToastsToTranslate);
-        ImGui.Spacing();
-        changed |= ImGui.Checkbox(
-            Resources.ToastGuiCaptureForSupportedToastsLabel,
-            ref config.UseToastGuiCaptureForSupportedToasts);
-        ImGui.TextWrapped(
-            Resources.ToastGuiCaptureForSupportedToastsDescription);
-        ImGui.Spacing();
         ImGui.TextWrapped(
             Resources.ToastGuiNormalToastRouteStatusLabel + ": " +
             GetToastGuiRouteStateText(normalRouteState));
@@ -394,6 +389,7 @@ public static class OverlayTab
             Resources.ToastGuiTextGimmickHintRouteStatusLabel + ": " +
             Resources.ToastGuiRouteStateAddonHandlerOnly);
         ImGui.Spacing();
+#endif
 
         changed |= ImGui.Checkbox(
             Resources.TranslateScreenInfoToastToggleText,
@@ -436,6 +432,7 @@ public static class OverlayTab
     /// </summary>
     /// <param name="routeState">The effective route state.</param>
     /// <returns>The localized UI label for the route state.</returns>
+#if DEBUG
     private static string GetToastGuiRouteStateText(
         NativeUI.AddonHandlers.Toasts.ToastGuiRouteState routeState)
     {
@@ -448,6 +445,7 @@ public static class OverlayTab
             _ => Resources.ToastGuiRouteStateLegacyAddonHandlers,
         };
     }
+#endif
 
     private static bool DrawToastTypePage(
         Config config,

--- a/PluginUI/Tabs/OverlayTab.cs
+++ b/PluginUI/Tabs/OverlayTab.cs
@@ -369,6 +369,12 @@ public static class OverlayTab
 
         ImGui.TextWrapped(Resources.WhichToastsToTranslate);
         ImGui.Spacing();
+        changed |= ImGui.Checkbox(
+            Resources.ToastGuiCaptureForSupportedToastsLabel,
+            ref config.UseToastGuiCaptureForSupportedToasts);
+        ImGui.TextWrapped(
+            Resources.ToastGuiCaptureForSupportedToastsDescription);
+        ImGui.Spacing();
 
         changed |= ImGui.Checkbox(
             Resources.TranslateScreenInfoToastToggleText,

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -2621,6 +2621,78 @@ namespace Echoglossian.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Supported normal toast route.
+        /// </summary>
+        public static string ToastGuiNormalToastRouteStatusLabel {
+            get {
+                return ResourceManager.GetString("ToastGuiNormalToastRouteStatusLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Supported error toast route.
+        /// </summary>
+        public static string ToastGuiErrorToastRouteStatusLabel {
+            get {
+                return ResourceManager.GetString("ToastGuiErrorToastRouteStatusLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Quest toast route.
+        /// </summary>
+        public static string ToastGuiQuestToastRouteStatusLabel {
+            get {
+                return ResourceManager.GetString("ToastGuiQuestToastRouteStatusLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text Gimmick Hint route.
+        /// </summary>
+        public static string ToastGuiTextGimmickHintRouteStatusLabel {
+            get {
+                return ResourceManager.GetString("ToastGuiTextGimmickHintRouteStatusLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Legacy addon handlers.
+        /// </summary>
+        public static string ToastGuiRouteStateLegacyAddonHandlers {
+            get {
+                return ResourceManager.GetString("ToastGuiRouteStateLegacyAddonHandlers", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to ToastGui capture/prefetch.
+        /// </summary>
+        public static string ToastGuiRouteStateCapturePrefetch {
+            get {
+                return ResourceManager.GetString("ToastGuiRouteStateCapturePrefetch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to ToastGui full runtime.
+        /// </summary>
+        public static string ToastGuiRouteStateFullRuntime {
+            get {
+                return ResourceManager.GetString("ToastGuiRouteStateFullRuntime", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Addon handler only.
+        /// </summary>
+        public static string ToastGuiRouteStateAddonHandlerOnly {
+            get {
+                return ResourceManager.GetString("ToastGuiRouteStateAddonHandlerOnly", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to YandexCloud Api Key.
         /// </summary>
         public static string YandexCloudApiKey {

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -2603,6 +2603,24 @@ namespace Echoglossian.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Use ToastGui-assisted capture for supported normal/error toasts (experimental).
+        /// </summary>
+        public static string ToastGuiCaptureForSupportedToastsLabel {
+            get {
+                return ResourceManager.GetString("ToastGuiCaptureForSupportedToastsLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Keeps overlay bounds and native replacement on the addon handlers, but listens to ToastGui callbacks to prefetch translations earlier. Quest toasts already use ToastGui; Text Gimmick Hint still uses the addon path..
+        /// </summary>
+        public static string ToastGuiCaptureForSupportedToastsDescription {
+            get {
+                return ResourceManager.GetString("ToastGuiCaptureForSupportedToastsDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to YandexCloud Api Key.
         /// </summary>
         public static string YandexCloudApiKey {

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -2916,6 +2916,87 @@ namespace Echoglossian.Properties {
                 return ResourceManager.GetString("CouldNotFetchOllamaModels", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeNoActiveWatch {
+            get {
+                return ResourceManager.GetString("AddonProbeNoActiveWatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeStopped {
+            get {
+                return ResourceManager.GetString("AddonProbeStopped", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeUsage {
+            get {
+                return ResourceManager.GetString("AddonProbeUsage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeInvalidDurationFormat {
+            get {
+                return ResourceManager.GetString("AddonProbeInvalidDurationFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeStartedFormat {
+            get {
+                return ResourceManager.GetString("AddonProbeStartedFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeDurationMinuteFormat {
+            get {
+                return ResourceManager.GetString("AddonProbeDurationMinuteFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeDurationMinutesFormat {
+            get {
+                return ResourceManager.GetString("AddonProbeDurationMinutesFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeDurationSecondFormat {
+            get {
+                return ResourceManager.GetString("AddonProbeDurationSecondFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string.
+        /// </summary>
+        public static string AddonProbeDurationSecondsFormat {
+            get {
+                return ResourceManager.GetString("AddonProbeDurationSecondsFormat", resourceCulture);
+            }
+        }
     }
 }
 

--- a/Properties/Resources.pt-BR.resx
+++ b/Properties/Resources.pt-BR.resx
@@ -921,4 +921,31 @@
   <data name="ClaudeModelTooltipOpus41" xml:space="preserve">
     <value>Modelo Claude de nível mais alto quando você deseja qualidade máxima.</value>
   </data>
+  <data name="AddonProbeNoActiveWatch" xml:space="preserve">
+    <value>Não há um watch ativo do addon probe para parar.</value>
+  </data>
+  <data name="AddonProbeStopped" xml:space="preserve">
+    <value>Watch do addon probe parado.</value>
+  </data>
+  <data name="AddonProbeUsage" xml:space="preserve">
+    <value>Uso: /egloaddonprobe &lt;nome do addon&gt; [índice] [duração] ou /egloaddonprobe stop</value>
+  </data>
+  <data name="AddonProbeInvalidDurationFormat" xml:space="preserve">
+    <value>Duração inválida para addon probe. Use valores como 90s ou 15m, até {0} minutos.</value>
+  </data>
+  <data name="AddonProbeStartedFormat" xml:space="preserve">
+    <value>Watch do addon probe iniciado para '{0}'[{1}] por {2}. Verifique o Dalamud log para os dumps de eventos e árvore.</value>
+  </data>
+  <data name="AddonProbeDurationMinuteFormat" xml:space="preserve">
+    <value>{0} minuto</value>
+  </data>
+  <data name="AddonProbeDurationMinutesFormat" xml:space="preserve">
+    <value>{0} minutos</value>
+  </data>
+  <data name="AddonProbeDurationSecondFormat" xml:space="preserve">
+    <value>{0} segundo</value>
+  </data>
+  <data name="AddonProbeDurationSecondsFormat" xml:space="preserve">
+    <value>{0} segundos</value>
+  </data>
 </root>

--- a/Properties/Resources.pt-BR.resx
+++ b/Properties/Resources.pt-BR.resx
@@ -234,6 +234,30 @@
   <data name="ToastGuiCaptureForSupportedToastsDescription" xml:space="preserve">
     <value>Mantém os limites da overlay e a substituição nativa nos handlers do addon, mas escuta os callbacks do ToastGui para pré-carregar as traduções mais cedo. Quest toasts já usam ToastGui; Text Gimmick Hint continua usando o caminho do addon.</value>
   </data>
+  <data name="ToastGuiNormalToastRouteStatusLabel" xml:space="preserve">
+    <value>Rota dos toasts normais suportados</value>
+  </data>
+  <data name="ToastGuiErrorToastRouteStatusLabel" xml:space="preserve">
+    <value>Rota dos toasts de erro suportados</value>
+  </data>
+  <data name="ToastGuiQuestToastRouteStatusLabel" xml:space="preserve">
+    <value>Rota dos quest toasts</value>
+  </data>
+  <data name="ToastGuiTextGimmickHintRouteStatusLabel" xml:space="preserve">
+    <value>Rota do Text Gimmick Hint</value>
+  </data>
+  <data name="ToastGuiRouteStateLegacyAddonHandlers" xml:space="preserve">
+    <value>Handlers legados do addon</value>
+  </data>
+  <data name="ToastGuiRouteStateCapturePrefetch" xml:space="preserve">
+    <value>Captura/pré-busca via ToastGui</value>
+  </data>
+  <data name="ToastGuiRouteStateFullRuntime" xml:space="preserve">
+    <value>Runtime completo via ToastGui</value>
+  </data>
+  <data name="ToastGuiRouteStateAddonHandlerOnly" xml:space="preserve">
+    <value>Apenas handler do addon</value>
+  </data>
   <data name="AssetsCheckingPopupMsg" xml:space="preserve">
     <value>Verificando os arquivos do Plugin!</value>
   </data>

--- a/Properties/Resources.pt-BR.resx
+++ b/Properties/Resources.pt-BR.resx
@@ -228,6 +228,12 @@
   <data name="WhichToastsToTranslate" xml:space="preserve">
     <value>Selecione qual tipo de mensagens de toast traduzir</value>
   </data>
+  <data name="ToastGuiCaptureForSupportedToastsLabel" xml:space="preserve">
+    <value>Usar captura assistida por ToastGui para toasts normais/de erro suportados (experimental)</value>
+  </data>
+  <data name="ToastGuiCaptureForSupportedToastsDescription" xml:space="preserve">
+    <value>Mantém os limites da overlay e a substituição nativa nos handlers do addon, mas escuta os callbacks do ToastGui para pré-carregar as traduções mais cedo. Quest toasts já usam ToastGui; Text Gimmick Hint continua usando o caminho do addon.</value>
+  </data>
   <data name="AssetsCheckingPopupMsg" xml:space="preserve">
     <value>Verificando os arquivos do Plugin!</value>
   </data>

--- a/Properties/Resources.pt.resx
+++ b/Properties/Resources.pt.resx
@@ -951,4 +951,31 @@
   <data name="ClaudeModelTooltipOpus41" xml:space="preserve">
     <value>Modelo Claude de nível mais alto quando você deseja qualidade máxima.</value>
   </data>
+  <data name="AddonProbeNoActiveWatch" xml:space="preserve">
+    <value>Não há um watch ativo do addon probe para parar.</value>
+  </data>
+  <data name="AddonProbeStopped" xml:space="preserve">
+    <value>Watch do addon probe parado.</value>
+  </data>
+  <data name="AddonProbeUsage" xml:space="preserve">
+    <value>Uso: /egloaddonprobe &lt;nome do addon&gt; [índice] [duração] ou /egloaddonprobe stop</value>
+  </data>
+  <data name="AddonProbeInvalidDurationFormat" xml:space="preserve">
+    <value>Duração inválida para addon probe. Use valores como 90s ou 15m, até {0} minutos.</value>
+  </data>
+  <data name="AddonProbeStartedFormat" xml:space="preserve">
+    <value>Watch do addon probe iniciado para '{0}'[{1}] por {2}. Verifique o Dalamud log para os dumps de eventos e árvore.</value>
+  </data>
+  <data name="AddonProbeDurationMinuteFormat" xml:space="preserve">
+    <value>{0} minuto</value>
+  </data>
+  <data name="AddonProbeDurationMinutesFormat" xml:space="preserve">
+    <value>{0} minutos</value>
+  </data>
+  <data name="AddonProbeDurationSecondFormat" xml:space="preserve">
+    <value>{0} segundo</value>
+  </data>
+  <data name="AddonProbeDurationSecondsFormat" xml:space="preserve">
+    <value>{0} segundos</value>
+  </data>
 </root>

--- a/Properties/Resources.pt.resx
+++ b/Properties/Resources.pt.resx
@@ -279,6 +279,30 @@
   <data name="ToastGuiCaptureForSupportedToastsDescription" xml:space="preserve">
     <value>Mantém os limites da overlay e a substituição nativa nos handlers do addon, mas escuta os callbacks do ToastGui para pré-carregar as traduções mais cedo. Os quest toasts já usam ToastGui; o Text Gimmick Hint continua a usar o caminho do addon.</value>
   </data>
+  <data name="ToastGuiNormalToastRouteStatusLabel" xml:space="preserve">
+    <value>Rota dos toasts normais suportados</value>
+  </data>
+  <data name="ToastGuiErrorToastRouteStatusLabel" xml:space="preserve">
+    <value>Rota dos toasts de erro suportados</value>
+  </data>
+  <data name="ToastGuiQuestToastRouteStatusLabel" xml:space="preserve">
+    <value>Rota dos quest toasts</value>
+  </data>
+  <data name="ToastGuiTextGimmickHintRouteStatusLabel" xml:space="preserve">
+    <value>Rota do Text Gimmick Hint</value>
+  </data>
+  <data name="ToastGuiRouteStateLegacyAddonHandlers" xml:space="preserve">
+    <value>Handlers legados do addon</value>
+  </data>
+  <data name="ToastGuiRouteStateCapturePrefetch" xml:space="preserve">
+    <value>Captura/pré-busca via ToastGui</value>
+  </data>
+  <data name="ToastGuiRouteStateFullRuntime" xml:space="preserve">
+    <value>Runtime completo via ToastGui</value>
+  </data>
+  <data name="ToastGuiRouteStateAddonHandlerOnly" xml:space="preserve">
+    <value>Apenas handler do addon</value>
+  </data>
   <data name="ConfigTab8Name" xml:space="preserve">
     <value>Solucionando problemas</value>
   </data>

--- a/Properties/Resources.pt.resx
+++ b/Properties/Resources.pt.resx
@@ -273,6 +273,12 @@
   <data name="WhichToastsToTranslate" xml:space="preserve">
     <value>Selecione o tipo de notificação de mensagens do jogo a ser traduzida</value>
   </data>
+  <data name="ToastGuiCaptureForSupportedToastsLabel" xml:space="preserve">
+    <value>Usar captura assistida por ToastGui para toasts normais/de erro suportados (experimental)</value>
+  </data>
+  <data name="ToastGuiCaptureForSupportedToastsDescription" xml:space="preserve">
+    <value>Mantém os limites da overlay e a substituição nativa nos handlers do addon, mas escuta os callbacks do ToastGui para pré-carregar as traduções mais cedo. Os quest toasts já usam ToastGui; o Text Gimmick Hint continua a usar o caminho do addon.</value>
+  </data>
   <data name="ConfigTab8Name" xml:space="preserve">
     <value>Solucionando problemas</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -394,6 +394,12 @@
   <data name="WhichToastsToTranslate" xml:space="preserve">
     <value>Select which kind of in-game message toasts to translate</value>
   </data>
+  <data name="ToastGuiCaptureForSupportedToastsLabel" xml:space="preserve">
+    <value>Use ToastGui-assisted capture for supported normal/error toasts (experimental)</value>
+  </data>
+  <data name="ToastGuiCaptureForSupportedToastsDescription" xml:space="preserve">
+    <value>Keeps overlay bounds and native replacement on the addon handlers, but listens to ToastGui callbacks to prefetch translations earlier. Quest toasts already use ToastGui; Text Gimmick Hint still uses the addon path.</value>
+  </data>
   <data name="ConfigTab8Name" xml:space="preserve">
     <value>Troubleshooting</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -1183,4 +1183,31 @@
   <data name="ClaudeModelTooltipOpus41" xml:space="preserve">
     <value>Highest-tier Claude model when you want maximum quality.</value>
   </data>
+  <data name="AddonProbeNoActiveWatch" xml:space="preserve">
+    <value>No active addon probe watch to stop.</value>
+  </data>
+  <data name="AddonProbeStopped" xml:space="preserve">
+    <value>Addon probe watch stopped.</value>
+  </data>
+  <data name="AddonProbeUsage" xml:space="preserve">
+    <value>Usage: /egloaddonprobe &lt;addon name&gt; [index] [duration] or /egloaddonprobe stop</value>
+  </data>
+  <data name="AddonProbeInvalidDurationFormat" xml:space="preserve">
+    <value>Invalid addon probe duration. Use values like 90s or 15m, up to {0} minutes.</value>
+  </data>
+  <data name="AddonProbeStartedFormat" xml:space="preserve">
+    <value>Addon probe watch started for '{0}'[{1}] for {2}. Check the Dalamud log for event and tree dumps.</value>
+  </data>
+  <data name="AddonProbeDurationMinuteFormat" xml:space="preserve">
+    <value>{0} minute</value>
+  </data>
+  <data name="AddonProbeDurationMinutesFormat" xml:space="preserve">
+    <value>{0} minutes</value>
+  </data>
+  <data name="AddonProbeDurationSecondFormat" xml:space="preserve">
+    <value>{0} second</value>
+  </data>
+  <data name="AddonProbeDurationSecondsFormat" xml:space="preserve">
+    <value>{0} seconds</value>
+  </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -400,6 +400,30 @@
   <data name="ToastGuiCaptureForSupportedToastsDescription" xml:space="preserve">
     <value>Keeps overlay bounds and native replacement on the addon handlers, but listens to ToastGui callbacks to prefetch translations earlier. Quest toasts already use ToastGui; Text Gimmick Hint still uses the addon path.</value>
   </data>
+  <data name="ToastGuiNormalToastRouteStatusLabel" xml:space="preserve">
+    <value>Supported normal toast route</value>
+  </data>
+  <data name="ToastGuiErrorToastRouteStatusLabel" xml:space="preserve">
+    <value>Supported error toast route</value>
+  </data>
+  <data name="ToastGuiQuestToastRouteStatusLabel" xml:space="preserve">
+    <value>Quest toast route</value>
+  </data>
+  <data name="ToastGuiTextGimmickHintRouteStatusLabel" xml:space="preserve">
+    <value>Text Gimmick Hint route</value>
+  </data>
+  <data name="ToastGuiRouteStateLegacyAddonHandlers" xml:space="preserve">
+    <value>Legacy addon handlers</value>
+  </data>
+  <data name="ToastGuiRouteStateCapturePrefetch" xml:space="preserve">
+    <value>ToastGui capture/prefetch</value>
+  </data>
+  <data name="ToastGuiRouteStateFullRuntime" xml:space="preserve">
+    <value>ToastGui full runtime</value>
+  </data>
+  <data name="ToastGuiRouteStateAddonHandlerOnly" xml:space="preserve">
+    <value>Addon handler only</value>
+  </data>
   <data name="ConfigTab8Name" xml:space="preserve">
     <value>Troubleshooting</value>
   </data>

--- a/UIOverlays/TranslationOverlay/OverlayConfigs.cs
+++ b/UIOverlays/TranslationOverlay/OverlayConfigs.cs
@@ -107,18 +107,28 @@ public partial class Echoglossian
         this.registeredOverlays.Add(
             new OverlayRegistration(
                 this.toastOverlay,
-                () => TranslationWindowConfig.FromConfigForWideTextToast(this.configuration),
+                () => TranslationWindowConfig.FromConfigForToast(this.configuration),
                 isEnabled: () =>
-                    this.configuration.TranslateToast &&
-                    this.configuration.TranslateWideTextToast &&
-                    NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
-                        this.configuration.WideTextToastTranslationDisplayMode,
-                        this.configuration.OverlayOnlyLanguage),
+                    NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+                        this.configuration)
+                        ? NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
+                            NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(
+                                this.configuration),
+                            this.configuration.OverlayOnlyLanguage)
+                        : this.configuration.TranslateToast &&
+                          this.configuration.TranslateWideTextToast &&
+                          NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
+                              this.configuration.WideTextToastTranslationDisplayMode,
+                              this.configuration.OverlayOnlyLanguage),
                 syncBeforeDraw: () =>
-                    this.TrySyncToastOverlayToAddon(
-                        "_WideText",
-                        this.toastOverlay,
-                        AddonTextNodeResolvers.ResolveWideTextNode)));
+                    NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+                        this.configuration)
+                        ? this.toastGuiSupportedToastRuntime.TrySyncNormalToastOverlayToViewport(
+                            this.toastOverlay)
+                        : this.TrySyncToastOverlayToAddon(
+                            "_WideText",
+                            this.toastOverlay,
+                            AddonTextNodeResolvers.ResolveWideTextNode)));
 
         this.registeredOverlays.Add(
             new OverlayRegistration(
@@ -126,16 +136,25 @@ public partial class Echoglossian
                 () => TranslationWindowConfig.FromConfigForErrorToast(
                     this.configuration),
                 isEnabled: () =>
-                    this.configuration.TranslateToast &&
-                    this.configuration.TranslateErrorToast &&
-                    NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
-                        this.configuration.ErrorToastTranslationDisplayMode,
-                        this.configuration.OverlayOnlyLanguage),
+                    NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedErrorToastRuntime(
+                        this.configuration)
+                        ? NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
+                            this.configuration.ErrorToastTranslationDisplayMode,
+                            this.configuration.OverlayOnlyLanguage)
+                        : this.configuration.TranslateToast &&
+                          this.configuration.TranslateErrorToast &&
+                          NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
+                              this.configuration.ErrorToastTranslationDisplayMode,
+                              this.configuration.OverlayOnlyLanguage),
                 syncBeforeDraw: () =>
-                    this.TrySyncToastOverlayToAddon(
-                        "_TextError",
-                        this.errorToastOverlay,
-                        AddonTextNodeResolvers.ResolveFirstTextNode)));
+                    NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedErrorToastRuntime(
+                        this.configuration)
+                        ? this.toastGuiSupportedToastRuntime.TrySyncErrorToastOverlayToViewport(
+                            this.errorToastOverlay)
+                        : this.TrySyncToastOverlayToAddon(
+                            "_TextError",
+                            this.errorToastOverlay,
+                            AddonTextNodeResolvers.ResolveFirstTextNode)));
 
         this.registeredOverlays.Add(
             new OverlayRegistration(
@@ -143,6 +162,8 @@ public partial class Echoglossian
                 () => TranslationWindowConfig.FromConfigForAreaToast(
                     this.configuration),
                 isEnabled: () =>
+                    !NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+                        this.configuration) &&
                     this.configuration.TranslateToast &&
                     this.configuration.TranslateAreaToast &&
                     NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(
@@ -160,6 +181,8 @@ public partial class Echoglossian
                 () => TranslationWindowConfig.FromConfigForClassChangeToast(
                     this.configuration),
                 isEnabled: () =>
+                    !NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+                        this.configuration) &&
                     this.configuration.TranslateToast &&
                     this.configuration.TranslateClassChangeToast &&
                     NativeUI.Helpers.TranslationDisplayModeHelper.UsesOverlayPresentation(

--- a/UIOverlays/TranslationOverlay/TranslationOverlayDrawer.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayDrawer.cs
@@ -862,7 +862,11 @@ namespace Echoglossian
         TranslationOverlaySurfaceId.MiniTalk => this.configuration.MiniTalkTranslationDisplayMode,
         TranslationOverlaySurfaceId.CutSceneSelectString => this.configuration.CutSceneSelectStringTranslationDisplayMode,
         TranslationOverlaySurfaceId.TextGimmickHint => this.configuration.TextGimmickHintTranslationDisplayMode,
-        TranslationOverlaySurfaceId.WideTextToast => this.configuration.WideTextToastTranslationDisplayMode,
+        TranslationOverlaySurfaceId.WideTextToast => NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.UseSupportedNormalToastRuntime(
+                this.configuration)
+            ? NativeUI.AddonHandlers.Toasts.ToastGuiSupportedToastPolicy.GetNormalToastDisplayMode(
+                this.configuration)
+            : this.configuration.WideTextToastTranslationDisplayMode,
         TranslationOverlaySurfaceId.ErrorToast => this.configuration.ErrorToastTranslationDisplayMode,
         TranslationOverlaySurfaceId.AreaToast => this.configuration.AreaToastTranslationDisplayMode,
         TranslationOverlaySurfaceId.ClassChangeToast => this.configuration.ClassChangeToastTranslationDisplayMode,

--- a/docs/commands/egloaddonprobe.md
+++ b/docs/commands/egloaddonprobe.md
@@ -37,11 +37,12 @@ When started, the probe watches the requested addon for a short period and logs:
 - raw subscriber ids plus best-effort addon-name resolution for those arrays
 
 When `stop` or `cancel` is passed, the active watch is stopped if one exists.
-In `DEBUG` builds, the plugin also auto-starts managed probe watches for
+In `DEBUG` builds, the plugin can also auto-start managed probe watches for
 `_BattleTalk` and `_MiniTalk` once per login session so their earliest hidden
-state can be captured before the in-game chat is available. `/egloaddonprobe stop`
-stops both the manual watch and any auto-started managed watches for the current
-login session.
+state can be captured before the in-game chat is available. This path is gated
+by the hidden config flag `EnableDebugLoginAddonProbe`, which defaults to
+`false`. `/egloaddonprobe stop` stops both the manual watch and any auto-started
+managed watches for the current login session.
 
 The optional `duration` token accepts:
 

--- a/docs/commands/egloaddonprobe.md
+++ b/docs/commands/egloaddonprobe.md
@@ -37,6 +37,11 @@ When started, the probe watches the requested addon for a short period and logs:
 - raw subscriber ids plus best-effort addon-name resolution for those arrays
 
 When `stop` or `cancel` is passed, the active watch is stopped if one exists.
+In `DEBUG` builds, the plugin also auto-starts managed probe watches for
+`_BattleTalk` and `_MiniTalk` once per login session so their earliest hidden
+state can be captured before the in-game chat is available. `/egloaddonprobe stop`
+stops both the manual watch and any auto-started managed watches for the current
+login session.
 
 The optional `duration` token accepts:
 

--- a/docs/commands/egloaddonprobe.md
+++ b/docs/commands/egloaddonprobe.md
@@ -10,6 +10,7 @@ It is the main diagnostic command for understanding addon tree structure, node l
 
 ```text
 /egloaddonprobe <addon name> [index]
+/egloaddonprobe <addon name> [index] [duration]
 /egloaddonprobe stop
 ```
 
@@ -18,6 +19,8 @@ Examples:
 ```text
 /egloaddonprobe JournalDetail
 /egloaddonprobe _ToDoList 0
+/egloaddonprobe _BattleTalk 15m
+/egloaddonprobe _BattleTalk 0 900s
 /egloaddonprobe stop
 ```
 
@@ -34,6 +37,19 @@ When started, the probe watches the requested addon for a short period and logs:
 - raw subscriber ids plus best-effort addon-name resolution for those arrays
 
 When `stop` or `cancel` is passed, the active watch is stopped if one exists.
+
+The optional `duration` token accepts:
+
+- `<n>s` for seconds
+- `<n>m` for minutes
+
+Examples:
+
+- `90s`
+- `10m`
+- `15m`
+
+The current maximum watch duration is `30m`.
 
 ## Typical Use
 

--- a/docs/dialogue-and-toast-runtime-flows.md
+++ b/docs/dialogue-and-toast-runtime-flows.md
@@ -56,6 +56,11 @@ Toast-family surfaces covered here:
 - `_TextGimmickHint`
 - quest toast callback runtime
 
+Optional alternate capture runtime:
+
+- `IToastGui.Toast` prefetch for supported normal toasts
+- `IToastGui.ErrorToast` prefetch for error toasts
+
 ## Registration map
 
 All of these surfaces are wired from
@@ -307,16 +312,18 @@ Current risk:
 
 ## Toast-family overview
 
-There are two different runtime shapes in the toast family:
+There are three different runtime shapes in the toast family:
 
 1. AddonLifecycle-driven text-node toasts
 2. callback-driven quest toast
+3. optional callback-assisted prefetch for supported normal/error toasts
 
 ```mermaid
 flowchart TD
     A[Toast event] --> B{Surface}
     B --> C[AddonLifecycle toast addon]
     B --> D[Quest toast callback]
+    B --> E[ToastGui callback prefetch]
 
     C --> C1[PreUpdate read visible text node]
     C1 --> C2[Cache or DB lookup]
@@ -329,6 +336,11 @@ flowchart TD
     D2 --> D3[Publish overlay]
     D2 --> D4[Mutate callback SeString directly if native mode]
     D2 --> D5[Queue async translation on miss]
+
+    E --> E1[Read callback SeString source]
+    E1 --> E2[Prefetch DB or cache row]
+    E2 --> E3[Later addon handler reuses cached row]
+    E3 --> E4[Overlay bounds and swap logic still come from live addon]
 ```
 
 ## AddonLifecycle toast family
@@ -431,6 +443,55 @@ flowchart TD
 
 This is the most source-native toast flow in the family today.
 
+## Optional `ToastGui`-assisted capture for supported normal/error toasts
+
+Current owner:
+
+- [ToastGuiCaptureRuntime.cs](../NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs)
+
+Key facts:
+
+- this path is gated by `Config.UseToastGuiCaptureForSupportedToasts`
+- it listens to:
+  - `IToastGui.Toast`
+  - `IToastGui.ErrorToast`
+- it does not replace the addon handlers
+- it does not publish overlays directly
+- it does not mutate the callback payload
+- it only prefetches translated rows into the same `ToastMessage` history that
+  addon-based toast handlers already use
+
+Current flow:
+
+```mermaid
+flowchart TD
+    A[IToastGui.Toast or IToastGui.ErrorToast] --> B[Read original SeString text]
+    B --> C{Translated row already exists}
+    C -->|yes| D[Do nothing else]
+    C -->|no| E[Queue async prefetch translation]
+    E --> F[Store ToastMessage row]
+    F --> G[Later addon handler sees DB or cache hit]
+    G --> H[Overlay publication still uses live addon bounds]
+    G --> I[Native replacement still uses live addon path]
+```
+
+Why it exists:
+
+- it captures toast source earlier than addon-node polling
+- it reduces dependence on reading a live text node that might already be
+  mutated by native replacement
+- it preserves the current overlay path, so swap mode and overlay positioning
+  still depend on the visible addon and should not regress just because the
+  source was prefetched earlier
+
+Important limitation:
+
+- generic `IToastGui.Toast` does not expose enough subtype metadata to replace
+  the per-addon presentation model outright
+- because of that, `_WideText`, `_AreaText`, and `_TextClassChange` still keep
+  the addon handlers as presentation owners
+- `_TextGimmickHint` remains addon-only for now
+
 ## Overlay ownership
 
 Overlay publication for these surfaces is still separate from capture and native
@@ -448,6 +509,9 @@ That means:
 - overlay bounds and overlay text are not owned by the dialogue or toast
   handlers directly
 - the handlers only publish content and ask for bounds synchronization
+- the experimental `ToastGui`-assisted toast path still relies on the addon
+  handlers for overlay publication, specifically to preserve bounds, swap mode,
+  and native/overlay presentation parity
 
 ## Current pain points
 

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -520,3 +520,33 @@ Changes:
 
 Validation:
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter NativeTextNodeLayoutHelperTests`
+
+## Iteration 17
+
+Goal:
+- apply the global non-quest native replacement diacritics-removal toggle
+  consistently across shared DB-first native UI surfaces
+- keep overlay-only payloads and persistence semantics unchanged
+
+Root cause:
+- Talk, BattleTalk, MiniTalk, subtitles, and toast-family handlers already
+  normalized replacement text in their addon-local native apply paths
+- shared DB-first handlers and the `_MainCommand` refresh writer still wrote
+  translated native text directly without passing through that same
+  normalization step
+
+Changes:
+- added `NativeReplacementTextNormalizationHelper` as a pure shared payload
+  normalizer for native replacement-only writes
+- added `Echoglossian.TryCreateNativeReplacementTextNormalizer(...)` so shared
+  handlers can reuse the same game-font diacritics-removal callback without
+  changing DB semantics
+- `DbFirstGameWindowAddonHandler.ApplyPayload(...)` now normalizes translated
+  payloads only for display modes that actually write native translation
+- `_MainCommand` refresh apply now normalizes translated payloads before
+  writing translated labels into refresh `AtkValue`s
+- added focused tests in:
+  - `Echoglossian.Tests/NativeReplacementTextNormalizationHelperTests.cs`
+
+Validation:
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter NativeReplacementTextNormalizationHelperTests`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -619,6 +619,35 @@ Validation:
 - `dotnet build Echoglossian.sln -c Debug --no-restore`
 - `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`
 
+## Iteration 21
+
+Goal:
+- guarantee that users upgrading from older persisted configs receive newly
+  introduced config fields with defaults materialized in their local
+  `Echoglossian.json`
+
+Root cause:
+- runtime already handles missing fields safely through `Config` defaults, but
+  older persisted JSON files can still omit new keys until some later manual
+  save
+- that makes support/debug harder because runtime and persisted config may not
+  match immediately after update
+
+Changes:
+- added `EnsureConfigDefaultsPersistedForMissingKeys()` in
+  `GeneralHelpers/Utils.cs`
+- startup now calls this check right after config migrations in
+  `Echoglossian` constructor
+- the check compares persisted JSON keys against the current runtime config
+  shape and triggers one `SaveConfig(...)` when any known field is missing,
+  materializing defaults into the user file
+- failure to inspect the JSON is handled as a warning without blocking plugin
+  startup
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`
+
 ## Iteration 20
 
 Goal:

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -321,3 +321,42 @@ Changes:
 Validation:
 - `dotnet build Echoglossian.sln -c Debug --no-restore`
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 11
+
+Goal:
+- reduce the remaining `_MiniTalk` flicker by letting the game keep the live
+  bubble position while still restoring the original geometry between native
+  apply passes
+- give `_MiniTalk` a little more horizontal room derived from the live bubble
+  padding instead of fixed widths
+- stop re-centering toast text inside widened backgrounds when that centering
+  pushes the text to the right of the visual addon center
+
+Findings:
+- `_MiniTalk` bubbles track NPC movement, so restoring the snapshot X/Y
+  positions on every reset can fight the game and create frame-to-frame
+  position jitter
+- the prior width fix had not actually landed in a validated build because the
+  new `_MiniTalk` helper had a compile-time type ambiguity
+- the shared horizontal-centering helper was still running for addon toasts and
+  could visibly shift text rightward relative to the toast background
+
+Changes:
+- `RestoreLayoutSnapshot(...)` now supports restoring size/flags without
+  restoring node positions
+- `_MiniTalk` now restores tracked native layouts with `restorePositions: false`
+  so the bubble keeps the game-controlled live position while geometry resets to
+  the original client state
+- `_MiniTalk` native apply now adds a small extra wrap-width allowance derived
+  from the current left/right padding inside the live bubble
+- the shared native text reflow helper now accepts:
+  - `restoreHorizontalCentering`
+  - `additionalWrapWidth`
+- addon toasts and `_TextGimmickHint` now disable the horizontal-centering
+  adjustment so their text can stay anchored to the original addon layout
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+- `dotnet build Echoglossian.csproj -c Release --no-restore`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -1,0 +1,161 @@
+# Native Toast And MiniTalk Iteration Log
+
+Date: 2026-05-19
+
+## Scope
+
+This log tracks the follow-up work on native text reflow and state restoration
+ for:
+
+- `_MiniTalk`
+- `_BattleTalk`
+- native addon toasts handled through addon-node mutation
+- `_TextGimmickHint`
+
+This document exists because the work is highly iterative and probe-driven. The
+ goal is to keep the history of what was attempted, what was learned from the
+ probes, and what changed in code.
+
+## Iteration 1
+
+Goal:
+- introduce a shared native text reflow helper so translated text can grow
+  wrappers and the nearest background without repeating handler-specific sizing
+  code
+
+Changes:
+- added shared native sizing and wrapper-growth logic in
+  `NativeTextNodeLayoutHelper`
+- wired the helper into:
+  - `_BattleTalk`
+  - `_MiniTalk`
+  - addon toast handlers
+  - `_TextGimmickHint`
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 2
+
+Goal:
+- stop `_MiniTalk` from repeatedly translating already-translated visible text
+
+Findings:
+- `_MiniTalk` in native replacement mode could recapture its own translated
+  visible text as a new source line
+
+Changes:
+- `_MiniTalk` now tries to recover the original source through:
+  - tracked replacement-to-original state
+  - `OriginalTextPointer`
+  - known replacement-to-original mapping across tracked bubbles
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 3
+
+Goal:
+- stop repeated width collapse in `_MiniTalk`
+
+Findings:
+- repeated reflow reused the already-shrunk text-node width as the next wrap
+  width
+- bubble reuse caused each pass to get narrower and taller
+
+Changes:
+- the shared helper now prefers a stable container/background width over a
+  previously shrunken text-node width
+- `_BattleTalk` was aligned to the same width-resolution rule
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 4
+
+Goal:
+- make addon probing usable for long-lived `_BattleTalk` and toast captures
+
+Changes:
+- `/egloaddonprobe` now accepts explicit watch durations such as:
+  - `/egloaddonprobe _BattleTalk 15m`
+  - `/egloaddonprobe _BattleTalk 900s`
+- localized the new probe command wording in `Resources`
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 5
+
+Goal:
+- understand why `_MiniTalk` still degraded after the shared text-node helper
+  looked mostly correct
+
+Probe findings:
+- `_MiniTalk` is a pooled addon with multiple reusable bubble slots
+- hidden component roots can still leave descendant text nodes readable
+- the problem is not just text-node width; it is slot-state leakage across the
+  whole bubble
+- the addon has a dedicated `StringArrayData` subscription:
+  - `_MiniTalk`
+  - `stringArrayIndex=32`
+
+Conclusion:
+- `_MiniTalk` must be handled as a component-backed bubble pool, not as a
+  simple list of free-standing text nodes
+
+## Iteration 6
+
+Goal:
+- restore whole-slot layout state and stop stale translation/layout reuse in
+  `_MiniTalk` and toast-family native replacement
+
+Changes:
+- `AddonTextNodeResolvers.ResolveMiniTalkBubbleTextNodes(...)` now resolves
+  bubble text nodes from visible top-level component slots instead of collecting
+  any readable text node from the entire addon tree
+- `_MiniTalk` now reconciles the currently visible source line before trusting
+  already-resolved translated state
+- restoring a prior native layout snapshot can now skip writing the previous
+  original text back when the slot has already been reused by a different
+  source line
+- `NativeTextNodeLayoutHelper` now restores:
+  - wrapper X/Y
+  - wrapper width/height
+  - secondary-container X/Y
+  - secondary-container width/height
+- addon toast handlers and `_TextGimmickHint` now reconcile visible source text
+  before using stale resolved state, following the same model
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+- `dotnet build Echoglossian.csproj -c Release --no-restore`
+
+## Current State
+
+What improved:
+- `_BattleTalk` native mode is visually better than the earlier fixed-width and
+  forced-font-shrink implementation
+- the code now has shared snapshot-and-restore infrastructure instead of ad hoc
+  one-off sizing per handler
+- `_MiniTalk` and toast-family state handling is now much closer to a correct
+  pooled-slot model
+
+What still needs in-game confirmation:
+- `_MiniTalk` bubble reuse stability after the slot-level reconcile changes
+- toast-family source reconciliation and centering consistency
+- whether additional toast surfaces can be moved to an earlier `IToastGui`
+  callback path instead of addon-node mutation
+
+## Next Investigation
+
+1. test the latest `_MiniTalk` and toast-family reconcile changes in game
+2. investigate `IToastGui.Toast` and `IToastGui.ErrorToast` as alternate
+   source-level handling paths behind a config toggle
+3. preserve the current addon-node flow as the default stable path until the
+   alternate toast runtime proves safe

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -236,3 +236,42 @@ Changes:
 
 Validation:
 - pending after implementation
+
+## Iteration 9
+
+Goal:
+- start probing `_BattleTalk` and `_MiniTalk` automatically at login in
+  `DEBUG` builds so the earliest hidden addon state can be captured before the
+  game chat becomes available
+- allow `/egloaddonprobe stop` to stop both manual and auto-started probe
+  watches for the current login session
+
+Findings:
+- the existing addon-probe command only tracked one manual watch
+- the shared `AddonStructureProbeWatch` already dumps an addon even when it is
+  resolved while invisible, so it can capture `_BattleTalk`'s startup state as
+  soon as the login session becomes ready
+- `_MiniTalk` is not guaranteed to exist at login, but starting a managed watch
+  there is still useful because the watch will dump as soon as the addon
+  appears later in the same session
+
+Changes:
+- added `AddonProbeAutoWatchPolicy` as the small testable gate for:
+  - one automatic watch set per login session
+  - stop-command suppression until the next logout
+- added `AddonProbeAutoWatchHelpers` to:
+  - tick the manual watch
+  - tick managed auto-started watches
+  - start `_BattleTalk` and `_MiniTalk` managed watches for `15m` once per
+    login session
+  - reset that gate on logout
+- `/egloaddonprobe stop` now stops:
+  - the manual watch
+  - any auto-started managed watches
+- documented the new `DEBUG` login auto-probe behavior in
+  `docs/commands/egloaddonprobe.md`
+
+Validation:
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter AddonProbeAutoWatchPolicyTests`
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -595,3 +595,26 @@ Changes:
 
 Focused validation:
 - `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --filter ToastGuiSupportedToastPolicyTests`
+
+## Iteration 19
+
+Goal:
+- stop ImGui table assertions that were spamming `dalamud.log` and potentially
+  impacting frame-time stability while the DB Editor window is open
+
+Root cause:
+- `DbTableView` called `ImGui.TableSetupColumn` with a non-zero initial width
+  (`150f`) while using `ImGuiTableColumnFlags.None`
+- ImGui requires explicit table or column sizing policy whenever
+  `initWidthOrWeight` is specified; otherwise it triggers:
+  - `init_width_or_weight <= 0.0f && "Can only specify width/weight if sizing policy is set explicitly in either Table or Column."`
+
+Changes:
+- updated `DBManagerUI/Components/DbTableView.cs` so data columns use explicit
+  `ImGuiTableColumnFlags.WidthFixed` when passing an initial width
+- kept behavior narrow: no table routing, cache, or native-surface behavior
+  changes
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -197,3 +197,42 @@ What still needs in-game confirmation:
    - `_TextClassChange`
 3. preserve the current addon-node flow as the default stable path until the
    callback-assisted runtime proves safe enough to own more of the pipeline
+
+## Iteration 8
+
+Goal:
+- stop `_MiniTalk` and `_BattleTalk` from re-applying native layout on top of
+  already-mutated geometry
+- keep wrap width tied to the stable original bubble/addon width instead of the
+  potentially bloated width left behind by a prior native replacement pass
+
+Findings:
+- `_MiniTalk` could still capture a layout snapshot from an already-mutated
+  bubble when the same visible line was re-applied
+- `_BattleTalk` native replacement still used exact string equality for the
+  visible translated text, so layout-driven whitespace changes could trigger
+  another apply pass against the same source line
+- the shared helper still trusted the current text-node width over the stable
+  container width, and it allowed `ResizeNodeForCurrentText()` to report a
+  larger width than the intended wrap width
+
+Changes:
+- `NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(...)` now prefers the
+  bounded container width whenever it exists
+- `NativeTextNodeLayoutHelper.ApplyWrappedTextAndMeasure(...)` now clamps the
+  effective width back to the chosen wrap width after the resize pass and uses
+  that width for downstream container sizing
+- `_MiniTalk` now restores the tracked native layout for the same bubble/source
+  before reapplying translation, so each apply pass starts from the original
+  bubble geometry
+- `_MiniTalk` native reflow now keeps width growth disabled again, relying on a
+  better stable wrap width instead of growing the whole bubble horizontally
+- `_BattleTalk` now restores the tracked native layout before a same-source
+  reapply
+- `_BattleTalk` now uses normalized text comparison when checking whether the
+  visible translated text is already applied
+- `_BattleTalk` native reflow now keeps width growth disabled so the original
+  addon width remains the wrap target
+
+Validation:
+- pending after implementation

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -550,3 +550,48 @@ Changes:
 
 Validation:
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter NativeReplacementTextNormalizationHelperTests`
+
+## Iteration 18
+
+Goal:
+- make it explicit, in runtime UI and policy tests, whether supported toasts
+  are currently using the legacy addon path, the old ToastGui capture/prefetch
+  path, or the full ToastGui runtime path
+- enable the full supported-toast ToastGui route in the user's real local
+  `Echoglossian.json` without guessing
+
+Root cause:
+- the hidden toast routing toggles lived only in config and policy code
+- there was no explicit runtime-facing status showing which route was actually
+  active for normal/error toasts
+- the real local config file did not contain either hidden ToastGui toast key,
+  so runtime behavior silently fell back to the default legacy addon handlers
+
+Changes:
+- added `ToastGuiRouteState` as the canonical route-state enum for supported
+  toast-family routing
+- added:
+  - `ToastGuiSupportedToastPolicy.GetSupportedNormalToastRouteState(...)`
+  - `ToastGuiSupportedToastPolicy.GetSupportedErrorToastRouteState(...)`
+- expanded `ToastGuiSupportedToastPolicyTests` to cover:
+  - default legacy state
+  - capture/prefetch state
+  - full runtime state
+  for both normal and error toast families
+- updated `OverlayTab.DrawToastGeneralPage(...)` to show live route status for:
+  - supported normal toasts
+  - supported error toasts
+  - quest toast
+  - text gimmick hint
+- added localized resource keys for those route-status labels and values
+- manually aligned `Resources.Designer.cs` because this repo branch did not
+  regenerate the designer automatically during the test-first pass
+- updated the real local config at:
+  - `%APPDATA%\\XIVLauncher\\pluginConfigs\\Echoglossian.json`
+  to set:
+  - `UseToastGuiRuntimeForSupportedToasts = true`
+  - `UseToastGuiCaptureForSupportedToasts = false`
+  with a timestamped backup created alongside the file
+
+Focused validation:
+- `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --filter ToastGuiSupportedToastPolicyTests`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -270,6 +270,8 @@ Changes:
   - any auto-started managed watches
 - documented the new `DEBUG` login auto-probe behavior in
   `docs/commands/egloaddonprobe.md`
+- added hidden config flag `EnableDebugLoginAddonProbe`, default `false`, so
+  the login auto-probe path is opt-in instead of always-on
 
 Validation:
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter AddonProbeAutoWatchPolicyTests`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -618,3 +618,34 @@ Changes:
 Validation:
 - `dotnet build Echoglossian.sln -c Debug --no-restore`
 - `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 20
+
+Goal:
+- make the supported toast ToastGui runtime path always active when
+  `TranslateToast` is enabled
+- remove redundant user-facing controls for legacy capture/runtime toggles
+- keep route-state diagnostics visible only in debug builds
+
+Root cause:
+- the first toast general-page checkbox (`UseToastGuiCaptureForSupportedToasts`)
+  had become operationally redundant for user flows after we stabilized the
+  callback-owned path
+- exposing hidden route toggles in normal UI increased confusion and made it
+  harder to reason about effective runtime ownership
+
+Changes:
+- updated `ToastGuiSupportedToastPolicy` so supported runtime activation is now
+  driven only by `TranslateToast`
+- disabled legacy capture-prefetch policy gates in that policy (`false`)
+- removed `UseToastGuiRuntimeForSupportedToasts` from addon-handler
+  registration signature refresh inputs (it no longer affects routing)
+- removed the toast general-page hidden capture checkbox from public UI
+- kept route-status text blocks behind `#if DEBUG` in
+  `PluginUI/Tabs/OverlayTab.cs`
+- updated toast policy tests and capture-runtime gating test semantics to
+  reflect the always-on callback-owned supported-toast route
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -489,3 +489,34 @@ Changes:
 
 Focused validation:
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter "ConfigDefaultsTests|ToastGuiCaptureRuntimeTests|ToastGuiSupportedToastPolicyTests"`
+
+## Iteration 16
+
+Goal:
+- keep the BattleTalk timer spinner inside the visible background after native
+  text reflow
+- preserve client-derived sizing instead of introducing fixed widths or
+  resolution-specific heuristics
+
+Root cause:
+- BattleTalk already re-anchored the timer/spinner node after text reflow, but
+  the nine-grid background width was not guaranteed to grow with it
+- that let the spinner end up past the right edge of the background even when
+  the parent addon and text node had resized correctly
+
+Changes:
+- extended `NativeTextNodeLayoutSnapshot` to capture:
+  - anchored sibling width
+  - original right padding between the anchored sibling and the secondary
+    background
+- added
+  `NativeTextNodeLayoutHelper.ResolveMinimumSecondaryWidthForAnchoredNode(...)`
+  as a reusable geometry helper
+- `ResizeFromSnapshot(...)` now grows the secondary container just enough to
+  keep an anchored sibling node covered by the same background, while clamping
+  negative historical padding to zero
+- added focused tests in:
+  - `Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs`
+
+Validation:
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter NativeTextNodeLayoutHelperTests`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -277,3 +277,47 @@ Validation:
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter AddonProbeAutoWatchPolicyTests`
 - `dotnet build Echoglossian.sln -c Debug --no-restore`
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+## Iteration 10
+
+Goal:
+- stop cross-surface leakage where stale `OriginalTextPointer` content could be
+  mistaken for the logical source line in `_MiniTalk`, addon toasts, or
+  `_TextGimmickHint`
+- reduce `_MiniTalk` and `BattleTalk` flicker by restoring only geometry before
+  same-source native reapply passes instead of briefly writing the original text
+  back into the node mid-frame
+
+Findings:
+- `_MiniTalk`, addon toasts, and `_TextGimmickHint` all trusted
+  `AtkTextNode.OriginalTextPointer` whenever it differed from the visible node
+  text
+- pooled/recycled native text nodes can carry stale original-pointer content
+  from an unrelated prior use, which is enough to make one surface believe the
+  source text belongs to another surface
+- `_MiniTalk` and `BattleTalk` same-source reapply paths restored the original
+  text as part of the geometry reset, which can create visible flicker when the
+  next apply happens in a later lifecycle callback of the same frame
+
+Changes:
+- `_MiniTalk` now accepts `OriginalTextPointer` only when MiniTalk itself can
+  corroborate that original through:
+  - the current bubble state
+  - another tracked MiniTalk bubble state
+  - or a stored `MiniTalkMessage` row whose replacement matches the visible text
+- addon toasts now accept `OriginalTextPointer` only when the toast surface can
+  corroborate it through:
+  - the current toast handler state
+  - or a stored `ToastMessage` row whose replacement matches the visible text
+- `_TextGimmickHint` now applies the same corroboration rule through:
+  - the current gimmick-hint handler state
+  - or a stored `TextGimmickHintMessage` row whose replacement matches the
+    visible text
+- `_MiniTalk` same-source reapply now restores only geometry and flags before
+  writing the replacement back, avoiding an intermediate original-text flash
+- `BattleTalk` same-source reapply now restores only geometry and flags before
+  reapplying the translated text and translated speaker name
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -146,16 +146,54 @@ What improved:
 - `_MiniTalk` and toast-family state handling is now much closer to a correct
   pooled-slot model
 
+## Iteration 7
+
+Goal:
+- explore `ToastGui` as an earlier source-capture path for supported toasts
+  without regressing the existing overlay/native presentation behavior
+
+Findings:
+- `IToastGui.QuestToast` is already a full callback-native runtime in the repo
+- `IToastGui.Toast` and `IToastGui.ErrorToast` expose earlier source payloads
+  for normal/error toasts
+- generic `IToastGui.Toast` does not expose enough subtype metadata to replace
+  `_WideText`, `_AreaText`, and `_TextClassChange` as presentation owners
+- because overlay bounds and swap mode still depend on the live addon shape,
+  the safest first step is callback-assisted prefetch, not a full replacement
+  of the addon handlers
+
+Changes:
+- added `Config.UseToastGuiCaptureForSupportedToasts`
+- added `ToastGuiCaptureRuntime`
+- registered `IToastGui.Toast` and `IToastGui.ErrorToast` callbacks
+- the callback runtime now prefetches translations into the existing
+  `ToastMessage` persistence path for:
+  - supported normal toasts
+  - error toasts
+- overlay publication and native replacement remain owned by the addon
+  handlers, preserving existing overlay bounds behavior
+- documented the split explicitly in
+  `docs/dialogue-and-toast-runtime-flows.md`
+
+Validation:
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
 What still needs in-game confirmation:
 - `_MiniTalk` bubble reuse stability after the slot-level reconcile changes
 - toast-family source reconciliation and centering consistency
-- whether additional toast surfaces can be moved to an earlier `IToastGui`
-  callback path instead of addon-node mutation
+- whether the `ToastGui`-assisted toast path improves cache-hit timing without
+  changing overlay/swap presentation
+- whether additional toast surfaces can be moved further toward source-level
+  handling after this first prefetch-only cut
 
 ## Next Investigation
 
 1. test the latest `_MiniTalk` and toast-family reconcile changes in game
-2. investigate `IToastGui.Toast` and `IToastGui.ErrorToast` as alternate
-   source-level handling paths behind a config toggle
+2. test the new `ToastGui`-assisted capture toggle with:
+   - `_WideText`
+   - `_TextError`
+   - `_AreaText`
+   - `_TextClassChange`
 3. preserve the current addon-node flow as the default stable path until the
-   alternate toast runtime proves safe
+   callback-assisted runtime proves safe enough to own more of the pipeline

--- a/docs/native-toast-and-minitalk-iteration-log.md
+++ b/docs/native-toast-and-minitalk-iteration-log.md
@@ -360,3 +360,132 @@ Validation:
 - `dotnet build Echoglossian.sln -c Debug --no-restore`
 - `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
 - `dotnet build Echoglossian.csproj -c Release --no-restore`
+
+## Iteration 12
+
+Goal:
+- document the current toast runtime ownership model in English
+- document the proposed full alternate `ToastGui` path for supported toasts in
+  English
+- make the distinction explicit between:
+  - today's addon-handler presentation path
+  - today's optional `ToastGui` prefetch
+  - the proposed callback-owned full runtime
+
+Changes:
+- added `docs/toast-runtime-current-state.md`
+- added `docs/toastgui-runtime-alternative-path.md`
+- recorded the current and proposed ownership of:
+  - capture
+  - translation lookup
+  - overlay publication
+  - native mutation
+  - persistence
+- documented that `_TextGimmickHint` remains outside the proposed migration
+
+Validation:
+- not run, docs-only change
+
+## Iteration 13
+
+Goal:
+- verify exactly what `ToastGui` supports in Dalamud before implementing a full
+  alternate callback-owned toast route
+- update the toast design docs with the real callback boundaries and
+  architectural constraints
+
+Findings from Dalamud source and docs:
+- `IToastGui` exposes exactly three callback surfaces:
+  - `Toast`
+  - `QuestToast`
+  - `ErrorToast`
+- the implementation hooks:
+  - `UIModule.ShowWideText`
+  - `UIModule.ShowText`
+  - `UIModule.ShowErrorText`
+- `isHandled = true` suppresses the original native call
+- the generic normal-toast callback only exposes:
+  - `SeString message`
+  - `ToastOptions.Position`
+  - `ToastOptions.Speed`
+- it does not expose:
+  - addon name
+  - normal-toast subtype
+  - a stable identity that distinguishes `_WideText`, `_AreaText`, and
+    `_TextClassChange`
+
+Implication:
+- a full `ToastGui` route is straightforward for quest and error toasts
+- a full subtype-preserving normal-toast migration needs either:
+  - a correlation layer
+  - or a deliberate collapse into one generic normal-toast family under the
+    alternate route
+
+Changes:
+- updated `docs/toast-runtime-current-state.md`
+- updated `docs/toastgui-runtime-alternative-path.md`
+
+Validation:
+- not run, docs-only change
+
+## Iteration 14
+
+Goal:
+- record the architectural decision for the future `ToastGui` alternate route
+  after confirming that Echoglossian already persists supported normal toasts
+  as one logical DB family
+
+Decision:
+- under the alternate `ToastGui` route, `_WideText`, `_AreaText`, and
+  `_TextClassChange` should be treated as one unified `Toast / NonError`
+  runtime family
+- the alternate route should not try to preserve addon-specific ownership for
+  activation or behavior inside that normal-toast family
+
+Changes:
+- updated `docs/toast-runtime-current-state.md`
+- updated `docs/toastgui-runtime-alternative-path.md`
+
+Validation:
+- not run, docs-only change
+
+## Iteration 15
+
+Goal:
+- implement the hidden full `ToastGui` route for supported normal and error
+  toasts
+- keep the legacy addon-handler route as the default fallback
+- stop treating `_WideText`, `_AreaText`, and `_TextClassChange` as separate
+  activation owners while the hidden route is enabled
+
+Changes:
+- added hidden config toggle:
+  - `UseToastGuiRuntimeForSupportedToasts`
+- added `ToastGuiSupportedToastPolicy`
+- added `ToastGuiSupportedToastRuntime`
+- added `ToastGuiSupportedToastRuntimeRegistration`
+- the supported normal-toast family is now callback-owned through
+  `IToastGui.Toast` when the hidden route is enabled
+- the error-toast family is now callback-owned through
+  `IToastGui.ErrorToast` when the hidden route is enabled
+- legacy addon handlers for:
+  - `_WideText`
+  - `_AreaText`
+  - `_TextClassChange`
+  - `_TextError`
+  are not registered while the hidden route is active
+- the old capture-only `ToastGui` runtime now self-suppresses when the hidden
+  full route owns the same family
+- the hidden route treats supported normal toasts as one logical
+  `Toast / NonError` family and currently reuses
+  `WideTextToastTranslationDisplayMode` as its family display-mode source
+- added focused tests for:
+  - hidden config default
+  - legacy prefetch suppression
+  - family-level normal-toast routing policy
+- updated:
+  - `docs/toast-runtime-current-state.md`
+  - `docs/toastgui-runtime-alternative-path.md`
+
+Focused validation:
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --filter "ConfigDefaultsTests|ToastGuiCaptureRuntimeTests|ToastGuiSupportedToastPolicyTests"`

--- a/docs/toast-runtime-current-state.md
+++ b/docs/toast-runtime-current-state.md
@@ -1,0 +1,345 @@
+# Toast Runtime Current State
+
+This document captures the actual toast runtime state on
+`issue-188-minitalk-toast-reflow-followup`.
+
+It covers:
+
+- which runtime owns capture
+- which runtime owns translation lookup and persistence
+- which runtime owns overlay publication
+- which runtime owns native mutation
+- where `ToastGui` is used today
+- how the hidden full `ToastGui` route changes ownership
+
+## Scope
+
+Toast-family surfaces covered here:
+
+- `_WideText`
+- `_TextError`
+- `_AreaText`
+- `_TextClassChange`
+- quest toast callback runtime
+- `_TextGimmickHint`
+
+Related callback surfaces:
+
+- `IToastGui.Toast`
+- `IToastGui.QuestToast`
+- `IToastGui.ErrorToast`
+
+## High-Level Summary
+
+There are now four toast runtime shapes in the branch:
+
+1. `IAddonLifecycle`-driven addon toasts
+2. `IToastGui.QuestToast` runtime
+3. optional `ToastGui` capture/prefetch for supported normal and error toasts
+4. hidden full `ToastGui` runtime for supported normal and error toasts
+
+`TextGimmickHint` is still outside every `ToastGui` path.
+
+## Verified `ToastGui` Support Boundaries In Dalamud
+
+After reviewing the public Dalamud API and the current `ToastGui`
+implementation, the supported callback surfaces are exactly:
+
+- `IToastGui.Toast`
+- `IToastGui.QuestToast`
+- `IToastGui.ErrorToast`
+
+Relevant sources:
+
+- `IToastGui` interface:
+  - <https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Plugin/Services/IToastGui.cs>
+- `ToastGui` implementation:
+  - <https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/Gui/Toast/ToastGui.cs>
+
+Important implementation facts:
+
+- normal toasts are hooked through `UIModule.ShowWideText`
+- quest toasts are hooked through `UIModule.ShowText`
+- error toasts are hooked through `UIModule.ShowErrorText`
+- `isHandled = true` suppresses the original game/UI call entirely
+
+The callback metadata is not symmetric:
+
+- `Toast`
+  - `SeString message`
+  - `ToastOptions.Position`
+  - `ToastOptions.Speed`
+- `QuestToast`
+  - `SeString message`
+  - `QuestToastOptions.Position`
+  - `QuestToastOptions.IconId`
+  - `QuestToastOptions.DisplayCheckmark`
+  - `QuestToastOptions.PlaySound`
+- `ErrorToast`
+  - `SeString message`
+
+The generic normal-toast callback does not expose:
+
+- addon name
+- toast subtype
+- sheet row
+- any explicit marker that distinguishes `_WideText`, `_AreaText`, and
+  `_TextClassChange`
+
+That is why the hidden full `ToastGui` route treats those supported normal
+toasts as one logical `Toast / NonError` family instead of preserving
+addon-specific runtime ownership.
+
+## Persistence Semantics
+
+From a DB point of view, Echoglossian already treats the supported normal toast
+family as one logical group:
+
+- `_WideText`
+- `_AreaText`
+- `_TextClassChange`
+
+are stored in `ToastMessage` with:
+
+- `ToastType = "NonError"`
+
+`_TextError` uses:
+
+- `ToastType = "Error"`
+
+`QuestToast` also persists through `ToastMessage`.
+
+`_TextGimmickHint` remains separate in:
+
+- `TextGimmickHintMessage`
+
+## Hidden Runtime Toggles
+
+Two hidden or semi-hidden toast-callback switches now exist:
+
+- `UseToastGuiCaptureForSupportedToasts`
+  - legacy callback prefetch only
+- `UseToastGuiRuntimeForSupportedToasts`
+  - full callback-owned route for supported normal and error toasts
+
+`UseToastGuiRuntimeForSupportedToasts` defaults to `false`.
+
+## Ownership Matrix
+
+| Surface | Toggle state | Capture owner | Translation owner | Overlay owner | Native write owner | Persistence table | ToastGui role |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `_WideText` / `_AreaText` / `_TextClassChange` | hidden full route off | addon handler | addon handler | addon handler | addon handler | `ToastMessage` | none or optional prefetch |
+| `_WideText` / `_AreaText` / `_TextClassChange` | hidden full route on | `ToastGuiSupportedToastRuntime` | `ToastGuiSupportedToastRuntime` | `ToastGuiSupportedToastRuntime` | `ToastGuiSupportedToastRuntime` | `ToastMessage` | full route |
+| `_TextError` | hidden full route off | addon handler | addon handler | addon handler | addon handler | `ToastMessage` | none or optional prefetch |
+| `_TextError` | hidden full route on | `ToastGuiSupportedToastRuntime` | `ToastGuiSupportedToastRuntime` | `ToastGuiSupportedToastRuntime` | `ToastGuiSupportedToastRuntime` | `ToastMessage` | full route |
+| quest toast | always | `QuestToastRuntime` | `QuestToastRuntime` | `QuestToastRuntime` | `QuestToastRuntime` | `ToastMessage` | full route |
+| `_TextGimmickHint` | always | dedicated handler | dedicated handler | dedicated handler | dedicated handler | `TextGimmickHintMessage` | excluded |
+
+## Routing Overview
+
+```mermaid
+flowchart TD
+    A["Toast-family event"] --> B{"Surface / callback"}
+
+    B --> C["AddonLifecycle toast addon"]
+    B --> D["QuestToast callback"]
+    B --> E["Toast callback / ErrorToast callback"]
+    B --> F["TextGimmickHint addon"]
+
+    C --> C1["Legacy addon toast path"]
+    C1 --> C2["Read visible text node"]
+    C2 --> C3["ToastMessage lookup or queue"]
+    C3 --> C4["Addon-owned overlay"]
+    C3 --> C5["Late native node mutation"]
+
+    D --> D1["QuestToastRuntime"]
+    D1 --> D2["Read callback SeString"]
+    D2 --> D3["ToastMessage lookup or queue"]
+    D3 --> D4["Runtime-owned overlay"]
+    D3 --> D5["Callback payload replacement"]
+
+    E --> E1{"Full runtime toggle?"}
+    E1 -->|off| E2["Optional capture-only prefetch"]
+    E2 --> C1
+    E1 -->|on| E3["ToastGuiSupportedToastRuntime"]
+    E3 --> E4["Read callback SeString"]
+    E4 --> E5["ToastMessage lookup or queue"]
+    E5 --> E6["Runtime-owned overlay"]
+    E5 --> E7["Callback payload replacement"]
+
+    F --> F1["Dedicated addon handler"]
+```
+
+## Legacy Addon Toast Family
+
+Shared base:
+
+- [NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/AddonTextToastHandler.cs)
+
+Concrete handlers:
+
+- [NativeUI/AddonHandlers/Toasts/WideTextToastHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/WideTextToastHandler.cs)
+- [NativeUI/AddonHandlers/Toasts/ErrorToastHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ErrorToastHandler.cs)
+- [NativeUI/AddonHandlers/Toasts/AreaToastHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/AreaToastHandler.cs)
+- [NativeUI/AddonHandlers/Toasts/ClassChangeToastHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ClassChangeToastHandler.cs)
+
+Current legacy shape:
+
+1. `PreUpdate` resolves the live `AtkTextNode`.
+2. The handler reads the visible source text.
+3. It looks up a `ToastMessage` row or queues translation.
+4. Overlay bounds are synchronized from the live addon.
+5. Overlay publication is handler-owned.
+6. In native mode, the handler mutates the live node late and reflows the
+   wrapper chain/background.
+
+This path still exists and remains the default when the hidden full
+`ToastGui` route is off.
+
+## Quest Toast Runtime
+
+Owner:
+
+- [NativeUI/AddonHandlers/Toasts/QuestToastRuntime.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/QuestToastRuntime.cs)
+
+Registration:
+
+- [NativeUI/Helpers/QuestToastRuntimeRegistration.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/Helpers/QuestToastRuntimeRegistration.cs)
+
+Shape:
+
+1. `IToastGui.QuestToast` provides the source `SeString`.
+2. The runtime performs cache-first lookup against `ToastMessage`.
+3. Overlay publication is runtime-owned.
+4. In native mode, the callback payload is replaced directly.
+5. No addon handler owns translation or mutation for quest toast.
+
+This is the reference callback-owned toast flow in the plugin.
+
+## Legacy `ToastGui` Capture/Prefetch
+
+Owner:
+
+- [NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ToastGuiCaptureRuntime.cs)
+
+Registration:
+
+- [NativeUI/Helpers/ToastGuiCaptureRuntimeRegistration.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/Helpers/ToastGuiCaptureRuntimeRegistration.cs)
+
+Shape:
+
+1. `IToastGui.Toast` and `IToastGui.ErrorToast` are observed.
+2. When enabled, the runtime prefetches supported rows into `ToastMessage`.
+3. It does not publish overlays.
+4. It does not mutate the callback payload.
+5. The addon handlers still own presentation, overlay bounds, and native
+   replacement.
+
+Current gate:
+
+- `UseToastGuiCaptureForSupportedToasts`
+
+This path now self-suppresses automatically whenever the hidden full
+`ToastGui` runtime is enabled for the same supported family.
+
+## Hidden Full `ToastGui` Runtime
+
+Owner:
+
+- [NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastRuntime.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastRuntime.cs)
+
+Registration:
+
+- [NativeUI/Helpers/ToastGuiSupportedToastRuntimeRegistration.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/Helpers/ToastGuiSupportedToastRuntimeRegistration.cs)
+
+Family policy:
+
+- [NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs)
+
+Shape:
+
+1. `IToastGui.Toast` owns the supported `Toast / NonError` family.
+2. `IToastGui.ErrorToast` owns the error-toast family.
+3. Cache hits apply immediately at the callback payload level.
+4. Cache misses queue translation asynchronously into `ToastMessage`.
+5. Overlay publication is runtime-owned for supported toasts.
+6. Native replacement is runtime-owned for supported toasts.
+7. Legacy addon handlers for `_WideText`, `_AreaText`, `_TextClassChange`,
+   and `_TextError` do not register while the hidden route is active.
+
+Important current design choice:
+
+- the supported normal-toast family is activated at the family level when the
+  hidden route is on
+- it is not gated by `_WideText` vs `_AreaText` vs `_TextClassChange`
+- its current family display mode is sourced from
+  `WideTextToastTranslationDisplayMode`
+
+That family-level config reuse is deliberate and narrow. It gives the
+alternate route one stable display-mode source without inventing a new user
+setting yet.
+
+## `TextGimmickHint`
+
+Owner:
+
+- [NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs)
+
+Shape:
+
+1. capture happens from the live addon text node
+2. persistence uses `TextGimmickHintMessage`
+3. overlay publication is owned by the dedicated handler
+4. native mutation remains a late text-node rewrite plus local reflow
+
+This surface is intentionally outside the hidden full `ToastGui` route.
+
+## Overlay Behavior Today
+
+Overlay ownership is now split like this:
+
+- legacy addon-family toasts publish overlays from addon handlers
+- quest toast publishes overlays from `QuestToastRuntime`
+- hidden supported normal/error route publishes overlays from
+  `ToastGuiSupportedToastRuntime`
+- `TextGimmickHint` publishes overlays from its own handler
+
+When the hidden full route is active:
+
+- `toastOverlay` is synchronized from the viewport using `ToastOptions.Position`
+- `errorToastOverlay` is synchronized from the viewport using a stable
+  top-center anchor
+- `areaToastOverlay` and `classChangeToastOverlay` are intentionally inactive
+
+## Current Risks
+
+### 1. Cache-miss native replacement
+
+For callback-owned toasts, native replacement can only happen on a cache hit in
+the current callback. A cache miss can still populate DB and overlay state, but
+it cannot retroactively rewrite a toast that already went through the callback.
+
+That is already how the callback-owned quest-toast runtime behaves.
+
+### 2. Family-level config reuse
+
+Under the hidden full route, supported normal toasts intentionally stop using
+their legacy per-addon activation/behavior split. The family currently reuses
+the wide-text toast display mode as its canonical mode.
+
+### 3. `TextGimmickHint`
+
+`TextGimmickHint` remains a separate surface and is not part of the callback
+toast migration.
+
+## Bottom Line
+
+The branch now has both:
+
+- the legacy addon-handler toast route
+- and a hidden full callback-owned `ToastGui` route for supported normal and
+  error toasts
+
+Quest toast was already callback-owned.
+
+`TextGimmickHint` still is not part of the `ToastGui` family.

--- a/docs/toastgui-runtime-alternative-path.md
+++ b/docs/toastgui-runtime-alternative-path.md
@@ -1,0 +1,310 @@
+# ToastGui Runtime Alternative Path
+
+This document describes the hidden full `ToastGui` path implemented on
+`issue-188-minitalk-toast-reflow-followup`.
+
+It exists as the parallel route for supported toasts while the legacy
+addon-handler route remains available as the default fallback.
+
+## Goal
+
+Move the supported toast family toward the same callback-first shape already
+used by quest toast:
+
+- source capture starts at `ToastGui`
+- translation lookup and queueing are runtime-owned
+- overlay publication is runtime-owned
+- native replacement is performed at the callback payload level
+- supported addon handlers stop owning translation and native mutation while
+  the hidden route is active
+
+## Non-Goals
+
+This route does not include:
+
+- `_TextGimmickHint`
+- `_MiniTalk`
+- `BattleTalk`
+- unrelated native layout work
+
+`TextGimmickHint` remains explicitly outside this migration.
+
+## Why This Route Exists
+
+Quest toast already shows the cleanest toast flow in the plugin:
+
+- source arrives early from `ToastGui`
+- translation can be resolved before late node mutation is needed
+- native replacement happens on the callback payload instead of by fighting a
+  live addon tree after layout
+
+The alternate supported-toast route tries to bring the rest of the supported
+toast family closer to that model.
+
+## Verified `ToastGui` Constraints From Dalamud
+
+`ToastGui` exposes exactly these callback surfaces:
+
+- `IToastGui.Toast`
+- `IToastGui.QuestToast`
+- `IToastGui.ErrorToast`
+
+Important facts:
+
+- normal toasts are intercepted through `UIModule.ShowWideText`
+- quest toasts are intercepted through `UIModule.ShowText`
+- error toasts are intercepted through `UIModule.ShowErrorText`
+- `isHandled = true` prevents the original native call from running
+
+The generic normal-toast callback exposes only:
+
+- `SeString message`
+- `ToastOptions.Position`
+- `ToastOptions.Speed`
+
+It does not expose:
+
+- addon name
+- subtype identity
+- sheet row
+- a stable marker that distinguishes `_WideText`, `_AreaText`, and
+  `_TextClassChange`
+
+That is why the alternate route deliberately treats those normal-toast
+surfaces as one unified `Toast / NonError` family.
+
+## Hidden Toggle
+
+The full route is guarded by:
+
+- `UseToastGuiRuntimeForSupportedToasts`
+
+Current semantics:
+
+- `false`
+  - legacy addon-handler route remains active
+  - optional prefetch-only `ToastGui` capture can still be used separately
+- `true`
+  - supported normal toasts use the callback-owned `ToastGui` family route
+  - supported error toasts use the callback-owned `ToastGui` error route
+  - legacy addon handlers for those supported families do not register
+  - `TextGimmickHint` is unaffected
+
+This toggle defaults to `false`.
+
+## Supported Surfaces
+
+### Included
+
+Unified normal-toast family:
+
+- `_WideText`
+- `_AreaText`
+- `_TextClassChange`
+
+Dedicated error-toast family:
+
+- `_TextError`
+
+Already-callback-owned:
+
+- quest toast
+
+### Excluded
+
+- `_TextGimmickHint`
+
+## Design Decision: Treat Supported Normal Toasts As One Family
+
+Under the hidden full route:
+
+- `_WideText`, `_AreaText`, and `_TextClassChange` are treated as one logical
+  `Toast / NonError` family
+- the route does not try to preserve addon-specific ownership
+- activation is not tied to those legacy addon identities
+- behavior is not tied to those legacy addon identities
+
+The plugin already matches this at the persistence level:
+
+- those surfaces already live in `ToastMessage`
+- with `ToastType = "NonError"`
+
+## Current Implementation Shape
+
+### Normal Toast Family
+
+Runtime:
+
+- [NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastRuntime.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastRuntime.cs)
+
+Policy:
+
+- [NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/ToastGuiSupportedToastPolicy.cs)
+
+Registration:
+
+- [NativeUI/Helpers/ToastGuiSupportedToastRuntimeRegistration.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/Helpers/ToastGuiSupportedToastRuntimeRegistration.cs)
+
+Current behavior:
+
+1. `IToastGui.Toast` captures the source `SeString`.
+2. The runtime looks up `ToastMessage` with `ToastType = "NonError"`.
+3. Cache hits apply immediately:
+   - overlay publication if needed
+   - callback payload replacement if native/swap mode needs it
+4. Cache misses queue translation asynchronously into `ToastMessage`.
+5. The unified `toastOverlay` is synchronized to the viewport using
+   `ToastOptions.Position`.
+
+Current family-level display mode source:
+
+- `WideTextToastTranslationDisplayMode`
+
+That reuse is intentional and narrow. It gives the hidden route one stable
+family-level display-mode setting without inventing a new public setting yet.
+
+### Error Toast Family
+
+Runtime:
+
+- same `ToastGuiSupportedToastRuntime`
+
+Current behavior:
+
+1. `IToastGui.ErrorToast` captures the source `SeString`.
+2. The runtime looks up `ToastMessage` with `ToastType = "Error"`.
+3. Cache hits apply immediately:
+   - overlay publication if needed
+   - callback payload replacement if native/swap mode needs it
+4. Cache misses queue translation asynchronously into `ToastMessage`.
+5. `errorToastOverlay` is synchronized to a stable top-center viewport anchor.
+
+### Quest Toast
+
+Runtime:
+
+- [NativeUI/AddonHandlers/Toasts/QuestToastRuntime.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/QuestToastRuntime.cs)
+
+This path is unchanged and remains the reference callback-owned route.
+
+### `TextGimmickHint`
+
+Runtime:
+
+- [NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs](/C:/Dante/_dalamud/Echoglossian/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs)
+
+This path remains addon-owned and outside the migration.
+
+## Flow Diagram
+
+```mermaid
+flowchart TD
+    A["ToastGui callback"] --> B{"Surface"}
+
+    B --> C["QuestToastRuntime"]
+    B --> D["ToastGuiSupportedToastRuntime - NormalToast family"]
+    B --> E["ToastGuiSupportedToastRuntime - ErrorToast family"]
+    B --> F["TextGimmickHint handler"]
+
+    D --> D1["Read callback SeString"]
+    D1 --> D2["Lookup ToastMessage / NonError"]
+    D2 --> D3["Publish toastOverlay if overlay/swap mode"]
+    D2 --> D4["Replace callback payload if native/swap mode"]
+    D2 --> D5["Queue async translation on miss"]
+
+    E --> E1["Read callback SeString"]
+    E1 --> E2["Lookup ToastMessage / Error"]
+    E2 --> E3["Publish errorToastOverlay if overlay/swap mode"]
+    E2 --> E4["Replace callback payload if native/swap mode"]
+    E2 --> E5["Queue async translation on miss"]
+
+    C --> C1["QuestToast callback-owned flow"]
+    F --> F1["Legacy dedicated addon path"]
+```
+
+## Overlay and Swap Semantics That Must Be Preserved
+
+The full route still respects the same stage separation:
+
+1. capture
+2. translation lookup or queue
+3. overlay publication
+4. native mutation
+
+For the supported normal/error callback-owned route:
+
+- overlay-only mode
+  - do not mutate the callback payload
+  - publish translated overlay text
+- native mode
+  - replace the callback payload with the translation
+  - overlay may stay off
+- swap mode
+  - replace the callback payload with the translation
+  - publish the original text in the overlay
+
+The alternate route therefore keeps the same high-level user semantics while
+changing who owns the stages.
+
+## What Changes In Addon Registration
+
+When the hidden full route is enabled:
+
+- `_WideText` handler does not register
+- `_AreaText` handler does not register
+- `_TextClassChange` handler does not register
+- `_TextError` handler does not register
+
+That keeps ownership clean. The callback runtime is the translation owner, not
+the addon handlers.
+
+`TextGimmickHint` still registers normally.
+
+## Why This Is Better Than Prefetch-Only
+
+The older callback-assisted path only improved source timing. It still left:
+
+- overlay publication
+- native mutation
+- late reflow/alignment problems
+
+inside the addon-handler route.
+
+The hidden full route removes that split ownership for supported normal and
+error toasts.
+
+## Known Constraint
+
+### Cache-Miss Native Replacement
+
+For callback-owned toasts, native replacement can only happen on a cache hit in
+the current callback.
+
+On a cache miss:
+
+- translation is still queued and persisted
+- overlay publication can still happen if the active mode uses overlays
+- the toast that already passed through the callback cannot be rewritten
+  natively afterward
+
+This is an inherent callback limitation, not a plugin-specific quirk.
+
+## Why `TextGimmickHint` Stays Out
+
+`TextGimmickHint` is not exposed through `ToastGui` in a way that matches the
+supported callback families, and it already has its own dedicated DB and
+surface semantics.
+
+Keeping it out avoids pretending it is part of the same runtime contract when
+it is not.
+
+## Migration Intent
+
+This branch keeps both routes:
+
+- legacy addon-handler route
+- hidden full callback-owned `ToastGui` route
+
+That lets the plugin compare behavior safely in-game before deciding whether
+the callback-owned route should become the future default for supported toast
+families.


### PR DESCRIPTION
## Summary\n- fix DB editor ImGui assertion spam by using fixed-width table columns\n- make supported toast runtime always use ToastGui route when toast translation is enabled\n- remove redundant public toggle and keep route status debug-only\n- backfill missing persisted config defaults on plugin update\n\n## Validation\n- dotnet build Echoglossian.sln -c Debug --no-restore\n- dotnet test Echoglossian.Tests/Echoglossian.Tests.csproj -c Debug --no-build\n\n## In-game focus\n- MiniTalk/BattleTalk native reflow stability\n- Toast alignment and non-dup route behavior\n- no recurring ImGui table assertions in DB editor