### PR TITLE
#174 Share story-surface inspection UI and retranslation

### DIFF
--- a/DBManagerUI/Components/DbTableView.cs
+++ b/DBManagerUI/Components/DbTableView.cs
@@ -13,8 +13,7 @@ namespace Echoglossian.DBManagerUI.Components
   {
     private readonly Func<IReadOnlyList<IProperty>?> getScalarProps;
     private readonly Func<IList<object>?> getRows;
-    private readonly Func<HashSet<int>> getSelection;
-    private readonly Action<object> onRowDoubleClick;
+    private readonly InspectionTableView inspectionTableView;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DbTableView"/> class.
@@ -31,8 +30,21 @@ namespace Echoglossian.DBManagerUI.Components
     {
       this.getScalarProps = getScalarProps;
       this.getRows = getRows;
-      this.getSelection = getSelection;
-      this.onRowDoubleClick = onRowDoubleClick;
+      this.inspectionTableView = new InspectionTableView(
+        tableId: "dbTable",
+        getColumns: this.BuildColumns,
+        getRows: this.BuildRows,
+        noRecordsLoadedMessage: Resources.NoRecordsLoaded,
+        noRecordsFoundMessage: Resources.NoRecordsFoundInThisTable,
+        noColumnsMessage: Resources.NoScalarPropertiesToDisplay,
+        getSelection: getSelection,
+        onRowDoubleClick: (row) =>
+        {
+          if (row.Payload != null)
+          {
+            onRowDoubleClick(row.Payload);
+          }
+        });
     }
 
     /// <summary>
@@ -40,106 +52,43 @@ namespace Echoglossian.DBManagerUI.Components
     /// </summary>
     public void Draw()
     {
-      var props = this.getScalarProps();
-      var rows = this.getRows();
+      this.inspectionTableView.Draw();
+    }
 
-      if (rows == null)
+    private IReadOnlyList<InspectionColumnDefinition>? BuildColumns()
+    {
+      var props = this.getScalarProps();
+      if (props == null)
       {
-        ImGui.Text("No records loaded.");
-        return;
+        return null;
       }
 
-      if (rows.Count == 0)
+      return props
+        .Select(prop => new InspectionColumnDefinition(prop.Name))
+        .ToList();
+    }
+
+    private IReadOnlyList<InspectionRow>? BuildRows()
+    {
+      var props = this.getScalarProps();
+      var rows = this.getRows();
+      if (rows == null)
       {
-        ImGui.Text("No records found in this table.");
-        return;
+        return null;
       }
 
       if (props == null || props.Count == 0)
       {
-        ImGui.Text("No scalar properties to display.");
-        return;
+        return new List<InspectionRow>();
       }
 
-      int totalColumns = 1 + props.Count;
-
-      if (ImGui.BeginTable("##dbTable", totalColumns, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY | ImGuiTableFlags.Resizable))
-      {
-        ImGui.TableSetupScrollFreeze(0, 1);
-
-        ImGui.TableSetupColumn("##sel", ImGuiTableColumnFlags.WidthFixed, 28f);
-
-        foreach (var prop in props)
-        {
-          ImGui.TableSetupColumn(prop.Name, ImGuiTableColumnFlags.WidthFixed, 150f);
-        }
-
-        ImGui.TableHeadersRow();
-
-        var selection = this.getSelection();
-
-        for (int i = 0; i < rows.Count; i++)
-        {
-          var row = rows[i];
-
-          ImGui.TableNextRow();
-
-          // Selection checkbox column
-          ImGui.TableSetColumnIndex(0);
-          bool isSelected = selection.Contains(i);
-          if (ImGui.Checkbox($"##chk{i}", ref isSelected))
-          {
-            if (isSelected)
-            {
-              selection.Add(i);
-            }
-            else
-            {
-              selection.Remove(i);
-            }
-          }
-
-          // Data columns
-          for (int c = 0; c < props.Count; c++)
-          {
-            var prop = props[c];
-            ImGui.TableSetColumnIndex(c + 1);
-
-            object? val = this.SafeGetValue(row, prop.PropertyInfo!);
-            string text = this.RenderCellValue(val);
-
-            ImGui.PushID((i * 10000) + c);
-
-            // compute a wrap width equal to the current column content width
-            float wrapAt = ImGui.GetCursorPosX() + ImGui.GetColumnWidth();
-
-            // draw wrapped text item
-            ImGui.PushTextWrapPos(wrapAt);
-            ImGui.TextUnformatted(text);
-            ImGui.PopTextWrapPos();
-
-            // tooltip for very long strings
-            if (text.Length > 256 && ImGui.IsItemHovered())
-            {
-              ImGui.BeginTooltip();
-              ImGui.PushTextWrapPos(ImGui.GetFontSize() * 60.0f);
-              ImGui.TextUnformatted(text);
-              ImGui.PopTextWrapPos();
-              ImGui.EndTooltip();
-            }
-
-            // reliable double-click detection on this item
-            if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
-            {
-              this.onRowDoubleClick(row);
-            }
-
-            ImGui.PopID();
-          }
-        }
-
-        ImGui.EndTable();
-      }
+      return rows
+        .Select(row => new InspectionRow(
+          props
+            .Select(prop => InspectionCellFormatter.Format(this.SafeGetValue(row, prop.PropertyInfo!)))
+            .ToList(),
+          row))
+        .ToList();
     }
 
     private object? SafeGetValue(object obj, PropertyInfo pi)
@@ -152,27 +101,6 @@ namespace Echoglossian.DBManagerUI.Components
       {
         return null;
       }
-    }
-
-    private string RenderCellValue(object? val)
-    {
-      if (val == null)
-      {
-        return "(null)";
-      }
-
-      if (val is byte[] bytes)
-      {
-        return $"[BLOB {bytes.Length} bytes]";
-      }
-
-      string s = val.ToString() ?? string.Empty;
-      if (s.Length > 256)
-      {
-        s = s.Substring(0, 256) + "…";
-      }
-
-      return s;
     }
   }
 }

--- a/DBManagerUI/Components/InspectionCell.cs
+++ b/DBManagerUI/Components/InspectionCell.cs
@@ -1,0 +1,34 @@
+// <copyright file="InspectionCell.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.DBManagerUI.Components
+{
+  /// <summary>
+  /// Represents a single display-ready inspection cell.
+  /// </summary>
+  public sealed class InspectionCell
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InspectionCell"/> class.
+    /// </summary>
+    /// <param name="text">Inline text shown in the table cell.</param>
+    /// <param name="tooltipText">Optional full text shown on hover.</param>
+    public InspectionCell(string text, string? tooltipText = null)
+    {
+      this.Text = text;
+      this.TooltipText = tooltipText;
+    }
+
+    /// <summary>
+    /// Gets the inline text shown in the table cell.
+    /// </summary>
+    public string Text { get; }
+
+    /// <summary>
+    /// Gets the optional full text shown on hover.
+    /// </summary>
+    public string? TooltipText { get; }
+  }
+}

--- a/DBManagerUI/Components/InspectionCellFormatter.cs
+++ b/DBManagerUI/Components/InspectionCellFormatter.cs
@@ -1,0 +1,47 @@
+// <copyright file="InspectionCellFormatter.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.DBManagerUI.Components
+{
+  /// <summary>
+  /// Formats raw values into display-ready inspection cells.
+  /// </summary>
+  public static class InspectionCellFormatter
+  {
+    /// <summary>
+    /// The default inline text limit before overflow is moved to a tooltip.
+    /// </summary>
+    public const int DefaultInlineTextLimit = 256;
+
+    /// <summary>
+    /// Formats a raw value into an inspection cell.
+    /// </summary>
+    /// <param name="value">The raw value to format.</param>
+    /// <param name="inlineTextLimit">The maximum inline text length.</param>
+    /// <returns>A display-ready cell.</returns>
+    public static InspectionCell Format(object? value, int inlineTextLimit = DefaultInlineTextLimit)
+    {
+      if (value == null)
+      {
+        return new InspectionCell("(null)");
+      }
+
+      if (value is byte[] bytes)
+      {
+        return new InspectionCell($"[BLOB {bytes.Length} bytes]");
+      }
+
+      string text = value.ToString() ?? string.Empty;
+      if (text.Length <= inlineTextLimit)
+      {
+        return new InspectionCell(text);
+      }
+
+      return new InspectionCell(
+        text.Substring(0, inlineTextLimit) + "…",
+        text);
+    }
+  }
+}

--- a/DBManagerUI/Components/InspectionColumnDefinition.cs
+++ b/DBManagerUI/Components/InspectionColumnDefinition.cs
@@ -1,0 +1,44 @@
+// <copyright file="InspectionColumnDefinition.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.DBManagerUI.Components
+{
+  /// <summary>
+  /// Represents one display column in a reusable inspection table.
+  /// </summary>
+  public sealed class InspectionColumnDefinition
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InspectionColumnDefinition"/> class.
+    /// </summary>
+    /// <param name="header">Column header label.</param>
+    /// <param name="flags">ImGui column sizing flags.</param>
+    /// <param name="initialWidth">Initial column width.</param>
+    public InspectionColumnDefinition(
+      string header,
+      ImGuiTableColumnFlags flags = ImGuiTableColumnFlags.WidthFixed,
+      float initialWidth = 150f)
+    {
+      this.Header = header;
+      this.Flags = flags;
+      this.InitialWidth = initialWidth;
+    }
+
+    /// <summary>
+    /// Gets the column header label.
+    /// </summary>
+    public string Header { get; }
+
+    /// <summary>
+    /// Gets the ImGui sizing flags for the column.
+    /// </summary>
+    public ImGuiTableColumnFlags Flags { get; }
+
+    /// <summary>
+    /// Gets the initial width for the column.
+    /// </summary>
+    public float InitialWidth { get; }
+  }
+}

--- a/DBManagerUI/Components/InspectionRow.cs
+++ b/DBManagerUI/Components/InspectionRow.cs
@@ -1,0 +1,34 @@
+// <copyright file="InspectionRow.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.DBManagerUI.Components
+{
+  /// <summary>
+  /// Represents a single row in a reusable inspection table.
+  /// </summary>
+  public sealed class InspectionRow
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InspectionRow"/> class.
+    /// </summary>
+    /// <param name="cells">Display-ready cells for the row.</param>
+    /// <param name="payload">Optional context payload associated with the row.</param>
+    public InspectionRow(IReadOnlyList<InspectionCell> cells, object? payload = null)
+    {
+      this.Cells = cells;
+      this.Payload = payload;
+    }
+
+    /// <summary>
+    /// Gets the display-ready cells for the row.
+    /// </summary>
+    public IReadOnlyList<InspectionCell> Cells { get; }
+
+    /// <summary>
+    /// Gets the optional row payload for callbacks.
+    /// </summary>
+    public object? Payload { get; }
+  }
+}

--- a/DBManagerUI/Components/InspectionTableView.cs
+++ b/DBManagerUI/Components/InspectionTableView.cs
@@ -65,15 +65,15 @@ namespace Echoglossian.DBManagerUI.Components
         return;
       }
 
-      if (rows.Count == 0)
-      {
-        ImGui.Text(this.noRecordsFoundMessage);
-        return;
-      }
-
       if (columns == null || columns.Count == 0)
       {
         ImGui.Text(this.noColumnsMessage);
+        return;
+      }
+
+      if (rows.Count == 0)
+      {
+        ImGui.Text(this.noRecordsFoundMessage);
         return;
       }
 

--- a/DBManagerUI/Components/InspectionTableView.cs
+++ b/DBManagerUI/Components/InspectionTableView.cs
@@ -1,0 +1,190 @@
+// <copyright file="InspectionTableView.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.DBManagerUI.Components
+{
+  /// <summary>
+  /// Renders a reusable wrapped-text inspection table with optional selection
+  /// and double-click callbacks.
+  /// </summary>
+  public sealed class InspectionTableView
+  {
+    private readonly string tableId;
+    private readonly Func<IReadOnlyList<InspectionColumnDefinition>?> getColumns;
+    private readonly Func<IReadOnlyList<InspectionRow>?> getRows;
+    private readonly Func<HashSet<int>>? getSelection;
+    private readonly Action<InspectionRow>? onRowDoubleClick;
+    private readonly string noRecordsLoadedMessage;
+    private readonly string noRecordsFoundMessage;
+    private readonly string noColumnsMessage;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InspectionTableView"/> class.
+    /// </summary>
+    /// <param name="tableId">Stable ImGui table identifier.</param>
+    /// <param name="getColumns">Accessor for current column definitions.</param>
+    /// <param name="getRows">Accessor for current rows.</param>
+    /// <param name="noRecordsLoadedMessage">Message shown when rows are unavailable.</param>
+    /// <param name="noRecordsFoundMessage">Message shown when the table is empty.</param>
+    /// <param name="noColumnsMessage">Message shown when no columns are available.</param>
+    /// <param name="getSelection">Optional selection state accessor.</param>
+    /// <param name="onRowDoubleClick">Optional double-click callback.</param>
+    public InspectionTableView(
+      string tableId,
+      Func<IReadOnlyList<InspectionColumnDefinition>?> getColumns,
+      Func<IReadOnlyList<InspectionRow>?> getRows,
+      string noRecordsLoadedMessage,
+      string noRecordsFoundMessage,
+      string noColumnsMessage,
+      Func<HashSet<int>>? getSelection = null,
+      Action<InspectionRow>? onRowDoubleClick = null)
+    {
+      this.tableId = tableId;
+      this.getColumns = getColumns;
+      this.getRows = getRows;
+      this.noRecordsLoadedMessage = noRecordsLoadedMessage;
+      this.noRecordsFoundMessage = noRecordsFoundMessage;
+      this.noColumnsMessage = noColumnsMessage;
+      this.getSelection = getSelection;
+      this.onRowDoubleClick = onRowDoubleClick;
+    }
+
+    /// <summary>
+    /// Draws the inspection table.
+    /// </summary>
+    public void Draw()
+    {
+      var columns = this.getColumns();
+      var rows = this.getRows();
+
+      if (rows == null)
+      {
+        ImGui.Text(this.noRecordsLoadedMessage);
+        return;
+      }
+
+      if (rows.Count == 0)
+      {
+        ImGui.Text(this.noRecordsFoundMessage);
+        return;
+      }
+
+      if (columns == null || columns.Count == 0)
+      {
+        ImGui.Text(this.noColumnsMessage);
+        return;
+      }
+
+      bool supportsSelection = this.getSelection != null;
+      int totalColumns = columns.Count + (supportsSelection ? 1 : 0);
+
+      if (!ImGui.BeginTable(
+            $"##{this.tableId}",
+            totalColumns,
+            ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY | ImGuiTableFlags.Resizable))
+      {
+        return;
+      }
+
+      ImGui.TableSetupScrollFreeze(0, 1);
+
+      if (supportsSelection)
+      {
+        ImGui.TableSetupColumn("##sel", ImGuiTableColumnFlags.WidthFixed, 28f);
+      }
+
+      foreach (var column in columns)
+      {
+        ImGui.TableSetupColumn(column.Header, column.Flags, column.InitialWidth);
+      }
+
+      ImGui.TableHeadersRow();
+
+      var selection = supportsSelection ? this.getSelection!() : null;
+
+      for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++)
+      {
+        var row = rows[rowIndex];
+        ImGui.TableNextRow();
+
+        if (selection != null)
+        {
+          this.DrawSelectionCell(selection, rowIndex);
+        }
+
+        for (int columnIndex = 0; columnIndex < columns.Count; columnIndex++)
+        {
+          ImGui.TableSetColumnIndex(columnIndex + (selection != null ? 1 : 0));
+          this.DrawDataCell(rowIndex, columnIndex, row);
+        }
+      }
+
+      ImGui.EndTable();
+    }
+
+    /// <summary>
+    /// Draws the optional selection checkbox cell for a row.
+    /// </summary>
+    /// <param name="selection">Selection state store.</param>
+    /// <param name="rowIndex">The row index.</param>
+    private void DrawSelectionCell(HashSet<int> selection, int rowIndex)
+    {
+      ImGui.TableSetColumnIndex(0);
+
+      bool isSelected = selection.Contains(rowIndex);
+      if (!ImGui.Checkbox($"##chk{rowIndex}", ref isSelected))
+      {
+        return;
+      }
+
+      if (isSelected)
+      {
+        selection.Add(rowIndex);
+      }
+      else
+      {
+        selection.Remove(rowIndex);
+      }
+    }
+
+    /// <summary>
+    /// Draws a single wrapped-text data cell.
+    /// </summary>
+    /// <param name="rowIndex">The row index.</param>
+    /// <param name="columnIndex">The zero-based data column index.</param>
+    /// <param name="row">The row being rendered.</param>
+    private void DrawDataCell(int rowIndex, int columnIndex, InspectionRow row)
+    {
+      InspectionCell cell = columnIndex < row.Cells.Count
+        ? row.Cells[columnIndex]
+        : new InspectionCell(string.Empty);
+
+      ImGui.PushID($"{this.tableId}-{rowIndex}-{columnIndex}");
+
+      float wrapAt = ImGui.GetCursorPosX() + ImGui.GetColumnWidth();
+      ImGui.PushTextWrapPos(wrapAt);
+      ImGui.TextUnformatted(cell.Text);
+      ImGui.PopTextWrapPos();
+
+      if (!string.IsNullOrEmpty(cell.TooltipText) && ImGui.IsItemHovered())
+      {
+        ImGui.BeginTooltip();
+        ImGui.PushTextWrapPos(ImGui.GetFontSize() * 60.0f);
+        ImGui.TextUnformatted(cell.TooltipText);
+        ImGui.PopTextWrapPos();
+        ImGui.EndTooltip();
+      }
+
+      if (this.onRowDoubleClick != null &&
+          ImGui.IsItemHovered() &&
+          ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
+      {
+        this.onRowDoubleClick(row);
+      }
+
+      ImGui.PopID();
+    }
+  }
+}

--- a/DBManagerUI/DBEditorWindow.cs
+++ b/DBManagerUI/DBEditorWindow.cs
@@ -150,6 +150,35 @@ namespace Echoglossian.DBManagerUI
     }
 
     /// <summary>
+    /// Opens the DB manager window and selects the requested table when it exists.
+    /// </summary>
+    /// <param name="tableName">The table name to select.</param>
+    public void OpenAndSelectTable(string tableName)
+    {
+      this.IsOpen = true;
+
+      if (this.tableNames == null)
+      {
+        this.InitializeTableNames();
+      }
+
+      if (this.tableNames == null)
+      {
+        return;
+      }
+
+      var matchedTable = DbTableNameMatcher.Match(this.tableNames, tableName);
+      if (matchedTable == null)
+      {
+        return;
+      }
+
+      this.selectedTable = matchedTable;
+      this.page = 0;
+      this.LoadRows();
+    }
+
+    /// <summary>
     /// Initializes the entity (table) name list.
     /// </summary>
     private void InitializeTableNames()

--- a/DBManagerUI/Services/DbTableNameMatcher.cs
+++ b/DBManagerUI/Services/DbTableNameMatcher.cs
@@ -1,0 +1,37 @@
+// <copyright file="DbTableNameMatcher.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.DBManagerUI.Services
+{
+  /// <summary>
+  /// Resolves DB manager table names from caller-supplied requests.
+  /// </summary>
+  public static class DbTableNameMatcher
+  {
+    /// <summary>
+    /// Finds the exact matching table name from the available DB manager tables.
+    /// </summary>
+    /// <param name="tables">The available table names.</param>
+    /// <param name="requestedTable">The requested table name.</param>
+    /// <returns>
+    /// The matched table name, or <see langword="null"/> when no exact match exists.
+    /// </returns>
+    public static string? Match(
+      IReadOnlyList<string> tables,
+      string requestedTable)
+    {
+      if (tables.Count == 0 || string.IsNullOrWhiteSpace(requestedTable))
+      {
+        return null;
+      }
+
+      return tables.FirstOrDefault(
+        table => string.Equals(
+          table,
+          requestedTable,
+          StringComparison.Ordinal));
+    }
+  }
+}

--- a/Echoglossian.Tests/DbTableNameMatcherTests.cs
+++ b/Echoglossian.Tests/DbTableNameMatcherTests.cs
@@ -1,0 +1,41 @@
+// <copyright file="DbTableNameMatcherTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.DBManagerUI.Services;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers exact table-name matching used by debugger-to-DB-manager handoff.
+/// </summary>
+public class DbTableNameMatcherTests
+{
+  /// <summary>
+  ///     Ensures exact matches are returned unchanged.
+  /// </summary>
+  [Fact]
+  public void Match_ReturnsExactTableName()
+  {
+    var matched = DbTableNameMatcher.Match(
+        ["TalkMessage", "BattleTalkMessage", "SelectString"],
+        "SelectString");
+
+    Assert.Equal("SelectString", matched);
+  }
+
+  /// <summary>
+  ///     Ensures unknown requests do not resolve to arbitrary tables.
+  /// </summary>
+  [Fact]
+  public void Match_ReturnsNullForUnknownTable()
+  {
+    var matched = DbTableNameMatcher.Match(
+        ["TalkMessage", "BattleTalkMessage"],
+        "UnknownTable");
+
+    Assert.Null(matched);
+  }
+}

--- a/Echoglossian.Tests/InspectionCellFormatterTests.cs
+++ b/Echoglossian.Tests/InspectionCellFormatterTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="InspectionCellFormatterTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.DBManagerUI.Components;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers shared inspection-table cell formatting used by DB-backed and
+///     debugger-backed views.
+/// </summary>
+public class InspectionCellFormatterTests
+{
+  /// <summary>
+  ///     Ensures null values are rendered with the DB manager's existing
+  ///     placeholder text.
+  /// </summary>
+  [Fact]
+  public void Format_NullValue_UsesNullPlaceholder()
+  {
+    var cell = InspectionCellFormatter.Format(null);
+
+    Assert.Equal("(null)", cell.Text);
+    Assert.Null(cell.TooltipText);
+  }
+
+  /// <summary>
+  ///     Ensures binary payloads render as size-only placeholders instead of
+  ///     dumping raw bytes into inspection tables.
+  /// </summary>
+  [Fact]
+  public void Format_ByteArray_UsesBlobPlaceholder()
+  {
+    var cell = InspectionCellFormatter.Format(new byte[12]);
+
+    Assert.Equal("[BLOB 12 bytes]", cell.Text);
+    Assert.Null(cell.TooltipText);
+  }
+
+  /// <summary>
+  ///     Ensures long text is truncated inline while preserving the full value
+  ///     for hover inspection.
+  /// </summary>
+  [Fact]
+  public void Format_LongString_TruncatesInlineAndPreservesTooltip()
+  {
+    var sourceText = new string('x', 300);
+
+    var cell = InspectionCellFormatter.Format(sourceText);
+
+    Assert.Equal(new string('x', 256) + "…", cell.Text);
+    Assert.Equal(sourceText, cell.TooltipText);
+  }
+
+  /// <summary>
+  ///     Ensures short values stay unchanged and do not allocate redundant
+  ///     tooltip content.
+  /// </summary>
+  [Fact]
+  public void Format_ShortString_PreservesTextWithoutTooltip()
+  {
+    const string sourceText = "visible story surface";
+
+    var cell = InspectionCellFormatter.Format(sourceText);
+
+    Assert.Equal(sourceText, cell.Text);
+    Assert.Null(cell.TooltipText);
+  }
+}

--- a/Echoglossian.Tests/VisibleStorySurfaceDiagnosticsStoreTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceDiagnosticsStoreTests.cs
@@ -81,4 +81,112 @@ public class VisibleStorySurfaceDiagnosticsStoreTests
         VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot()!
             .Value.LastRetranslationMessage);
   }
+
+  /// <summary>
+  ///     Ensures clearing the current latest surface falls back to the newest
+  ///     retained snapshot instead of leaving the debugger without any latest
+  ///     snapshot.
+  /// </summary>
+  [Fact]
+  public void Clear_RemovingLatestSurfacePromotesNewestRemainingSnapshot()
+  {
+    VisibleStorySurfaceDiagnosticsStore.Clear();
+
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.Talk,
+            VisibleStorySurfaceProvenanceKind.DbReuse,
+            "TalkMessage",
+            string.Empty,
+            "Original talk",
+            string.Empty,
+            string.Empty,
+            "Translated talk",
+            string.Empty,
+            false,
+            2,
+            new DateTime(2026, 07, 11, 15, 0, 0, DateTimeKind.Utc),
+            null,
+            null));
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.TextGimmickHint,
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            "TextGimmickHintMessage",
+            string.Empty,
+            "Original hint",
+            string.Empty,
+            string.Empty,
+            "Translated hint",
+            string.Empty,
+            false,
+            8,
+            new DateTime(2026, 07, 11, 15, 1, 0, DateTimeKind.Utc),
+            null,
+            null));
+
+    VisibleStorySurfaceDiagnosticsStore.Clear(
+        VisibleStorySurfaceKind.TextGimmickHint);
+
+    Assert.Equal(
+        VisibleStorySurfaceKind.Talk,
+        VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot()!.Value.Surface);
+  }
+
+  /// <summary>
+  ///     Ensures explicit retranslation promotes the updated surface to the
+  ///     latest debugger snapshot.
+  /// </summary>
+  [Fact]
+  public void SetRetranslationOutcome_PromotesUpdatedSurfaceToLatest()
+  {
+    VisibleStorySurfaceDiagnosticsStore.Clear();
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.Talk,
+            VisibleStorySurfaceProvenanceKind.DbReuse,
+            "TalkMessage",
+            string.Empty,
+            "Original talk",
+            string.Empty,
+            string.Empty,
+            "Translated talk",
+            string.Empty,
+            false,
+            2,
+            new DateTime(2026, 07, 11, 15, 0, 0, DateTimeKind.Utc),
+            null,
+            null));
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.TalkSubtitle,
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            "TalkSubtitleMessage",
+            string.Empty,
+            "Original subtitle",
+            string.Empty,
+            string.Empty,
+            "Translated subtitle",
+            string.Empty,
+            false,
+            2,
+            new DateTime(2026, 07, 11, 15, 1, 0, DateTimeKind.Utc),
+            null,
+            null));
+
+    VisibleStorySurfaceDiagnosticsStore.SetRetranslationOutcome(
+        VisibleStorySurfaceKind.Talk,
+        true,
+        VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(
+            VisibleStorySurfaceKind.Talk),
+        new DateTime(2026, 07, 11, 15, 2, 0, DateTimeKind.Utc));
+
+    var latestSnapshot = VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot()!
+        .Value;
+    Assert.Equal(VisibleStorySurfaceKind.Talk, latestSnapshot.Surface);
+    Assert.Equal(
+        VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(
+            VisibleStorySurfaceKind.Talk),
+        latestSnapshot.LastRetranslationMessage);
+  }
 }

--- a/Echoglossian.Tests/VisibleStorySurfaceDiagnosticsStoreTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceDiagnosticsStoreTests.cs
@@ -1,0 +1,84 @@
+// <copyright file="VisibleStorySurfaceDiagnosticsStoreTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers runtime-only storage for visible story-surface diagnostics.
+/// </summary>
+public class VisibleStorySurfaceDiagnosticsStoreTests
+{
+  /// <summary>
+  ///     Ensures recording a snapshot updates the latest visible story-surface state.
+  /// </summary>
+  [Fact]
+  public void Record_StoresLatestSnapshot()
+  {
+    VisibleStorySurfaceDiagnosticsStore.Clear();
+
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.TalkSubtitle,
+            VisibleStorySurfaceProvenanceKind.DbReuse,
+            "TalkSubtitleMessage",
+            string.Empty,
+            "Original subtitle",
+            string.Empty,
+            string.Empty,
+            "Translated subtitle",
+            string.Empty,
+            false,
+            2,
+            DateTime.UtcNow,
+            null,
+            null));
+
+    Assert.Equal(
+        VisibleStorySurfaceKind.TalkSubtitle,
+        VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot()!.Value.Surface);
+  }
+
+  /// <summary>
+  ///     Ensures explicit retranslation outcome updates are retained for the same surface.
+  /// </summary>
+  [Fact]
+  public void SetRetranslationOutcome_UpdatesLatestSnapshotForSameSurface()
+  {
+    VisibleStorySurfaceDiagnosticsStore.Clear();
+    var observedAtUtc = new DateTime(2026, 07, 11, 15, 0, 0, DateTimeKind.Utc);
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.TextGimmickHint,
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            "TextGimmickHintMessage",
+            string.Empty,
+            "Original hint",
+            string.Empty,
+            string.Empty,
+            "Translated hint",
+            string.Empty,
+            false,
+            8,
+            observedAtUtc,
+            null,
+            null));
+
+    VisibleStorySurfaceDiagnosticsStore.SetRetranslationOutcome(
+        VisibleStorySurfaceKind.TextGimmickHint,
+        true,
+        VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(
+            VisibleStorySurfaceKind.TextGimmickHint),
+        observedAtUtc.AddMinutes(1));
+
+    Assert.Equal(
+        VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(
+            VisibleStorySurfaceKind.TextGimmickHint),
+        VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot()!
+            .Value.LastRetranslationMessage);
+  }
+}

--- a/Echoglossian.Tests/VisibleStorySurfaceInspectionModelBuilderTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceInspectionModelBuilderTests.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.NativeUI.Helpers;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Properties;
 using Xunit;
 
 namespace Echoglossian.Tests;
@@ -24,6 +25,18 @@ public class VisibleStorySurfaceInspectionModelBuilderTests
         "SelectString",
         VisibleStorySurfaceTableMap.Resolve(
             VisibleStorySurfaceKind.CutSceneSelectString));
+  }
+
+  /// <summary>
+  ///     Ensures unknown story surfaces fail loudly instead of silently
+  ///     reusing the TalkMessage table mapping.
+  /// </summary>
+  [Fact]
+  public void Resolve_ThrowsForUnknownSurfaceMapping()
+  {
+    Assert.Throws<ArgumentOutOfRangeException>(
+        () => VisibleStorySurfaceTableMap.Resolve(
+            (VisibleStorySurfaceKind)999));
   }
 
   /// <summary>

--- a/Echoglossian.Tests/VisibleStorySurfaceInspectionModelBuilderTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceInspectionModelBuilderTests.cs
@@ -1,0 +1,59 @@
+// <copyright file="VisibleStorySurfaceInspectionModelBuilderTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+using Echoglossian.PluginUI.Helpers;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers debugger-facing story-surface inspection model helpers.
+/// </summary>
+public class VisibleStorySurfaceInspectionModelBuilderTests
+{
+  /// <summary>
+  ///     Ensures CutSceneSelectString diagnostics resolve to the SelectString table.
+  /// </summary>
+  [Fact]
+  public void Resolve_MapsCutSceneSelectStringToSelectString()
+  {
+    Assert.Equal(
+        "SelectString",
+        VisibleStorySurfaceTableMap.Resolve(
+            VisibleStorySurfaceKind.CutSceneSelectString));
+  }
+
+  /// <summary>
+  ///     Ensures option payloads become explicit inspection rows for debugger display.
+  /// </summary>
+  [Fact]
+  public void BuildRows_IncludesOptionsWhenPresent()
+  {
+    var rows = VisibleStorySurfaceInspectionModelBuilder.BuildRows(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.CutSceneSelectString,
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            "SelectString",
+            string.Empty,
+            "Question",
+            "Option A\nOption B",
+            string.Empty,
+            "Translated question",
+            "Translated A\nTranslated B",
+            false,
+            6,
+            new DateTime(2026, 07, 11, 18, 0, 0, DateTimeKind.Utc),
+            null,
+            null));
+
+    Assert.Contains(
+        rows,
+        row => row.Cells.Count >= 2 &&
+               row.Cells[0].Text ==
+               Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalOptions &&
+               row.Cells[1].Text.StartsWith("Option A", StringComparison.Ordinal));
+  }
+}

--- a/Echoglossian.Tests/VisibleStorySurfaceRetranslationDispatcherTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceRetranslationDispatcherTests.cs
@@ -3,10 +3,13 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using Dalamud.Game.Addon.Lifecycle;
+using static Dalamud.Plugin.Services.IAddonLifecycle;
 using Echoglossian.NativeUI.AddonHandlers.Talk;
 using Echoglossian.NativeUI.Handlers;
 using Echoglossian.NativeUI.Helpers;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Properties;
 using Xunit;
 
 namespace Echoglossian.Tests;
@@ -50,6 +53,25 @@ public class VisibleStorySurfaceRetranslationDispatcherTests
         result.SurfaceName);
   }
 
+  /// <summary>
+  ///     Ensures the dispatcher uses a neutral fallback surface label when no
+  ///     visible story-facing handler is applicable.
+  /// </summary>
+  [Fact]
+  public async Task DispatchAsync_ReturnsUnknownSurfaceNameWhenNoHandlerApplies()
+  {
+    var dispatcher = new VisibleStorySurfaceRetranslationDispatcher();
+
+    var result = await dispatcher.DispatchAsync([]);
+
+    Assert.False(result.IsApplicable);
+    Assert.Null(result.Surface);
+    Assert.Equal(Resources.TranslatorDebuggerUnknown, result.SurfaceName);
+    Assert.Equal(
+        VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage(),
+        result.Message);
+  }
+
   private sealed class FakeRetranslationHandler :
       IAddonTranslationHandler,
       IVisibleDialogueRetranslationHandler
@@ -70,9 +92,9 @@ public class VisibleStorySurfaceRetranslationDispatcherTests
           surfaceName + " result");
     }
 
-    public Dictionary<AddonEvent, IAddonLifecycle.AddonEventDelegate> GetEventHandlers()
+    public Dictionary<AddonEvent, AddonEventDelegate> GetEventHandlers()
     {
-      return new Dictionary<AddonEvent, IAddonLifecycle.AddonEventDelegate>();
+      return new Dictionary<AddonEvent, AddonEventDelegate>();
     }
 
     public Task<VisibleDialogueRetranslationResult> RetranslateVisibleTextAndPersistAsync()

--- a/Echoglossian.Tests/VisibleStorySurfaceRetranslationDispatcherTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceRetranslationDispatcherTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="VisibleStorySurfaceRetranslationDispatcherTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.AddonHandlers.Talk;
+using Echoglossian.NativeUI.Handlers;
+using Echoglossian.NativeUI.Helpers;
+using Echoglossian.PluginUI.Helpers;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers explicit visible story-surface retranslation dispatch across
+///     registered addon handlers.
+/// </summary>
+public class VisibleStorySurfaceRetranslationDispatcherTests
+{
+  /// <summary>
+  ///     Ensures the dispatcher returns the first applicable handler result.
+  /// </summary>
+  [Fact]
+  public async Task DispatchAsync_ReturnsFirstApplicableResult()
+  {
+    var dispatcher = new VisibleStorySurfaceRetranslationDispatcher();
+    var handlers = new List<(string AddonName, IAddonTranslationHandler Handler)>
+    {
+      ("Talk", new FakeRetranslationHandler(
+          false,
+          false,
+          VisibleStorySurfaceKind.Talk,
+          VisibleStorySurfaceText.ResolveSurfaceName(
+              VisibleStorySurfaceKind.Talk))),
+      ("TalkSubtitle", new FakeRetranslationHandler(
+          true,
+          true,
+          VisibleStorySurfaceKind.TalkSubtitle,
+          VisibleStorySurfaceText.ResolveSurfaceName(
+              VisibleStorySurfaceKind.TalkSubtitle))),
+    };
+
+    var result = await dispatcher.DispatchAsync(handlers);
+
+    Assert.True(result.IsApplicable);
+    Assert.Equal(VisibleStorySurfaceKind.TalkSubtitle, result.Surface);
+    Assert.Equal(
+        VisibleStorySurfaceText.ResolveSurfaceName(
+            VisibleStorySurfaceKind.TalkSubtitle),
+        result.SurfaceName);
+  }
+
+  private sealed class FakeRetranslationHandler :
+      IAddonTranslationHandler,
+      IVisibleDialogueRetranslationHandler
+  {
+    private readonly VisibleDialogueRetranslationResult result;
+
+    public FakeRetranslationHandler(
+        bool applicable,
+        bool success,
+        VisibleStorySurfaceKind surface,
+        string surfaceName)
+    {
+      this.result = new VisibleDialogueRetranslationResult(
+          applicable,
+          success,
+          surface,
+          surfaceName,
+          surfaceName + " result");
+    }
+
+    public Dictionary<AddonEvent, IAddonLifecycle.AddonEventDelegate> GetEventHandlers()
+    {
+      return new Dictionary<AddonEvent, IAddonLifecycle.AddonEventDelegate>();
+    }
+
+    public Task<VisibleDialogueRetranslationResult> RetranslateVisibleTextAndPersistAsync()
+    {
+      return Task.FromResult(this.result);
+    }
+  }
+}

--- a/Echoglossian.Tests/VisibleStorySurfaceTextTests.cs
+++ b/Echoglossian.Tests/VisibleStorySurfaceTextTests.cs
@@ -1,0 +1,39 @@
+// <copyright file="VisibleStorySurfaceTextTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers localized visible story-surface text helpers.
+/// </summary>
+public class VisibleStorySurfaceTextTests
+{
+  /// <summary>
+  ///     Ensures unsupported story surfaces fail loudly instead of silently
+  ///     reusing the Talk label.
+  /// </summary>
+  [Fact]
+  public void ResolveSurfaceName_ThrowsForUnknownSurface()
+  {
+    Assert.Throws<ArgumentOutOfRangeException>(
+        () => VisibleStorySurfaceText.ResolveSurfaceName(
+            (VisibleStorySurfaceKind)999));
+  }
+
+  /// <summary>
+  ///     Ensures unsupported provenance kinds fail loudly instead of silently
+  ///     reusing a known provenance label.
+  /// </summary>
+  [Fact]
+  public void ResolveProvenanceLabel_ThrowsForUnknownProvenance()
+  {
+    Assert.Throws<ArgumentOutOfRangeException>(
+        () => VisibleStorySurfaceText.ResolveProvenanceLabel(
+            (VisibleStorySurfaceProvenanceKind)999));
+  }
+}

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -374,6 +374,7 @@ public partial class Echoglossian : IDalamudPlugin
     this.dbEditorWindow = new DbEditorWindow(new EchoglossianDbContext(ConfigDirectory));
     this.translatorMetricsWindow = new TranslatorMetricsWindow(
         this.configuration,
+        this.OpenDbEditorForTable,
         this.RetranslateVisibleDialogueAndPersistAsync);
     // Subscribe to draw it:
     PluginInterface.UiBuilder.Draw += this.DrawDbEditorWindow;

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -20969,6 +20969,16 @@
             </summary>
             <returns>The latest snapshot, or <see langword="null"/> when none exist.</returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.ResolveLatestSurfaceUnsafe">
+            <summary>
+                Resolves the retained surface with the most recent observed snapshot
+                timestamp.
+            </summary>
+            <returns>
+                The latest retained surface, or <see langword="null"/> when none
+                remain.
+            </returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind">
             <summary>
                 Identifies a player-visible story-facing surface that can expose

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -16027,15 +16027,15 @@
         </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult">
             <summary>
-                Describes the outcome of one explicit visible-dialogue retranslation
+                Describes the outcome of one explicit visible story-surface retranslation
                 request.
             </summary>
             <param name="IsApplicable">
-            Whether the handler had an active visible dialogue line to operate on.
+            Whether the handler had an active visible story-facing payload to operate on.
             </param>
             <param name="Success">
             Whether the visible retranslation completed successfully for the current
-            line.
+            payload.
             </param>
             <param name="Surface">
             The visible story surface that handled the request, when applicable.
@@ -16045,15 +16045,15 @@
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.#ctor(System.Boolean,System.Boolean,System.Nullable{Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind},System.String,System.String)">
             <summary>
-                Describes the outcome of one explicit visible-dialogue retranslation
+                Describes the outcome of one explicit visible story-surface retranslation
                 request.
             </summary>
             <param name="IsApplicable">
-            Whether the handler had an active visible dialogue line to operate on.
+            Whether the handler had an active visible story-facing payload to operate on.
             </param>
             <param name="Success">
             Whether the visible retranslation completed successfully for the current
-            line.
+            payload.
             </param>
             <param name="Surface">
             The visible story surface that handled the request, when applicable.
@@ -16063,13 +16063,13 @@
         </member>
         <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.IsApplicable">
             <summary>
-            Whether the handler had an active visible dialogue line to operate on.
+            Whether the handler had an active visible story-facing payload to operate on.
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.Success">
             <summary>
             Whether the visible retranslation completed successfully for the current
-            line.
+            payload.
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.Surface">
@@ -22554,9 +22554,12 @@
                 class.
             </summary>
             <param name="config">The active plugin configuration.</param>
+            <param name="openDbEditorForTable">
+                Delegate used to open the DB manager on the requested table.
+            </param>
             <param name="retranslateVisibleDialogueAsync">
-                Delegate used to explicitly retranslate the currently visible dialogue
-                line and persist the refreshed result.
+                Delegate used to explicitly retranslate the currently visible
+                story-facing text and persist the refreshed result.
             </param>
         </member>
         <member name="P:Echoglossian.TranslatorMetricsWindow.IsOpen">

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -9731,6 +9731,13 @@
             <param name="scope">The logical scope to render inside square brackets.</param>
             <param name="message">The message to write.</param>
         </member>
+        <member name="M:Echoglossian.PluginRuntimeLog.Warning(System.Exception,System.String)">
+            <summary>
+                Writes a warning log line with exception details.
+            </summary>
+            <param name="exception">The exception to include in the log entry.</param>
+            <param name="message">The message to write.</param>
+        </member>
         <member name="M:Echoglossian.PluginRuntimeLog.Error(System.String)">
             <summary>
                 Writes an error log line.
@@ -20846,7 +20853,10 @@
             <param name="EffectiveTranslationEngineId">
             The effective translation engine identifier used for the snapshot.
             </param>
-            <param name="ObservedAtUtc">The UTC timestamp when the snapshot was observed.</param>
+            <param name="ObservedAtUtc">
+            The UTC timestamp when this snapshot was last updated, either from a live
+            observation or from an explicit retranslation outcome.
+            </param>
             <param name="LastRetranslationSuccess">
             The latest explicit retranslation success flag for this surface.
             </param>
@@ -20874,7 +20884,10 @@
             <param name="EffectiveTranslationEngineId">
             The effective translation engine identifier used for the snapshot.
             </param>
-            <param name="ObservedAtUtc">The UTC timestamp when the snapshot was observed.</param>
+            <param name="ObservedAtUtc">
+            The UTC timestamp when this snapshot was last updated, either from a live
+            observation or from an explicit retranslation outcome.
+            </param>
             <param name="LastRetranslationSuccess">
             The latest explicit retranslation success flag for this surface.
             </param>
@@ -20920,7 +20933,10 @@
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.ObservedAtUtc">
-            <summary>The UTC timestamp when the snapshot was observed.</summary>
+            <summary>
+            The UTC timestamp when this snapshot was last updated, either from a live
+            observation or from an explicit retranslation outcome.
+            </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.LastRetranslationSuccess">
             <summary>
@@ -20961,7 +20977,10 @@
             <param name="surface">The surface that handled the request.</param>
             <param name="success">Whether the explicit retranslation succeeded.</param>
             <param name="message">The user-facing outcome message.</param>
-            <param name="observedAtUtc">The UTC timestamp for the outcome.</param>
+            <param name="observedAtUtc">
+            The UTC timestamp to store as the snapshot's latest update time for the
+            explicit retranslation outcome.
+            </param>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot">
             <summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2174,8 +2174,17 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
+                Hosts debug-only automatic addon-probe watches that start on login for
+                selected addons with early hidden-state value.
+            </summary>
+            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
+            </summary>
+            <summary>
+                Handles the quest probe command used to inspect the complete quest data
+                shape from Lumina, the live quest progress resolver, and the current
+                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -2736,6 +2745,11 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
+        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
+            <summary>
+            Holds the currently active addon structure probe watch, if any.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -2895,6 +2909,11 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
+            <summary>
+                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -4262,6 +4281,109 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
+        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
+            <summary>
+                Ticks manual and automatic addon-probe watches, including the
+                debug-only login bootstrap for the default watch set.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
+            <summary>
+                Gets how many addon-probe watches are currently active across manual
+                and managed watch sets.
+            </summary>
+            <returns>The active probe-watch count.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
+            <summary>
+                Stops every active addon-probe watch known to the plugin.
+            </summary>
+            <param name="suppressAutoUntilLogout">
+                Whether the current login session should suppress the default
+                automatic watch set after the stop completes.
+            </param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
+            <summary>
+                Ticks the currently active manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
+            <summary>
+                Ticks every managed addon-probe watch and prunes the disposed ones.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic addon-probe watch set when the player
+                logs in, then resets the gate on logout.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic watch set used to capture early
+                structural state for pooled dialogue addons.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
+            <summary>
+                Starts one managed addon-probe watch and tracks it for later stop or
+                pruning.
+            </summary>
+            <param name="addonName">The addon name to watch.</param>
+            <param name="index">The addon instance index.</param>
+            <param name="duration">How long the watch should stay alive.</param>
+            <param name="reason">The debug log reason attached to the startup.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
+            <summary>
+                Stops the current manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
+            <summary>
+                Stops every managed automatic addon-probe watch.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
+            <summary>
+            Dumps a recursive probe of the requested addon to the log so we can
+            inspect its live node tree, component roots, and likely overlay anchors.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
+            <summary>
+            Parses the addon probe command arguments into an addon name, optional index,
+            and optional watch duration.
+            </summary>
+            <param name="args">The raw command arguments.</param>
+            <returns>The addon name, index, and duration to probe.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
+            <summary>
+            Parses one addon-probe duration token such as "90s" or "15m".
+            </summary>
+            <param name="token">The raw duration token.</param>
+            <param name="duration">Receives the parsed duration.</param>
+            <returns><see langword="true"/> when the token parsed successfully.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
+            <summary>
+            Determines whether a token looks like an addon-probe duration even when the
+            value is outside the accepted range.
+            </summary>
+            <param name="token">The token to inspect.</param>
+            <returns><see langword="true"/> when the token resembles a duration.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
+            <summary>
+            Formats one addon-probe watch duration for chat feedback.
+            </summary>
+            <param name="duration">The duration to format.</param>
+            <returns>The human-readable duration string.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -4530,6 +4652,102 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
+            <summary>
+                Handles the quest probe command.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
+            <summary>
+                Tries to resolve the quest probe target from either a quest id or a
+                quest name.
+            </summary>
+            <param name="input">The command argument.</param>
+            <param name="questIdText">The resolved quest id as text.</param>
+            <param name="questName">The resolved quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>True when the quest could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the quest data structure for inspection.
+            </summary>
+            <param name="questIdText">The quest id as text.</param>
+            <param name="questName">The quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the raw Lumina quest row properties.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs all rows from the quest text sheet, not just the live todo
+                entries, so we can inspect the full structure of the quest sheet.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
+            <summary>
+                Logs the QuestPlate rows currently stored for the quest.
+            </summary>
+            <param name="questIdText">The quest id text.</param>
+            <param name="questName">The quest name.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Logs the resolved live quest progression snapshot.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves a human-readable quest name from a quest row.
+            </summary>
+            <param name="questRow">The quest row.</param>
+            <returns>The resolved quest name, if available.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
+            <summary>
+                Converts quest text to a readable string for probe output.
+            </summary>
+            <param name="text">The quest text.</param>
+            <returns>The evaluated text string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
+            <summary>
+                Formats a probe value for log output.
+            </summary>
+            <param name="value">The value to format.</param>
+            <returns>A human-readable value string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Builds the raw quest sheet name used by the game files.
+            </summary>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>The quest text sheet name, if it can be derived.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest row id as text through reflection so the probe
+                stays compatible with generated sheet shapes.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest row id as text, or an empty string if unavailable.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest sheet identifier used to mount the quest text
+                sheet path.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -5459,14 +5677,20 @@
         </member>
         <member name="M:Echoglossian.Echoglossian.RetranslateVisibleDialogueAndPersistAsync">
             <summary>
-                Retranslates the currently visible Talk or BattleTalk line using the
-                active engine and persists the refreshed result when a dialogue handler
-                can resolve a live source line.
+                Retranslates the currently visible story-facing text using the active
+                engine and persists the refreshed result when a registered handler can
+                resolve a live source payload.
             </summary>
             <returns>
-                A result describing whether a visible dialogue line was available and
-                whether the explicit retranslation succeeded.
+                A result describing whether a visible story-facing surface was
+                available and whether the explicit retranslation succeeded.
             </returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OpenDbEditorForTable(System.String)">
+            <summary>
+            Opens the DB editor and preselects a requested table.
+            </summary>
+            <param name="tableName">The requested DB manager table name.</param>
         </member>
         <member name="M:Echoglossian.Echoglossian.OnEgloDbEditorCommand(System.String,System.String)">
             <summary>
@@ -6328,6 +6552,135 @@
             Draws editors for supported types. Strings are multiline with wrapping.
             </summary>
         </member>
+        <member name="T:Echoglossian.DBManagerUI.Components.InspectionCell">
+            <summary>
+            Represents a single display-ready inspection cell.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionCell.#ctor(System.String,System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Echoglossian.DBManagerUI.Components.InspectionCell"/> class.
+            </summary>
+            <param name="text">Inline text shown in the table cell.</param>
+            <param name="tooltipText">Optional full text shown on hover.</param>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionCell.Text">
+            <summary>
+            Gets the inline text shown in the table cell.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionCell.TooltipText">
+            <summary>
+            Gets the optional full text shown on hover.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.DBManagerUI.Components.InspectionCellFormatter">
+            <summary>
+            Formats raw values into display-ready inspection cells.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.DBManagerUI.Components.InspectionCellFormatter.DefaultInlineTextLimit">
+            <summary>
+            The default inline text limit before overflow is moved to a tooltip.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionCellFormatter.Format(System.Object,System.Int32)">
+            <summary>
+            Formats a raw value into an inspection cell.
+            </summary>
+            <param name="value">The raw value to format.</param>
+            <param name="inlineTextLimit">The maximum inline text length.</param>
+            <returns>A display-ready cell.</returns>
+        </member>
+        <member name="T:Echoglossian.DBManagerUI.Components.InspectionColumnDefinition">
+            <summary>
+            Represents one display column in a reusable inspection table.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionColumnDefinition.#ctor(System.String,Dalamud.Bindings.ImGui.ImGuiTableColumnFlags,System.Single)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Echoglossian.DBManagerUI.Components.InspectionColumnDefinition"/> class.
+            </summary>
+            <param name="header">Column header label.</param>
+            <param name="flags">ImGui column sizing flags.</param>
+            <param name="initialWidth">Initial column width.</param>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionColumnDefinition.Header">
+            <summary>
+            Gets the column header label.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionColumnDefinition.Flags">
+            <summary>
+            Gets the ImGui sizing flags for the column.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionColumnDefinition.InitialWidth">
+            <summary>
+            Gets the initial width for the column.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.DBManagerUI.Components.InspectionRow">
+            <summary>
+            Represents a single row in a reusable inspection table.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionRow.#ctor(System.Collections.Generic.IReadOnlyList{Echoglossian.DBManagerUI.Components.InspectionCell},System.Object)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Echoglossian.DBManagerUI.Components.InspectionRow"/> class.
+            </summary>
+            <param name="cells">Display-ready cells for the row.</param>
+            <param name="payload">Optional context payload associated with the row.</param>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionRow.Cells">
+            <summary>
+            Gets the display-ready cells for the row.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DBManagerUI.Components.InspectionRow.Payload">
+            <summary>
+            Gets the optional row payload for callbacks.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.DBManagerUI.Components.InspectionTableView">
+            <summary>
+            Renders a reusable wrapped-text inspection table with optional selection
+            and double-click callbacks.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionTableView.#ctor(System.String,System.Func{System.Collections.Generic.IReadOnlyList{Echoglossian.DBManagerUI.Components.InspectionColumnDefinition}},System.Func{System.Collections.Generic.IReadOnlyList{Echoglossian.DBManagerUI.Components.InspectionRow}},System.String,System.String,System.String,System.Func{System.Collections.Generic.HashSet{System.Int32}},System.Action{Echoglossian.DBManagerUI.Components.InspectionRow})">
+            <summary>
+            Initializes a new instance of the <see cref="T:Echoglossian.DBManagerUI.Components.InspectionTableView"/> class.
+            </summary>
+            <param name="tableId">Stable ImGui table identifier.</param>
+            <param name="getColumns">Accessor for current column definitions.</param>
+            <param name="getRows">Accessor for current rows.</param>
+            <param name="noRecordsLoadedMessage">Message shown when rows are unavailable.</param>
+            <param name="noRecordsFoundMessage">Message shown when the table is empty.</param>
+            <param name="noColumnsMessage">Message shown when no columns are available.</param>
+            <param name="getSelection">Optional selection state accessor.</param>
+            <param name="onRowDoubleClick">Optional double-click callback.</param>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionTableView.Draw">
+            <summary>
+            Draws the inspection table.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionTableView.DrawSelectionCell(System.Collections.Generic.HashSet{System.Int32},System.Int32)">
+            <summary>
+            Draws the optional selection checkbox cell for a row.
+            </summary>
+            <param name="selection">Selection state store.</param>
+            <param name="rowIndex">The row index.</param>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Components.InspectionTableView.DrawDataCell(System.Int32,System.Int32,Echoglossian.DBManagerUI.Components.InspectionRow)">
+            <summary>
+            Draws a single wrapped-text data cell.
+            </summary>
+            <param name="rowIndex">The row index.</param>
+            <param name="columnIndex">The zero-based data column index.</param>
+            <param name="row">The row being rendered.</param>
+        </member>
         <member name="T:Echoglossian.DBManagerUI.Components.Ui.TextInputHelpers">
             <summary>
             Helper methods for wrapped, multiline ImGui text inputs.
@@ -6365,6 +6718,12 @@
             <summary>
             Draws the window and its components.
             </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.DbEditorWindow.OpenAndSelectTable(System.String)">
+            <summary>
+            Opens the DB manager window and selects the requested table when it exists.
+            </summary>
+            <param name="tableName">The table name to select.</param>
         </member>
         <member name="M:Echoglossian.DBManagerUI.DbEditorWindow.InitializeTableNames">
             <summary>
@@ -6469,6 +6828,21 @@
             <param name="db">DbContext instance.</param>
             <param name="entityClrType">Entity CLR type.</param>
             <returns>DbSet instance as object.</returns>
+        </member>
+        <member name="T:Echoglossian.DBManagerUI.Services.DbTableNameMatcher">
+            <summary>
+            Resolves DB manager table names from caller-supplied requests.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBManagerUI.Services.DbTableNameMatcher.Match(System.Collections.Generic.IReadOnlyList{System.String},System.String)">
+            <summary>
+            Finds the exact matching table name from the available DB manager tables.
+            </summary>
+            <param name="tables">The available table names.</param>
+            <param name="requestedTable">The requested table name.</param>
+            <returns>
+            The matched table name, or <see langword="null"/> when no exact match exists.
+            </returns>
         </member>
         <member name="T:Echoglossian.DBManagerUI.Services.PropertyEditorRegistry">
             <summary>Draws editors for property values by type.</summary>
@@ -12496,6 +12870,9 @@
                 A dictionary mapping addon events to combined delegates.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.RetranslateVisibleTextAndPersistAsync">
+            <inheritdoc />
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.RegisterHandler(Dalamud.Game.Addon.Lifecycle.AddonEvent,Echoglossian.NativeUI.Handlers.LocalAddonHandlerDelegate)">
             <summary>
                 Registers a local delegate for the specified addon event.
@@ -12530,14 +12907,14 @@
                 Resolves a CutSceneSelectString translation without blocking the game UI.
             </summary>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.TranslateDialogAsync(System.String,System.Collections.Generic.IReadOnlyList{System.String})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.TranslateDialogAsync(System.String,System.Collections.Generic.IReadOnlyList{System.String},Echoglossian.Translators.TranslationSurfaceGroup)">
             <summary>
                 Translates the question and all options in a single batched request
                 when possible, falling back to per-item translation if the batch
                 parsing fails.
             </summary>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.TranslateDialogIndividuallyAsync(System.String,System.Collections.Generic.IReadOnlyList{System.String})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.TranslateDialogIndividuallyAsync(System.String,System.Collections.Generic.IReadOnlyList{System.String},Echoglossian.Translators.TranslationSurfaceGroup)">
             <summary>
                 Falls back to translating each dialog element individually.
             </summary>
@@ -12590,11 +12967,47 @@
                 Builds a database lookup entity for the currently visible question and options.
             </summary>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.TranslateOrFallbackAsync(System.String)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.TranslateOrFallbackAsync(System.String,Echoglossian.Translators.TranslationSurfaceGroup)">
             <summary>
                 Translates a piece of text or falls back to the original text when the
                 translation service does not return content.
             </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.HasUsableTranslatedDialogPayload(System.String,System.Collections.Generic.IReadOnlyList{System.String},System.String,System.Collections.Generic.IReadOnlyList{System.String},System.String,System.String)">
+            <summary>
+                Determines whether the translated CutSceneSelectString payload
+                contains at least one usable translated question or option.
+            </summary>
+            <param name="originalQuestion">The original question text.</param>
+            <param name="originalOptions">The original option payload.</param>
+            <param name="translatedQuestion">The translated question text.</param>
+            <param name="translatedOptions">The translated option payload.</param>
+            <param name="sourceLang">The original language.</param>
+            <param name="targetLang">The target language.</param>
+            <returns>
+                <see langword="true" /> when at least one translated element is
+                usable for persistence; otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.RecordDiagnosticsSnapshot(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Int32)">
+            <summary>
+                Records the latest visible CutSceneSelectString provenance snapshot
+                for the debugger.
+            </summary>
+            <param name="provenance">The provenance label kind to expose.</param>
+            <param name="originalQuestion">The original question text.</param>
+            <param name="originalOptions">The original option payload.</param>
+            <param name="translatedQuestion">The translated question text.</param>
+            <param name="translatedOptions">The translated option payload.</param>
+            <param name="effectiveTranslationEngineId">
+            The effective dialogue translation engine identifier.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.GetDialogueTranslationEngineId">
+            <summary>
+                Resolves the effective dialogue translation engine identifier.
+            </summary>
+            <returns>The effective dialogue translation engine identifier.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.CutSceneSelectString.CutSceneSelectStringHandler.NormalizeForReplacement(System.String)">
             <summary>
@@ -15478,6 +15891,23 @@
                 to a known original source line; otherwise, <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.RecordDiagnosticsSnapshot(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.String,System.String,System.String,System.Boolean,System.Int32)">
+            <summary>
+                Records the latest visible BattleTalk provenance snapshot for the
+                debugger.
+            </summary>
+            <param name="provenance">The provenance label kind to expose.</param>
+            <param name="originalName">The original speaker name.</param>
+            <param name="originalText">The original BattleTalk text.</param>
+            <param name="translatedName">The translated speaker name.</param>
+            <param name="translatedText">The translated BattleTalk text.</param>
+            <param name="usedRuntimeOnlyDialogueContext">
+            Whether runtime-only dialogue context influenced the live translation.
+            </param>
+            <param name="effectiveTranslationEngineId">
+            The effective dialogue translation engine identifier.
+            </param>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryMapVisibleSourceToOriginal(System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean,System.Boolean,System.String@,System.String@)">
             <summary>
                 Tries to map visible BattleTalk text back to a specific known original and
@@ -15580,19 +16010,19 @@
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Talk.IVisibleDialogueRetranslationHandler">
             <summary>
                 Defines the runtime contract for explicitly retranslating the currently
-                visible dialogue line and persisting the refreshed result.
+                visible story-facing text and persisting the refreshed result.
             </summary>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.IVisibleDialogueRetranslationHandler.RetranslateVisibleTextAndPersistAsync">
             <summary>
-                Retranslates the currently visible dialogue line using the active
+                Retranslates the currently visible story-facing text using the active
                 translator configuration and persists the refreshed result when the
                 output is usable.
             </summary>
             <returns>
                 A <see cref="T:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult" /> describing whether
-                this handler had an active visible line, whether retranslating it
-                succeeded, and the user-facing outcome message.
+                this handler had an active visible story-facing surface, whether
+                retranslating it succeeded, and the user-facing outcome message.
             </returns>
         </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult">
@@ -15607,10 +16037,13 @@
             Whether the visible retranslation completed successfully for the current
             line.
             </param>
+            <param name="Surface">
+            The visible story surface that handled the request, when applicable.
+            </param>
             <param name="SurfaceName">The surface that handled the request.</param>
             <param name="Message">The user-facing outcome message.</param>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.#ctor(System.Boolean,System.Boolean,System.String,System.String)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.#ctor(System.Boolean,System.Boolean,System.Nullable{Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind},System.String,System.String)">
             <summary>
                 Describes the outcome of one explicit visible-dialogue retranslation
                 request.
@@ -15621,6 +16054,9 @@
             <param name="Success">
             Whether the visible retranslation completed successfully for the current
             line.
+            </param>
+            <param name="Surface">
+            The visible story surface that handled the request, when applicable.
             </param>
             <param name="SurfaceName">The surface that handled the request.</param>
             <param name="Message">The user-facing outcome message.</param>
@@ -15634,6 +16070,11 @@
             <summary>
             Whether the visible retranslation completed successfully for the current
             line.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.Surface">
+            <summary>
+            The visible story surface that handled the request, when applicable.
             </summary>
         </member>
         <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult.SurfaceName">
@@ -15864,6 +16305,28 @@
             <param name="requestId">The request identifier used to reject stale results.</param>
             <returns>A task that completes when the translation state has been updated.</returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.RecordDiagnosticsSnapshot(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.String,System.String,System.String,System.Boolean,System.Int32)">
+            <summary>
+                Records the latest visible Talk provenance snapshot for the debugger.
+            </summary>
+            <param name="provenance">The provenance label kind to expose.</param>
+            <param name="originalName">The original speaker name.</param>
+            <param name="originalText">The original Talk text.</param>
+            <param name="translatedName">The translated speaker name.</param>
+            <param name="translatedText">The translated Talk text.</param>
+            <param name="usedRuntimeOnlyDialogueContext">
+            Whether runtime-only dialogue context influenced the live translation.
+            </param>
+            <param name="effectiveTranslationEngineId">
+            The effective dialogue translation engine identifier.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.GetDialogueTranslationEngineId">
+            <summary>
+                Resolves the effective dialogue translation engine identifier.
+            </summary>
+            <returns>The effective dialogue translation engine identifier.</returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.ShouldApplyNativeTalkText">
             <summary>
                 Determines whether native Talk text should be replaced instead of leaving
@@ -15968,6 +16431,9 @@
             <returns>
                 A dictionary mapping addon events to combined delegates.
             </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkSubtitleHandler.RetranslateVisibleTextAndPersistAsync">
+            <inheritdoc />
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkSubtitleHandler.RegisterHandler(Dalamud.Game.Addon.Lifecycle.AddonEvent,Echoglossian.NativeUI.Handlers.LocalAddonHandlerDelegate)">
             <summary>
@@ -16119,6 +16585,18 @@
                 dialogue-family routing path.
             </summary>
             <returns>The effective dialogue-family translation engine identifier.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkSubtitleHandler.RecordDiagnosticsSnapshot(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.String,System.Int32)">
+            <summary>
+                Records the latest visible TalkSubtitle provenance snapshot for the
+                debugger.
+            </summary>
+            <param name="provenance">The provenance label kind to expose.</param>
+            <param name="originalText">The original subtitle text.</param>
+            <param name="translatedText">The translated subtitle text.</param>
+            <param name="effectiveTranslationEngineId">
+            The effective dialogue translation engine identifier.
+            </param>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkSubtitleHandler.NormalizeForReplacement(System.String)">
             <summary>
@@ -16954,6 +17432,9 @@
                 A dictionary mapping addon events to combined delegates.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.RetranslateVisibleTextAndPersistAsync">
+            <inheritdoc />
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.RegisterHandler(Dalamud.Game.Addon.Lifecycle.AddonEvent,Echoglossian.NativeUI.Handlers.LocalAddonHandlerDelegate)">
             <summary>
                 Registers a local delegate for the specified addon event.
@@ -17061,18 +17542,6 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.IsStoredTranslationUsable(Echoglossian.EFCoreSqlite.Models.TextGimmickHintMessage,System.String)">
-            <summary>
-                Determines whether a stored gimmick-hint row still represents a usable
-                translation for the current source line.
-            </summary>
-            <param name="textGimmickHintMessage">The stored gimmick-hint row to validate.</param>
-            <param name="originalText">The expected original gimmick-hint text.</param>
-            <returns>
-                <see langword="true" /> when the stored row contains a non-empty
-                translation for the same source line; otherwise, <see langword="false" />.
-            </returns>
-        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.TryGetCurrentResolvedTranslation(System.String@,System.String@,System.String@)">
             <summary>
                 Returns the active resolved translation currently held by the handler
@@ -17113,6 +17582,24 @@
                 overlay mode is enabled.
             </summary>
             <param name="translatedText">The translated gimmick-hint text.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.RecordDiagnosticsSnapshot(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.String,System.Int32)">
+            <summary>
+                Records the latest visible TextGimmickHint provenance snapshot for
+                the debugger.
+            </summary>
+            <param name="provenance">The provenance label kind to expose.</param>
+            <param name="originalText">The original gimmick-hint text.</param>
+            <param name="translatedText">The translated gimmick-hint text.</param>
+            <param name="effectiveTranslationEngineId">
+            The effective dialogue translation engine identifier.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.GetDialogueTranslationEngineId">
+            <summary>
+                Resolves the effective dialogue translation engine identifier.
+            </summary>
+            <returns>The effective dialogue translation engine identifier.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Toasts.TextGimmickHintHandler.ShouldUseOverlay">
             <summary>
@@ -18061,6 +18548,46 @@
             <param name="addonLifecycle">The add-on lifecycle instance from which logging event listeners will be removed. Cannot be null.</param>
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
+            <summary>
+                Encapsulates the login-session gating rules for debug-only automatic
+                addon-probe watches.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
+            <summary>
+                Determines whether the current login session should start the default
+                automatic addon-probe watch set.
+            </summary>
+            <param name="isLoggedIn">Whether the client is currently logged in.</param>
+            <param name="hasStartedForCurrentLogin">
+                Whether the current login session already started its automatic probe
+                set.
+            </param>
+            <param name="isSuppressedUntilLogout">
+                Whether the user explicitly suppressed the automatic probe set until
+                the next logout.
+            </param>
+            <param name="activeManagedWatchCount">
+                How many managed automatic probe watches are currently alive.
+            </param>
+            <returns>
+                <see langword="true" /> when the automatic probe set should start.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
+            <summary>
+                Determines whether the automatic login-session gate should reset
+                because the player logged out.
+            </summary>
+            <param name="wasLoggedIn">
+                Whether the client was logged in on the previous tick.
+            </param>
+            <param name="isLoggedIn">Whether the client is logged in now.</param>
+            <returns>
+                <see langword="true" /> when the automatic probe gate should reset.
+            </returns>
         </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
@@ -20299,6 +20826,305 @@
                 <c>true</c> when the overlay should display the original text.
             </returns>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot">
+            <summary>
+                Represents one runtime-only diagnostic snapshot for the most recently
+                resolved visible story-facing surface.
+            </summary>
+            <param name="Surface">The active story surface.</param>
+            <param name="Provenance">The provenance label kind shown to operators.</param>
+            <param name="TableName">The effective DB manager table name for handoff.</param>
+            <param name="OriginalSpeakerText">The original speaker text when applicable.</param>
+            <param name="OriginalText">The primary original text payload.</param>
+            <param name="OriginalOptionsText">The original options payload when applicable.</param>
+            <param name="TranslatedSpeakerText">The translated speaker text when applicable.</param>
+            <param name="TranslatedText">The primary translated text payload.</param>
+            <param name="TranslatedOptionsText">The translated options payload when applicable.</param>
+            <param name="UsedRuntimeOnlyDialogueContext">
+            Whether runtime-only dialogue context influenced the live translation.
+            </param>
+            <param name="EffectiveTranslationEngineId">
+            The effective translation engine identifier used for the snapshot.
+            </param>
+            <param name="ObservedAtUtc">The UTC timestamp when the snapshot was observed.</param>
+            <param name="LastRetranslationSuccess">
+            The latest explicit retranslation success flag for this surface.
+            </param>
+            <param name="LastRetranslationMessage">
+            The latest explicit retranslation outcome message for this surface.
+            </param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.#ctor(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind,Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.Boolean,System.Int32,System.DateTime,System.Nullable{System.Boolean},System.String)">
+            <summary>
+                Represents one runtime-only diagnostic snapshot for the most recently
+                resolved visible story-facing surface.
+            </summary>
+            <param name="Surface">The active story surface.</param>
+            <param name="Provenance">The provenance label kind shown to operators.</param>
+            <param name="TableName">The effective DB manager table name for handoff.</param>
+            <param name="OriginalSpeakerText">The original speaker text when applicable.</param>
+            <param name="OriginalText">The primary original text payload.</param>
+            <param name="OriginalOptionsText">The original options payload when applicable.</param>
+            <param name="TranslatedSpeakerText">The translated speaker text when applicable.</param>
+            <param name="TranslatedText">The primary translated text payload.</param>
+            <param name="TranslatedOptionsText">The translated options payload when applicable.</param>
+            <param name="UsedRuntimeOnlyDialogueContext">
+            Whether runtime-only dialogue context influenced the live translation.
+            </param>
+            <param name="EffectiveTranslationEngineId">
+            The effective translation engine identifier used for the snapshot.
+            </param>
+            <param name="ObservedAtUtc">The UTC timestamp when the snapshot was observed.</param>
+            <param name="LastRetranslationSuccess">
+            The latest explicit retranslation success flag for this surface.
+            </param>
+            <param name="LastRetranslationMessage">
+            The latest explicit retranslation outcome message for this surface.
+            </param>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.Surface">
+            <summary>The active story surface.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.Provenance">
+            <summary>The provenance label kind shown to operators.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.TableName">
+            <summary>The effective DB manager table name for handoff.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.OriginalSpeakerText">
+            <summary>The original speaker text when applicable.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.OriginalText">
+            <summary>The primary original text payload.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.OriginalOptionsText">
+            <summary>The original options payload when applicable.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.TranslatedSpeakerText">
+            <summary>The translated speaker text when applicable.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.TranslatedText">
+            <summary>The primary translated text payload.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.TranslatedOptionsText">
+            <summary>The translated options payload when applicable.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.UsedRuntimeOnlyDialogueContext">
+            <summary>
+            Whether runtime-only dialogue context influenced the live translation.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.EffectiveTranslationEngineId">
+            <summary>
+            The effective translation engine identifier used for the snapshot.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.ObservedAtUtc">
+            <summary>The UTC timestamp when the snapshot was observed.</summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.LastRetranslationSuccess">
+            <summary>
+            The latest explicit retranslation success flag for this surface.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot.LastRetranslationMessage">
+            <summary>
+            The latest explicit retranslation outcome message for this surface.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore">
+            <summary>
+                Stores runtime-only visible story-surface diagnostics for the debugger.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.Clear">
+            <summary>
+            Clears all retained diagnostics snapshots.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.Clear(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+            Clears the retained diagnostics snapshot for one visible story surface.
+            </summary>
+            <param name="surface">The surface to clear.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.Record(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot)">
+            <summary>
+            Records the latest diagnostics snapshot for a visible story surface.
+            </summary>
+            <param name="snapshot">The snapshot to retain.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.SetRetranslationOutcome(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind,System.Boolean,System.String,System.DateTime)">
+            <summary>
+            Updates the latest explicit retranslation outcome for one story surface.
+            </summary>
+            <param name="surface">The surface that handled the request.</param>
+            <param name="success">Whether the explicit retranslation succeeded.</param>
+            <param name="message">The user-facing outcome message.</param>
+            <param name="observedAtUtc">The UTC timestamp for the outcome.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot">
+            <summary>
+            Gets the latest snapshot across all visible story surfaces.
+            </summary>
+            <returns>The latest snapshot, or <see langword="null"/> when none exist.</returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind">
+            <summary>
+                Identifies a player-visible story-facing surface that can expose
+                provenance and explicit retranslation diagnostics.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind.Talk">
+            <summary>
+            The standard Talk addon.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind.BattleTalk">
+            <summary>
+            The BattleTalk addon.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind.TalkSubtitle">
+            <summary>
+            The TalkSubtitle addon.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind.CutSceneSelectString">
+            <summary>
+            The CutSceneSelectString addon.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind.TextGimmickHint">
+            <summary>
+            The TextGimmickHint addon.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind">
+            <summary>
+                Identifies where the currently visible story-surface translation came
+                from for debugger provenance display.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind.DbReuse">
+            <summary>
+            The visible translation came from an existing DB row.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind.FreshLiveTranslation">
+            <summary>
+            The visible translation came from a fresh live translation.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind.FreshLiveTranslationRuntimeOnlyDialogueContext">
+            <summary>
+            The visible translation came from a fresh live translation that used
+            runtime-only dialogue context and therefore should not be persisted as a
+            canonical DB row.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceTableMap">
+            <summary>
+                Maps visible story surfaces to their DB manager table names.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceTableMap.Resolve(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+            Resolves the DB manager table name for one visible story surface.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The matching DB manager table name.</returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText">
+            <summary>
+                Resolves localized user-facing strings for visible story-surface
+                debugger and explicit retranslation flows.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.ResolveSurfaceName(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+                Resolves the localized display name for one visible story surface.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The localized surface display name.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.ResolveProvenanceLabel(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind)">
+            <summary>
+                Resolves the localized provenance label for one diagnostics snapshot.
+            </summary>
+            <param name="provenance">The provenance kind to format.</param>
+            <returns>The localized provenance label.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetNoVisibleTextMessage(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+                Builds the user-facing message shown when no visible text is available
+                for one story surface.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The localized unavailable message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetNoUsableTranslationMessage(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+                Builds the user-facing message shown when a visible retranslation did
+                not produce usable translated content.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The localized unusable-result message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetPersistenceFailedMessage(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind,System.String)">
+            <summary>
+                Builds the user-facing message shown when a live refresh applied but
+                persistence failed.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <param name="persistenceResult">The persistence-layer detail.</param>
+            <returns>The localized persistence failure message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetPersistedButVisibleChangedMessage(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+                Builds the user-facing message shown when a refreshed result was
+                persisted but the visible source changed before apply.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The localized stale-apply message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+                Builds the user-facing message shown when explicit retranslation
+                succeeds and is persisted.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The localized success message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetRetranslationFailedMessage(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceKind)">
+            <summary>
+                Builds the user-facing message shown when explicit retranslation
+                fails before a usable result can be applied.
+            </summary>
+            <param name="surface">The visible story surface.</param>
+            <returns>The localized failure message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage">
+            <summary>
+                Gets the user-facing message shown when no visible story surface is
+                currently available for explicit retranslation.
+            </summary>
+            <returns>The localized unavailable message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetUnexpectedFailureMessage">
+            <summary>
+                Gets the user-facing message shown when a visible retranslation task
+                faults before it returns a structured result.
+            </summary>
+            <returns>The localized unexpected-failure message.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.VisibleStorySurfaceText.GetCanceledMessage">
+            <summary>
+                Gets the user-facing message shown when a visible retranslation task
+                is canceled.
+            </summary>
+            <returns>The localized cancellation message.</returns>
+        </member>
         <member name="T:Echoglossian.SummaryQuest">
             <summary>
             Represents a journal summary quest entry and its translation state.
@@ -21254,6 +22080,58 @@
             </summary>
             <param name="fieldName">The name of the required field.</param>
         </member>
+        <member name="T:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceInspectionModelBuilder">
+            <summary>
+                Builds reusable inspection-table models for the latest visible
+                story-surface diagnostics snapshot.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceInspectionModelBuilder.BuildColumns">
+            <summary>
+            Builds the shared inspection table columns used by the debugger.
+            </summary>
+            <returns>The shared debugger columns.</returns>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceInspectionModelBuilder.BuildRows(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceDiagnosticsSnapshot)">
+            <summary>
+            Builds display-ready rows for a visible story-surface diagnostics snapshot.
+            </summary>
+            <param name="snapshot">The snapshot to render.</param>
+            <returns>The display-ready inspection rows.</returns>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceInspectionModelBuilder.BuildRow(System.String,System.String)">
+            <summary>
+            Builds one debugger inspection row.
+            </summary>
+            <param name="field">The field label.</param>
+            <param name="value">The field value.</param>
+            <returns>The display-ready row.</returns>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceInspectionModelBuilder.AddOptionalRow(System.Collections.Generic.ICollection{Echoglossian.DBManagerUI.Components.InspectionRow},System.String,System.String)">
+            <summary>
+            Adds one optional debugger inspection row when a value is available.
+            </summary>
+            <param name="rows">The row list to append to.</param>
+            <param name="field">The field label.</param>
+            <param name="value">The optional field value.</param>
+        </member>
+        <member name="T:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceRetranslationDispatcher">
+            <summary>
+                Dispatches explicit visible retranslation requests across registered
+                story-facing addon handlers.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Helpers.VisibleStorySurfaceRetranslationDispatcher.DispatchAsync(System.Collections.Generic.IEnumerable{System.ValueTuple{System.String,Echoglossian.NativeUI.Handlers.IAddonTranslationHandler}})">
+            <summary>
+                Dispatches the explicit retranslation request to the first applicable
+                visible story-surface handler.
+            </summary>
+            <param name="handlers">The registered addon handlers to inspect.</param>
+            <returns>
+                The first applicable visible retranslation result, or a non-applicable
+                result when no visible story surface is currently available.
+            </returns>
+        </member>
         <member name="T:Echoglossian.PluginUI.Tabs.AboutTab">
             <summary>
             Displays the "About Echoglossian" tab content with logo and disclaimer.
@@ -21382,7 +22260,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -21670,7 +22548,7 @@
                 operator inspection.
             </summary>
         </member>
-        <member name="M:Echoglossian.TranslatorMetricsWindow.#ctor(Echoglossian.Config,System.Func{System.Threading.Tasks.Task{Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult}})">
+        <member name="M:Echoglossian.TranslatorMetricsWindow.#ctor(Echoglossian.Config,System.Action{System.String},System.Func{System.Threading.Tasks.Task{Echoglossian.NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult}})">
             <summary>
                 Initializes a new instance of the <see cref="T:Echoglossian.TranslatorMetricsWindow" />
                 class.
@@ -21695,6 +22573,19 @@
             <summary>
                 Resolves a completed visible-dialogue retranslation task into the
                 session-scoped status message shown by the debugger window.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.TranslatorMetricsWindow.BuildVisibleStorySurfaceInspectionRows">
+            <summary>
+                Builds the reusable inspection rows for the latest retained visible
+                story-surface diagnostics snapshot.
+            </summary>
+            <returns>The reusable inspection rows for the latest snapshot.</returns>
+        </member>
+        <member name="M:Echoglossian.TranslatorMetricsWindow.DrawVisibleStorySurfaceDiagnostics">
+            <summary>
+                Draws the latest visible story-surface provenance snapshot and DB
+                manager handoff controls.
             </summary>
         </member>
         <member name="M:Echoglossian.TranslatorMetricsWindow.DrawDialogueOverrideStatus">
@@ -24029,6 +24920,196 @@
             </summary>
         </member>
         <member name="P:Echoglossian.Properties.Resources.AddonProbeDurationSecondsFormat">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerUnknown">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceCanceled">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceDescription">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldColumn">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldDbTable">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldEffectiveEngine">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldLastRetranslation">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldObservedUtc">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalOptions">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalSpeaker">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalText">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldProvenance">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldRuntimeOnlyDialogueContext">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldSurface">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldTranslatedOptions">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldTranslatedSpeaker">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceFieldTranslatedText">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNameBattleTalk">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNameTalk">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNameTalkSubtitle">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNameTextGimmickHint">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNoColumns">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNoSnapshot">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNoUsableTranslation">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNoVisibleSurfaceAvailable">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceNoVisibleText">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfacePersistenceFailed">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfacePersistedButVisibleChanged">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceDbReuse">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslationRuntimeOnlyContext">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceRetranslatedAndPersisted">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceRetranslationFailed">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceUnexpectedFailure">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceValueColumn">
+            <summary>
+                Pesquisa uma cadeia de caracteres localizada.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TranslatorDebuggerVisibleStorySurfaceViewInDbManager">
             <summary>
                 Pesquisa uma cadeia de caracteres localizada.
             </summary>

--- a/GeneralHelpers/PluginRuntimeLog.cs
+++ b/GeneralHelpers/PluginRuntimeLog.cs
@@ -347,6 +347,22 @@ internal static class PluginRuntimeLog
   }
 
   /// <summary>
+  ///     Writes a warning log line with exception details.
+  /// </summary>
+  /// <param name="exception">The exception to include in the log entry.</param>
+  /// <param name="message">The message to write.</param>
+  public static void Warning(Exception exception, string message)
+  {
+    var pluginLog = Echoglossian.PluginLog;
+    if (pluginLog == null)
+    {
+      return;
+    }
+
+    pluginLog.Warning(exception, message);
+  }
+
+  /// <summary>
   ///     Writes an error log line.
   /// </summary>
   /// <param name="message">The message to write.</param>

--- a/NativeUI/AddonHandlers/CutSceneSelectString/CutSceneSelectStringHandler.cs
+++ b/NativeUI/AddonHandlers/CutSceneSelectString/CutSceneSelectStringHandler.cs
@@ -17,7 +17,9 @@ public unsafe delegate void SyncCutSceneSelectStringOverlayBoundsDelegate(
 ///     The first readable text node becomes the question/title and the remaining
 ///     text nodes become the selectable options.
 /// </summary>
-public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
+public sealed class CutSceneSelectStringHandler :
+    IAddonTranslationHandler,
+    IVisibleDialogueRetranslationHandler
 {
   private const string AddonName = "CutSceneSelectString";
 
@@ -110,6 +112,185 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
             handler(evt, args);
           }
         }));
+  }
+
+  /// <inheritdoc />
+  public async Task<VisibleDialogueRetranslationResult>
+      RetranslateVisibleTextAndPersistAsync()
+  {
+    const VisibleStorySurfaceKind surface =
+        VisibleStorySurfaceKind.CutSceneSelectString;
+    var surfaceName = VisibleStorySurfaceText.ResolveSurfaceName(surface);
+    string originalQuestion;
+    List<string> originalOptions;
+    int requestId;
+    var sourceLang = ClientStateInterface.ClientLanguage.Humanize();
+    var targetLang = LangDict[LanguageInt].Code;
+
+    lock (this.stateGate)
+    {
+      originalQuestion = this.state.CurrentOriginalQuestion;
+      originalOptions = [.. this.state.CurrentOriginalOptions];
+      if (string.IsNullOrWhiteSpace(originalQuestion))
+      {
+        return new VisibleDialogueRetranslationResult(
+            false,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoVisibleTextMessage(surface));
+      }
+
+      this.state.ActiveRequestId++;
+      requestId = this.state.ActiveRequestId;
+      this.state.TranslationInFlight = true;
+      this.state.CurrentTranslatedQuestion = string.Empty;
+      this.state.CurrentTranslatedOptions = [];
+      this.state.CurrentReplacementQuestion = string.Empty;
+      this.state.CurrentReplacementOptions = [];
+    }
+
+    try
+    {
+      var (translatedQuestion, translatedOptions) = await this.TranslateDialogAsync(
+              originalQuestion,
+              originalOptions,
+              TranslationSurfaceGroup.Dialogue)
+          .ConfigureAwait(false);
+
+      if (!this.HasUsableTranslatedDialogPayload(
+              originalQuestion,
+              originalOptions,
+              translatedQuestion,
+              translatedOptions,
+              sourceLang,
+              targetLang))
+      {
+        lock (this.stateGate)
+        {
+          if (this.state.ActiveRequestId == requestId)
+          {
+            this.state.TranslationInFlight = false;
+            this.state.LastFailedSourceKey = this.BuildSourceKey(
+                originalQuestion,
+                originalOptions);
+          }
+        }
+
+        return new VisibleDialogueRetranslationResult(
+            true,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoUsableTranslationMessage(surface));
+      }
+
+      var dialogueTranslationEngine = this.GetDialogueTranslationEngineId();
+      var replacementQuestion = this.NormalizeForReplacement(translatedQuestion);
+      var replacementOptions = translatedOptions
+          .Select(this.NormalizeForReplacement)
+          .ToList();
+      var selectString = new SelectString(
+          originalQuestion,
+          sourceLang,
+          JsonConvert.SerializeObject(originalOptions),
+          translatedQuestion,
+          JsonConvert.SerializeObject(translatedOptions),
+          targetLang,
+          dialogueTranslationEngine,
+          DateTime.Now,
+          DateTime.Now);
+      var persistenceResult = await this.insertCutSceneSelectStringMessageAsync(
+              selectString)
+          .ConfigureAwait(false);
+      var persistenceSucceeded = !persistenceResult.StartsWith(
+          "ErrorSavingData:",
+          StringComparison.Ordinal) &&
+                                 !string.Equals(
+                                     persistenceResult,
+                                     "No data to save.",
+                                     StringComparison.Ordinal);
+      var sourceChangedBeforeApply = false;
+      lock (this.stateGate)
+      {
+        sourceChangedBeforeApply = this.state.ActiveRequestId != requestId;
+        if (!sourceChangedBeforeApply)
+        {
+          this.state.CurrentOriginalQuestion = originalQuestion;
+          this.state.CurrentOriginalOptions = [.. originalOptions];
+          this.state.CurrentTranslatedQuestion = translatedQuestion;
+          this.state.CurrentTranslatedOptions = [.. translatedOptions];
+          this.state.CurrentReplacementQuestion = replacementQuestion;
+          this.state.CurrentReplacementOptions = [.. replacementOptions];
+          this.state.TranslationInFlight = false;
+          this.state.LastFailedSourceKey = string.Empty;
+        }
+      }
+
+      if (!sourceChangedBeforeApply)
+      {
+        this.RecordDiagnosticsSnapshot(
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            originalQuestion,
+            originalOptions,
+            translatedQuestion,
+            translatedOptions,
+            dialogueTranslationEngine);
+        this.PublishOverlay();
+      }
+
+      if (!persistenceSucceeded)
+      {
+        return new VisibleDialogueRetranslationResult(
+            true,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistenceFailedMessage(
+                surface,
+                persistenceResult));
+      }
+
+      if (sourceChangedBeforeApply)
+      {
+        return new VisibleDialogueRetranslationResult(
+            true,
+            true,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistedButVisibleChangedMessage(
+                surface));
+      }
+
+      return new VisibleDialogueRetranslationResult(
+          true,
+          true,
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(surface));
+    }
+    catch (Exception ex)
+    {
+      lock (this.stateGate)
+      {
+        if (this.state.ActiveRequestId == requestId)
+        {
+          this.state.TranslationInFlight = false;
+          this.state.LastFailedSourceKey = this.BuildSourceKey(
+              originalQuestion,
+              originalOptions);
+        }
+      }
+
+      PluginRuntimeLog.Error(
+          $"[{AddonName}] Error retranslating visible CutSceneSelectString text: {ex}");
+      return new VisibleDialogueRetranslationResult(
+          true,
+          false,
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslationFailedMessage(surface));
+    }
   }
 
   /// <summary>
@@ -296,6 +477,8 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
       this.state = new DialogState();
     }
 
+    VisibleStorySurfaceDiagnosticsStore.Clear(
+        VisibleStorySurfaceKind.CutSceneSelectString);
     this.clearOverlay();
   }
 
@@ -343,6 +526,8 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
       List<string> originalOptions,
       int requestId)
   {
+    var sourceLang = ClientStateInterface.ClientLanguage.Humanize();
+    var targetLang = LangDict[LanguageInt].Code;
     string translatedQuestion;
     List<string> translatedOptions;
 
@@ -352,7 +537,10 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
           $"request={requestId} translating question='{this.Preview(originalQuestion)}' " +
           $"options={originalOptions.Count}");
       (translatedQuestion, translatedOptions) =
-          await this.TranslateDialogAsync(originalQuestion, originalOptions);
+          await this.TranslateDialogAsync(
+              originalQuestion,
+              originalOptions,
+              TranslationSurfaceGroup.Dialogue).ConfigureAwait(false);
     }
     catch (Exception e)
     {
@@ -371,6 +559,29 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
       return;
     }
 
+    if (!this.HasUsableTranslatedDialogPayload(
+            originalQuestion,
+            originalOptions,
+            translatedQuestion,
+            translatedOptions,
+            sourceLang,
+            targetLang))
+    {
+      lock (this.stateGate)
+      {
+        if (this.state.ActiveRequestId == requestId)
+        {
+          this.state.TranslationInFlight = false;
+          this.state.LastFailedSourceKey = this.BuildSourceKey(
+              originalQuestion,
+              originalOptions);
+        }
+      }
+
+      return;
+    }
+
+    var dialogueTranslationEngine = this.GetDialogueTranslationEngineId();
     var replacementQuestion = this.NormalizeForReplacement(translatedQuestion);
     var replacementOptions = translatedOptions
         .Select(this.NormalizeForReplacement)
@@ -382,12 +593,12 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
 
     var selectString = new SelectString(
         originalQuestion,
-        ClientStateInterface.ClientLanguage.Humanize(),
+        sourceLang,
         JsonConvert.SerializeObject(originalOptions),
         translatedQuestion,
         JsonConvert.SerializeObject(translatedOptions),
-        LangDict[LanguageInt].Code,
-        this.config.ChosenTransEngine,
+        targetLang,
+        dialogueTranslationEngine,
         DateTime.Now,
         DateTime.Now);
 
@@ -421,6 +632,14 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
       this.state.TranslationInFlight = false;
       this.state.LastFailedSourceKey = string.Empty;
     }
+
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+        originalQuestion,
+        originalOptions,
+        translatedQuestion,
+        translatedOptions,
+        dialogueTranslationEngine);
   }
 
   /// <summary>
@@ -431,7 +650,8 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
   private async Task<(string TranslatedQuestion, List<string> TranslatedOptions)>
       TranslateDialogAsync(
           string originalQuestion,
-          IReadOnlyList<string> originalOptions)
+          IReadOnlyList<string> originalOptions,
+          TranslationSurfaceGroup surfaceGroup)
   {
     var sourceLang = ClientStateInterface.ClientLanguage.Humanize();
     var targetLang = LangDict[LanguageInt].Code;
@@ -452,7 +672,8 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
       var translatedChunk = await this.translationService.TranslateAsync(
           chunk,
           sourceLang,
-          targetLang);
+          targetLang,
+          surfaceGroup).ConfigureAwait(false);
 
       if (string.IsNullOrWhiteSpace(translatedChunk))
       {
@@ -469,7 +690,8 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
     {
       return await this.TranslateDialogIndividuallyAsync(
           originalQuestion,
-          originalOptions);
+          originalOptions,
+          surfaceGroup).ConfigureAwait(false);
     }
 
     var translatedQuestion = translatedMap.TryGetValue(0, out var questionText) &&
@@ -500,14 +722,22 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
   private async Task<(string TranslatedQuestion, List<string> TranslatedOptions)>
       TranslateDialogIndividuallyAsync(
           string originalQuestion,
-          IReadOnlyList<string> originalOptions)
+          IReadOnlyList<string> originalOptions,
+          TranslationSurfaceGroup surfaceGroup)
   {
-    var translatedQuestion = await this.TranslateOrFallbackAsync(originalQuestion);
+    var translatedQuestion = await this.TranslateOrFallbackAsync(
+            originalQuestion,
+            surfaceGroup)
+        .ConfigureAwait(false);
     var translatedOptions = new List<string>(originalOptions.Count);
 
     foreach (var option in originalOptions)
     {
-      translatedOptions.Add(await this.TranslateOrFallbackAsync(option));
+      translatedOptions.Add(
+          await this.TranslateOrFallbackAsync(
+                  option,
+                  surfaceGroup)
+              .ConfigureAwait(false));
     }
 
     return (translatedQuestion, translatedOptions);
@@ -670,6 +900,13 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
         translatedOptions,
         replacementQuestion,
         replacementOptions);
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.DbReuse,
+        originalQuestion,
+        originalOptions,
+        translatedQuestion,
+        translatedOptions,
+        lookup.TranslationEngine ?? this.GetDialogueTranslationEngineId());
     return true;
   }
 
@@ -715,6 +952,13 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
         translatedOptions,
         replacementQuestion,
         replacementOptions);
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.DbReuse,
+        originalQuestion,
+        originalOptions,
+        translatedQuestion,
+        translatedOptions,
+        lookup.TranslationEngine ?? this.GetDialogueTranslationEngineId());
     return true;
   }
 
@@ -819,14 +1063,113 @@ public sealed class CutSceneSelectStringHandler : IAddonTranslationHandler
   ///     Translates a piece of text or falls back to the original text when the
   ///     translation service does not return content.
   /// </summary>
-  private async Task<string> TranslateOrFallbackAsync(string text)
+  private async Task<string> TranslateOrFallbackAsync(
+      string text,
+      TranslationSurfaceGroup surfaceGroup)
   {
     var translatedText = await this.translationService.TranslateAsync(
         text,
         ClientStateInterface.ClientLanguage.Humanize(),
-        LangDict[LanguageInt].Code);
+        LangDict[LanguageInt].Code,
+        surfaceGroup).ConfigureAwait(false);
 
     return string.IsNullOrWhiteSpace(translatedText) ? text : translatedText;
+  }
+
+  /// <summary>
+  ///     Determines whether the translated CutSceneSelectString payload
+  ///     contains at least one usable translated question or option.
+  /// </summary>
+  /// <param name="originalQuestion">The original question text.</param>
+  /// <param name="originalOptions">The original option payload.</param>
+  /// <param name="translatedQuestion">The translated question text.</param>
+  /// <param name="translatedOptions">The translated option payload.</param>
+  /// <param name="sourceLang">The original language.</param>
+  /// <param name="targetLang">The target language.</param>
+  /// <returns>
+  ///     <see langword="true" /> when at least one translated element is
+  ///     usable for persistence; otherwise, <see langword="false" />.
+  /// </returns>
+  private bool HasUsableTranslatedDialogPayload(
+      string originalQuestion,
+      IReadOnlyList<string> originalOptions,
+      string translatedQuestion,
+      IReadOnlyList<string> translatedOptions,
+      string sourceLang,
+      string targetLang)
+  {
+    if (TranslationPersistenceGuard.IsUsableDialogueTranslation(
+            originalQuestion,
+            translatedQuestion,
+            sourceLang,
+            targetLang))
+    {
+      return true;
+    }
+
+    var optionCount = Math.Min(originalOptions.Count, translatedOptions.Count);
+    for (var i = 0; i < optionCount; i++)
+    {
+      if (TranslationPersistenceGuard.IsUsableDialogueTranslation(
+              originalOptions[i],
+              translatedOptions[i],
+              sourceLang,
+              targetLang))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// <summary>
+  ///     Records the latest visible CutSceneSelectString provenance snapshot
+  ///     for the debugger.
+  /// </summary>
+  /// <param name="provenance">The provenance label kind to expose.</param>
+  /// <param name="originalQuestion">The original question text.</param>
+  /// <param name="originalOptions">The original option payload.</param>
+  /// <param name="translatedQuestion">The translated question text.</param>
+  /// <param name="translatedOptions">The translated option payload.</param>
+  /// <param name="effectiveTranslationEngineId">
+  /// The effective dialogue translation engine identifier.
+  /// </param>
+  private void RecordDiagnosticsSnapshot(
+      VisibleStorySurfaceProvenanceKind provenance,
+      string originalQuestion,
+      IReadOnlyList<string> originalOptions,
+      string translatedQuestion,
+      IReadOnlyList<string> translatedOptions,
+      int effectiveTranslationEngineId)
+  {
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.CutSceneSelectString,
+            provenance,
+            VisibleStorySurfaceTableMap.Resolve(
+                VisibleStorySurfaceKind.CutSceneSelectString),
+            string.Empty,
+            originalQuestion,
+            string.Join('\n', originalOptions),
+            string.Empty,
+            translatedQuestion,
+            string.Join('\n', translatedOptions),
+            false,
+            effectiveTranslationEngineId,
+            DateTime.UtcNow,
+            null,
+            null));
+  }
+
+  /// <summary>
+  ///     Resolves the effective dialogue translation engine identifier.
+  /// </summary>
+  /// <returns>The effective dialogue translation engine identifier.</returns>
+  private int GetDialogueTranslationEngineId()
+  {
+    return this.translationService.GetEffectiveTranslationEngineId(
+        TranslationSurfaceGroup.Dialogue);
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -119,6 +119,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   /// <inheritdoc />
   public async Task<VisibleDialogueRetranslationResult> RetranslateVisibleTextAndPersistAsync()
   {
+    const VisibleStorySurfaceKind surface = VisibleStorySurfaceKind.BattleTalk;
+    var surfaceName = VisibleStorySurfaceText.ResolveSurfaceName(surface);
     if (!this.TryCaptureCurrentBattleTalkSource(
             out var originalName,
             out var originalText))
@@ -126,8 +128,9 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
       return new VisibleDialogueRetranslationResult(
           false,
           false,
-          BattleTalkAddonName,
-          "No visible BattleTalk line is available to retranslate.");
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetNoVisibleTextMessage(surface));
     }
 
     int requestId;
@@ -184,8 +187,9 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         return new VisibleDialogueRetranslationResult(
             true,
             false,
-            BattleTalkAddonName,
-            "BattleTalk retranslation did not produce a usable translated result.");
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoUsableTranslationMessage(surface));
       }
 
       var translatedBattleTalkData = new BattleTalkMessage(
@@ -233,6 +237,14 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
       if (!sourceChangedBeforeApply)
       {
+        this.RecordDiagnosticsSnapshot(
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            originalName,
+            originalText,
+            translatedName,
+            translatedText,
+            usedRuntimeOnlyDialogueContext: false,
+            dialogueTranslationEngine);
         this.PublishOverlay(
             originalName,
             originalText,
@@ -245,8 +257,11 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         return new VisibleDialogueRetranslationResult(
             true,
             false,
-            BattleTalkAddonName,
-            $"BattleTalk retranslation updated the live line, but persistence failed: {persistenceResult}");
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistenceFailedMessage(
+                surface,
+                persistenceResult));
       }
 
       if (sourceChangedBeforeApply)
@@ -254,15 +269,18 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         return new VisibleDialogueRetranslationResult(
             true,
             true,
-            BattleTalkAddonName,
-            "BattleTalk retranslation was persisted, but the visible line changed before the refreshed text could be applied.");
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistedButVisibleChangedMessage(
+                surface));
       }
 
       return new VisibleDialogueRetranslationResult(
           true,
           true,
-          BattleTalkAddonName,
-          "BattleTalk visible dialogue was retranslated and persisted.");
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(surface));
     }
     catch (Exception ex)
     {
@@ -281,8 +299,9 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
       return new VisibleDialogueRetranslationResult(
           true,
           false,
-          BattleTalkAddonName,
-          "BattleTalk retranslation failed before a usable result could be applied.");
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslationFailedMessage(surface));
     }
   }
 
@@ -442,6 +461,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         this.ResetStateLocked();
       }
 
+      VisibleStorySurfaceDiagnosticsStore.Clear(
+          VisibleStorySurfaceKind.BattleTalk);
       this.clearOverlay();
     });
   }
@@ -466,6 +487,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
       this.ResetStateLocked();
     }
 
+    VisibleStorySurfaceDiagnosticsStore.Clear(VisibleStorySurfaceKind.BattleTalk);
     this.clearOverlay();
   }
 
@@ -756,6 +778,11 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
       string translatedName;
       string translatedText;
+      VisibleStorySurfaceProvenanceKind provenance;
+      bool usedRuntimeOnlyDialogueContext = false;
+      var dialogueTranslationEngine =
+          this.translationService.GetEffectiveTranslationEngineId(
+              TranslationSurfaceGroup.Dialogue);
 
       if (this.IsStoredTranslationUsable(
               foundBattleTalkMessage,
@@ -767,6 +794,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
             : string.Empty;
         translatedText =
             foundBattleTalkMessage.TranslatedBattleTalkMessage ?? string.Empty;
+        provenance = VisibleStorySurfaceProvenanceKind.DbReuse;
       }
       else
       {
@@ -781,6 +809,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
             this.translationService.WillUseDialogueContext(
                 dialogueContext,
                 TranslationSurfaceGroup.Dialogue);
+        usedRuntimeOnlyDialogueContext = usesRuntimeOnlyDialogueContext;
 
         translatedText = await this.translationService.TranslateAsync(
             originalText,
@@ -809,9 +838,6 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
         if (!usesRuntimeOnlyDialogueContext)
         {
-          var dialogueTranslationEngine =
-              this.translationService.GetEffectiveTranslationEngineId(
-                  TranslationSurfaceGroup.Dialogue);
           var translatedBattleTalkData = new BattleTalkMessage(
               originalName,
               originalText,
@@ -826,6 +852,13 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
               DateTime.Now);
 
           await this.insertBattleTalkMessageAsync(translatedBattleTalkData);
+          provenance = VisibleStorySurfaceProvenanceKind.FreshLiveTranslation;
+        }
+        else
+        {
+          provenance =
+              VisibleStorySurfaceProvenanceKind
+                  .FreshLiveTranslationRuntimeOnlyDialogueContext;
         }
       }
 
@@ -859,6 +892,14 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
       if (!string.IsNullOrWhiteSpace(translatedText))
       {
+        this.RecordDiagnosticsSnapshot(
+            provenance,
+            originalName,
+            originalText,
+            translatedName,
+            translatedText,
+            usedRuntimeOnlyDialogueContext,
+            dialogueTranslationEngine);
         this.PublishOverlay(
             originalName,
             originalText,
@@ -1277,6 +1318,49 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
     originalName = string.Empty;
     originalText = string.Empty;
     return false;
+  }
+
+  /// <summary>
+  ///     Records the latest visible BattleTalk provenance snapshot for the
+  ///     debugger.
+  /// </summary>
+  /// <param name="provenance">The provenance label kind to expose.</param>
+  /// <param name="originalName">The original speaker name.</param>
+  /// <param name="originalText">The original BattleTalk text.</param>
+  /// <param name="translatedName">The translated speaker name.</param>
+  /// <param name="translatedText">The translated BattleTalk text.</param>
+  /// <param name="usedRuntimeOnlyDialogueContext">
+  /// Whether runtime-only dialogue context influenced the live translation.
+  /// </param>
+  /// <param name="effectiveTranslationEngineId">
+  /// The effective dialogue translation engine identifier.
+  /// </param>
+  private void RecordDiagnosticsSnapshot(
+      VisibleStorySurfaceProvenanceKind provenance,
+      string originalName,
+      string originalText,
+      string translatedName,
+      string translatedText,
+      bool usedRuntimeOnlyDialogueContext,
+      int effectiveTranslationEngineId)
+  {
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.BattleTalk,
+            provenance,
+            VisibleStorySurfaceTableMap.Resolve(
+                VisibleStorySurfaceKind.BattleTalk),
+            originalName,
+            originalText,
+            string.Empty,
+            translatedName,
+            translatedText,
+            string.Empty,
+            usedRuntimeOnlyDialogueContext,
+            effectiveTranslationEngineId,
+            DateTime.UtcNow,
+            null,
+            null));
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs
@@ -7,19 +7,19 @@ namespace Echoglossian.NativeUI.AddonHandlers.Talk;
 
 /// <summary>
 ///     Defines the runtime contract for explicitly retranslating the currently
-///     visible dialogue line and persisting the refreshed result.
+///     visible story-facing text and persisting the refreshed result.
 /// </summary>
 public interface IVisibleDialogueRetranslationHandler
 {
   /// <summary>
-  ///     Retranslates the currently visible dialogue line using the active
-  ///     translator configuration and persists the refreshed result when the
-  ///     output is usable.
+  ///     Retranslates the currently visible story-facing text using the active
+///     translator configuration and persists the refreshed result when the
+///     output is usable.
   /// </summary>
   /// <returns>
   ///     A <see cref="VisibleDialogueRetranslationResult" /> describing whether
-  ///     this handler had an active visible line, whether retranslating it
-  ///     succeeded, and the user-facing outcome message.
+  ///     this handler had an active visible story-facing surface, whether
+  ///     retranslating it succeeded, and the user-facing outcome message.
   /// </returns>
   Task<VisibleDialogueRetranslationResult> RetranslateVisibleTextAndPersistAsync();
 }
@@ -35,10 +35,14 @@ public interface IVisibleDialogueRetranslationHandler
 /// Whether the visible retranslation completed successfully for the current
 /// line.
 /// </param>
+/// <param name="Surface">
+/// The visible story surface that handled the request, when applicable.
+/// </param>
 /// <param name="SurfaceName">The surface that handled the request.</param>
 /// <param name="Message">The user-facing outcome message.</param>
 public readonly record struct VisibleDialogueRetranslationResult(
     bool IsApplicable,
     bool Success,
+    VisibleStorySurfaceKind? Surface,
     string SurfaceName,
     string Message);

--- a/NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs
@@ -13,8 +13,8 @@ public interface IVisibleDialogueRetranslationHandler
 {
   /// <summary>
   ///     Retranslates the currently visible story-facing text using the active
-///     translator configuration and persists the refreshed result when the
-///     output is usable.
+  ///     translator configuration and persists the refreshed result when the
+  ///     output is usable.
   /// </summary>
   /// <returns>
   ///     A <see cref="VisibleDialogueRetranslationResult" /> describing whether
@@ -25,15 +25,15 @@ public interface IVisibleDialogueRetranslationHandler
 }
 
 /// <summary>
-///     Describes the outcome of one explicit visible-dialogue retranslation
+///     Describes the outcome of one explicit visible story-surface retranslation
 ///     request.
 /// </summary>
 /// <param name="IsApplicable">
-/// Whether the handler had an active visible dialogue line to operate on.
+/// Whether the handler had an active visible story-facing payload to operate on.
 /// </param>
 /// <param name="Success">
 /// Whether the visible retranslation completed successfully for the current
-/// line.
+/// payload.
 /// </param>
 /// <param name="Surface">
 /// The visible story surface that handled the request, when applicable.

--- a/NativeUI/AddonHandlers/Talk/TalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/TalkHandler.cs
@@ -110,13 +110,16 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   /// <inheritdoc />
   public async Task<VisibleDialogueRetranslationResult> RetranslateVisibleTextAndPersistAsync()
   {
+    const VisibleStorySurfaceKind surface = VisibleStorySurfaceKind.Talk;
+    var surfaceName = VisibleStorySurfaceText.ResolveSurfaceName(surface);
     if (!this.TryCaptureCurrentTalkSource(out var originalName, out var originalText))
     {
       return new VisibleDialogueRetranslationResult(
           false,
           false,
-          TalkAddonName,
-          "No visible Talk dialogue line is available to retranslate.");
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetNoVisibleTextMessage(surface));
     }
 
     int requestId;
@@ -169,8 +172,9 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
         return new VisibleDialogueRetranslationResult(
             true,
             false,
-            TalkAddonName,
-            "Talk retranslation did not produce a usable translated result.");
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoUsableTranslationMessage(surface));
       }
 
       var translatedTalkData = new TalkMessage(
@@ -212,6 +216,14 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
 
       if (!sourceChangedBeforeApply)
       {
+        this.RecordDiagnosticsSnapshot(
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            originalName,
+            originalText,
+            translatedName,
+            translatedText,
+            usedRuntimeOnlyDialogueContext: false,
+            dialogueTranslationEngine);
         this.PublishOverlay(
             originalName,
             originalText,
@@ -224,8 +236,11 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
         return new VisibleDialogueRetranslationResult(
             true,
             false,
-            TalkAddonName,
-            $"Talk retranslation updated the live line, but persistence failed: {persistenceResult}");
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistenceFailedMessage(
+                surface,
+                persistenceResult));
       }
 
       if (sourceChangedBeforeApply)
@@ -233,15 +248,18 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
         return new VisibleDialogueRetranslationResult(
             true,
             true,
-            TalkAddonName,
-            "Talk retranslation was persisted, but the visible line changed before the refreshed text could be applied.");
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistedButVisibleChangedMessage(
+                surface));
       }
 
       return new VisibleDialogueRetranslationResult(
           true,
           true,
-          TalkAddonName,
-          "Talk visible dialogue was retranslated and persisted.");
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(surface));
     }
     catch (Exception ex)
     {
@@ -258,8 +276,9 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
       return new VisibleDialogueRetranslationResult(
           true,
           false,
-          TalkAddonName,
-          "Talk retranslation failed before a usable result could be applied.");
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslationFailedMessage(surface));
     }
   }
 
@@ -523,6 +542,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
       this.translationInFlight = false;
     }
 
+    VisibleStorySurfaceDiagnosticsStore.Clear(VisibleStorySurfaceKind.Talk);
     this.nativeTalkTextNodeStateCaptured = false;
     this.nativeTalkTextNodeStateDirty = false;
     this.nativeTalkTextNodeStateCapturedForSourceText = string.Empty;
@@ -928,7 +948,20 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
       this.translationInFlight = false;
     }
 
-    return !string.IsNullOrWhiteSpace(translatedText);
+    if (string.IsNullOrWhiteSpace(translatedText))
+    {
+      return false;
+    }
+
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.DbReuse,
+        originalName,
+        originalText,
+        translatedName,
+        translatedText,
+        usedRuntimeOnlyDialogueContext: false,
+        this.GetDialogueTranslationEngineId());
+    return true;
   }
 
   /// <summary>
@@ -951,6 +984,11 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
 
       string translatedName;
       string translatedText;
+      VisibleStorySurfaceProvenanceKind provenance;
+      bool usedRuntimeOnlyDialogueContext = false;
+      var dialogueTranslationEngine =
+          this.translationService.GetEffectiveTranslationEngineId(
+              TranslationSurfaceGroup.Dialogue);
 
       if (foundTalkMessage != null)
       {
@@ -958,6 +996,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
             ? foundTalkMessage.TranslatedSenderName ?? string.Empty
             : string.Empty;
         translatedText = foundTalkMessage.TranslatedTalkMessage ?? string.Empty;
+        provenance = VisibleStorySurfaceProvenanceKind.DbReuse;
       }
       else
       {
@@ -972,6 +1011,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
             this.translationService.WillUseDialogueContext(
                 dialogueContext,
                 TranslationSurfaceGroup.Dialogue);
+        usedRuntimeOnlyDialogueContext = usesRuntimeOnlyDialogueContext;
 
         translatedText = await this.translationService.TranslateAsync(
             originalText,
@@ -997,12 +1037,10 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
               : string.Empty;
           translatedText =
               existingTranslatedTalkMessage.TranslatedTalkMessage ?? string.Empty;
+          provenance = VisibleStorySurfaceProvenanceKind.DbReuse;
         }
         else if (!usesRuntimeOnlyDialogueContext)
         {
-          var dialogueTranslationEngine =
-              this.translationService.GetEffectiveTranslationEngineId(
-                  TranslationSurfaceGroup.Dialogue);
           var translatedTalkData = new TalkMessage(
               originalName,
               originalText,
@@ -1017,6 +1055,13 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
               DateTime.Now);
 
           await this.insertTalkMessageAsync(translatedTalkData);
+          provenance = VisibleStorySurfaceProvenanceKind.FreshLiveTranslation;
+        }
+        else
+        {
+          provenance =
+              VisibleStorySurfaceProvenanceKind
+                  .FreshLiveTranslationRuntimeOnlyDialogueContext;
         }
       }
 
@@ -1036,6 +1081,14 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
 
       if (!string.IsNullOrWhiteSpace(translatedText))
       {
+        this.RecordDiagnosticsSnapshot(
+            provenance,
+            originalName,
+            originalText,
+            translatedName,
+            translatedText,
+            usedRuntimeOnlyDialogueContext,
+            dialogueTranslationEngine);
         this.PublishOverlay(
             originalName,
             originalText,
@@ -1059,6 +1112,57 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
 
       PluginRuntimeLog.Error($"[{TalkAddonName}] Error resolving Talk translation: {ex}");
     }
+  }
+
+  /// <summary>
+  ///     Records the latest visible Talk provenance snapshot for the debugger.
+  /// </summary>
+  /// <param name="provenance">The provenance label kind to expose.</param>
+  /// <param name="originalName">The original speaker name.</param>
+  /// <param name="originalText">The original Talk text.</param>
+  /// <param name="translatedName">The translated speaker name.</param>
+  /// <param name="translatedText">The translated Talk text.</param>
+  /// <param name="usedRuntimeOnlyDialogueContext">
+  /// Whether runtime-only dialogue context influenced the live translation.
+  /// </param>
+  /// <param name="effectiveTranslationEngineId">
+  /// The effective dialogue translation engine identifier.
+  /// </param>
+  private void RecordDiagnosticsSnapshot(
+      VisibleStorySurfaceProvenanceKind provenance,
+      string originalName,
+      string originalText,
+      string translatedName,
+      string translatedText,
+      bool usedRuntimeOnlyDialogueContext,
+      int effectiveTranslationEngineId)
+  {
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.Talk,
+            provenance,
+            VisibleStorySurfaceTableMap.Resolve(VisibleStorySurfaceKind.Talk),
+            originalName,
+            originalText,
+            string.Empty,
+            translatedName,
+            translatedText,
+            string.Empty,
+            usedRuntimeOnlyDialogueContext,
+            effectiveTranslationEngineId,
+            DateTime.UtcNow,
+            null,
+            null));
+  }
+
+  /// <summary>
+  ///     Resolves the effective dialogue translation engine identifier.
+  /// </summary>
+  /// <returns>The effective dialogue translation engine identifier.</returns>
+  private int GetDialogueTranslationEngineId()
+  {
+    return this.translationService.GetEffectiveTranslationEngineId(
+        TranslationSurfaceGroup.Dialogue);
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Talk/TalkSubtitleHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/TalkSubtitleHandler.cs
@@ -13,7 +13,9 @@ namespace Echoglossian.NativeUI.AddonHandlers.Talk;
 ///     handler so it can reuse the same cache-first, async translation pipeline as
 ///     Talk and BattleTalk while keeping the subtitle overlay independent.
 /// </summary>
-public sealed class TalkSubtitleHandler : IAddonTranslationHandler
+public sealed class TalkSubtitleHandler :
+    IAddonTranslationHandler,
+    IVisibleDialogueRetranslationHandler
 {
   private const string TalkSubtitleAddonName = "TalkSubtitle";
   private const int TextNodeId = 2;
@@ -99,6 +101,157 @@ public sealed class TalkSubtitleHandler : IAddonTranslationHandler
             handler(evt, args);
           }
         }));
+  }
+
+  /// <inheritdoc />
+  public async Task<VisibleDialogueRetranslationResult>
+      RetranslateVisibleTextAndPersistAsync()
+  {
+    const VisibleStorySurfaceKind surface = VisibleStorySurfaceKind.TalkSubtitle;
+    var surfaceName = VisibleStorySurfaceText.ResolveSurfaceName(surface);
+    string originalText;
+    int requestId;
+
+    lock (this.stateGate)
+    {
+      originalText = this.currentOriginalText;
+      if (string.IsNullOrWhiteSpace(originalText))
+      {
+        return new VisibleDialogueRetranslationResult(
+            false,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoVisibleTextMessage(surface));
+      }
+
+      this.activeRequestId++;
+      requestId = this.activeRequestId;
+      this.currentTranslatedText = string.Empty;
+      this.currentReplacementText = string.Empty;
+      this.translationInFlight = true;
+    }
+
+    try
+    {
+      var translatedText = await this.translationService.TranslateAsync(
+          originalText,
+          ClientStateInterface.ClientLanguage.Humanize(),
+          LangDict[LanguageInt].Code,
+          TranslationSurfaceGroup.Dialogue).ConfigureAwait(false) ?? string.Empty;
+
+      if (!TranslationPersistenceGuard.IsUsableDialogueTranslation(
+              originalText,
+              translatedText,
+              ClientStateInterface.ClientLanguage.Humanize(),
+              LangDict[LanguageInt].Code))
+      {
+        lock (this.stateGate)
+        {
+          if (requestId == this.activeRequestId)
+          {
+            this.translationInFlight = false;
+          }
+        }
+
+        return new VisibleDialogueRetranslationResult(
+            true,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoUsableTranslationMessage(surface));
+      }
+
+      var dialogueTranslationEngine = this.GetDialogueTranslationEngineId();
+      var translatedTalkSubtitle = new TalkSubtitleMessage(
+          originalText,
+          ClientStateInterface.ClientLanguage.Humanize(),
+          translatedText,
+          LangDict[LanguageInt].Code,
+          dialogueTranslationEngine,
+          DateTime.Now,
+          DateTime.Now);
+      var persistenceResult = await this.insertTalkSubtitleMessageAsync(
+          translatedTalkSubtitle).ConfigureAwait(false);
+      var persistenceSucceeded = !persistenceResult.StartsWith(
+          "ErrorSavingData:",
+          StringComparison.Ordinal) &&
+                                 !string.Equals(
+                                     persistenceResult,
+                                     "No data to save.",
+                                     StringComparison.Ordinal);
+      var replacementText = this.NormalizeForReplacement(translatedText);
+      var sourceChangedBeforeApply = false;
+      lock (this.stateGate)
+      {
+        sourceChangedBeforeApply = requestId != this.activeRequestId;
+        if (!sourceChangedBeforeApply)
+        {
+          this.translationInFlight = false;
+          this.currentTranslatedText = translatedText;
+          this.currentReplacementText = replacementText;
+        }
+      }
+
+      if (!sourceChangedBeforeApply)
+      {
+        this.RecordDiagnosticsSnapshot(
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            originalText,
+            translatedText,
+            effectiveTranslationEngineId: dialogueTranslationEngine);
+        this.PublishOverlay(originalText, translatedText);
+      }
+
+      if (!persistenceSucceeded)
+      {
+        return new VisibleDialogueRetranslationResult(
+            true,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistenceFailedMessage(
+                surface,
+                persistenceResult));
+      }
+
+      if (sourceChangedBeforeApply)
+      {
+        return new VisibleDialogueRetranslationResult(
+            true,
+            true,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistedButVisibleChangedMessage(
+                surface));
+      }
+
+      return new VisibleDialogueRetranslationResult(
+          true,
+          true,
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(surface));
+    }
+    catch (Exception ex)
+    {
+      lock (this.stateGate)
+      {
+        if (requestId == this.activeRequestId)
+        {
+          this.translationInFlight = false;
+        }
+      }
+
+      PluginRuntimeLog.Error(
+          $"[{TalkSubtitleAddonName}] Error retranslating visible TalkSubtitle text: {ex}");
+      return new VisibleDialogueRetranslationResult(
+          true,
+          false,
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslationFailedMessage(surface));
+    }
   }
 
   /// <summary>
@@ -297,6 +450,7 @@ public sealed class TalkSubtitleHandler : IAddonTranslationHandler
       this.lastFailedOriginalText = string.Empty;
     }
 
+    VisibleStorySurfaceDiagnosticsStore.Clear(VisibleStorySurfaceKind.TalkSubtitle);
     this.clearOverlay();
   }
 
@@ -367,6 +521,11 @@ public sealed class TalkSubtitleHandler : IAddonTranslationHandler
       this.lastFailedOriginalText = string.Empty;
     }
 
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+        originalText,
+        translatedText,
+        effectiveTranslationEngineId: this.GetDialogueTranslationEngineId());
     this.PublishOverlay(this.currentOriginalText, translatedText);
   }
 
@@ -432,6 +591,11 @@ public sealed class TalkSubtitleHandler : IAddonTranslationHandler
 
     translatedText = lookup.TranslatedTalkSubtitleMessage!;
     replacementText = this.NormalizeForReplacement(translatedText);
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.DbReuse,
+        originalText,
+        translatedText,
+        effectiveTranslationEngineId: this.GetDialogueTranslationEngineId());
     return true;
   }
 
@@ -618,6 +782,41 @@ public sealed class TalkSubtitleHandler : IAddonTranslationHandler
   {
     return this.translationService.GetEffectiveTranslationEngineId(
         TranslationSurfaceGroup.Dialogue);
+  }
+
+  /// <summary>
+  ///     Records the latest visible TalkSubtitle provenance snapshot for the
+  ///     debugger.
+  /// </summary>
+  /// <param name="provenance">The provenance label kind to expose.</param>
+  /// <param name="originalText">The original subtitle text.</param>
+  /// <param name="translatedText">The translated subtitle text.</param>
+  /// <param name="effectiveTranslationEngineId">
+  /// The effective dialogue translation engine identifier.
+  /// </param>
+  private void RecordDiagnosticsSnapshot(
+      VisibleStorySurfaceProvenanceKind provenance,
+      string originalText,
+      string translatedText,
+      int effectiveTranslationEngineId)
+  {
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.TalkSubtitle,
+            provenance,
+            VisibleStorySurfaceTableMap.Resolve(
+                VisibleStorySurfaceKind.TalkSubtitle),
+            string.Empty,
+            originalText,
+            string.Empty,
+            string.Empty,
+            translatedText,
+            string.Empty,
+            false,
+            effectiveTranslationEngineId,
+            DateTime.UtcNow,
+            null,
+            null));
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
@@ -666,7 +666,8 @@ internal sealed class TextGimmickHintHandler :
     catch (Exception ex)
     {
       PluginRuntimeLog.Warning(
-          $"[{TextGimmickHintAddonName}] Failed to persist translated TextGimmickHint text. {ex.Message}");
+          ex,
+          $"[{TextGimmickHintAddonName}] Failed to persist translated TextGimmickHint text.");
     }
 
     lock (this.stateGate)

--- a/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
+++ b/NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs
@@ -14,7 +14,9 @@ namespace Echoglossian.NativeUI.AddonHandlers.Toasts;
 ///     the TextGimmickHint.uld layout referenced by other open-source Dalamud
 ///     tooling.
 /// </summary>
-internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
+internal sealed class TextGimmickHintHandler :
+    IAddonTranslationHandler,
+    IVisibleDialogueRetranslationHandler
 {
   private const string TextGimmickHintAddonName = "_TextGimmickHint";
 
@@ -108,6 +110,163 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
             handler(evt, args);
           }
         }));
+  }
+
+  /// <inheritdoc />
+  public async Task<VisibleDialogueRetranslationResult>
+      RetranslateVisibleTextAndPersistAsync()
+  {
+    const VisibleStorySurfaceKind surface = VisibleStorySurfaceKind.TextGimmickHint;
+    var surfaceName = VisibleStorySurfaceText.ResolveSurfaceName(surface);
+    string originalText;
+    int requestId;
+    var sourceLang = ClientStateInterface.ClientLanguage.Humanize();
+    var targetLang = LangDict[LanguageInt].Code;
+
+    lock (this.stateGate)
+    {
+      originalText = this.currentOriginalText;
+      if (string.IsNullOrWhiteSpace(originalText))
+      {
+        return new VisibleDialogueRetranslationResult(
+            false,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoVisibleTextMessage(surface));
+      }
+
+      this.activeRequestId++;
+      requestId = this.activeRequestId;
+      this.translationInFlight = true;
+      this.lastFailedOriginalText = string.Empty;
+    }
+
+    try
+    {
+      var translatedText = await this.translationService.TranslateAsync(
+              originalText,
+              sourceLang,
+              targetLang,
+              TranslationSurfaceGroup.Dialogue)
+          .ConfigureAwait(false) ?? string.Empty;
+
+      if (!TranslationPersistenceGuard.IsUsableDialogueTranslation(
+              originalText,
+              translatedText,
+              sourceLang,
+              targetLang))
+      {
+        lock (this.stateGate)
+        {
+          if (requestId == this.activeRequestId)
+          {
+            this.translationInFlight = false;
+            this.lastFailedOriginalText = originalText;
+          }
+        }
+
+        return new VisibleDialogueRetranslationResult(
+            true,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetNoUsableTranslationMessage(surface));
+      }
+
+      var dialogueTranslationEngine = this.GetDialogueTranslationEngineId();
+      var translatedGimmickHint = new TextGimmickHintMessage(
+          originalText,
+          sourceLang,
+          translatedText,
+          targetLang,
+          dialogueTranslationEngine,
+          DateTime.Now,
+          DateTime.Now);
+      var persistenceResult = await this.insertTextGimmickHintMessageAsync(
+              translatedGimmickHint)
+          .ConfigureAwait(false);
+      var persistenceSucceeded = !persistenceResult.StartsWith(
+          "ErrorSavingData:",
+          StringComparison.Ordinal) &&
+                                 !string.Equals(
+                                     persistenceResult,
+                                     "No data to save.",
+                                     StringComparison.Ordinal);
+      var replacementText = this.NormalizeForReplacement(translatedText);
+      var sourceChangedBeforeApply = false;
+      lock (this.stateGate)
+      {
+        sourceChangedBeforeApply = requestId != this.activeRequestId;
+        if (!sourceChangedBeforeApply)
+        {
+          this.currentTranslatedText = translatedText;
+          this.currentReplacementText = replacementText;
+          this.translationInFlight = false;
+          this.lastFailedOriginalText = string.Empty;
+        }
+      }
+
+      if (!sourceChangedBeforeApply)
+      {
+        this.RecordDiagnosticsSnapshot(
+            VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+            originalText,
+            translatedText,
+            dialogueTranslationEngine);
+        this.PublishOverlay(originalText, translatedText, "explicit-retranslate");
+      }
+
+      if (!persistenceSucceeded)
+      {
+        return new VisibleDialogueRetranslationResult(
+            true,
+            false,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistenceFailedMessage(
+                surface,
+                persistenceResult));
+      }
+
+      if (sourceChangedBeforeApply)
+      {
+        return new VisibleDialogueRetranslationResult(
+            true,
+            true,
+            surface,
+            surfaceName,
+            VisibleStorySurfaceText.GetPersistedButVisibleChangedMessage(
+                surface));
+      }
+
+      return new VisibleDialogueRetranslationResult(
+          true,
+          true,
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslatedAndPersistedMessage(surface));
+    }
+    catch (Exception ex)
+    {
+      lock (this.stateGate)
+      {
+        if (requestId == this.activeRequestId)
+        {
+          this.translationInFlight = false;
+          this.lastFailedOriginalText = originalText;
+        }
+      }
+
+      PluginRuntimeLog.Error(
+          $"[{TextGimmickHintAddonName}] Error retranslating visible TextGimmickHint text: {ex}");
+      return new VisibleDialogueRetranslationResult(
+          true,
+          false,
+          surface,
+          surfaceName,
+          VisibleStorySurfaceText.GetRetranslationFailedMessage(surface));
+    }
   }
 
   /// <summary>
@@ -280,6 +439,8 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
     }
 
     this.TryRestoreNativeLayout(layoutSnapshot, layoutOriginalText);
+    VisibleStorySurfaceDiagnosticsStore.Clear(
+        VisibleStorySurfaceKind.TextGimmickHint);
     this.clearOverlay();
   }
 
@@ -408,17 +569,18 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
       return true;
     }
 
-    var lookupToast = this.BuildLookupMessage(originalText);
-    var storedToast = this.findTextGimmickHintMessage(lookupToast);
-    if (this.IsStoredTranslationUsable(storedToast, originalText))
+    if (this.TryLoadStoredTranslation(
+            originalText,
+            out var storedTranslatedText,
+            out var storedReplacementText))
     {
       this.SetResolvedState(
           originalText,
-          storedToast!.TranslatedText!,
-          this.NormalizeForReplacement(storedToast.TranslatedText!));
+          storedTranslatedText,
+          storedReplacementText);
       this.PublishOverlay(
           originalText,
-          storedToast.TranslatedText!,
+          storedTranslatedText,
           trigger);
       return true;
     }
@@ -444,13 +606,16 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
       string originalText,
       int requestId)
   {
+    var sourceLang = ClientStateInterface.ClientLanguage.Humanize();
+    var targetLang = LangDict[LanguageInt].Code;
     string translatedText;
     try
     {
       translatedText = await this.translationService.TranslateAsync(
           originalText,
-          ClientStateInterface.ClientLanguage.Humanize(),
-          LangDict[LanguageInt].Code) ?? string.Empty;
+          sourceLang,
+          targetLang,
+          TranslationSurfaceGroup.Dialogue).ConfigureAwait(false) ?? string.Empty;
     }
     catch (Exception ex)
     {
@@ -459,7 +624,11 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
       translatedText = string.Empty;
     }
 
-    if (string.IsNullOrWhiteSpace(translatedText))
+    if (!TranslationPersistenceGuard.IsUsableDialogueTranslation(
+            originalText,
+            translatedText,
+            sourceLang,
+            targetLang))
     {
       // PluginRuntimeLog.Debug(
       //     $"[{TextGimmickHintAddonName}] trigger=async-resolve empty translation for source='{originalText}'");
@@ -477,18 +646,28 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
     }
 
     var replacementText = this.NormalizeForReplacement(translatedText);
+    var dialogueTranslationEngine = this.GetDialogueTranslationEngineId();
     // PluginRuntimeLog.Debug(
     //     $"[{TextGimmickHintAddonName}] trigger=async-resolve translation ready for source='{originalText}'");
     var translatedGimmickHint = new TextGimmickHintMessage(
         originalText,
-        ClientStateInterface.ClientLanguage.Humanize(),
+        sourceLang,
         translatedText,
-        LangDict[LanguageInt].Code,
-        this.config.ChosenTransEngine,
+        targetLang,
+        dialogueTranslationEngine,
         DateTime.Now,
         DateTime.Now);
 
-    await this.insertTextGimmickHintMessageAsync(translatedGimmickHint);
+    try
+    {
+      await this.insertTextGimmickHintMessageAsync(translatedGimmickHint)
+          .ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+      PluginRuntimeLog.Warning(
+          $"[{TextGimmickHintAddonName}] Failed to persist translated TextGimmickHint text. {ex.Message}");
+    }
 
     lock (this.stateGate)
     {
@@ -503,6 +682,11 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
       this.lastFailedOriginalText = string.Empty;
     }
 
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.FreshLiveTranslation,
+        originalText,
+        translatedText,
+        dialogueTranslationEngine);
     this.PublishOverlay(originalText, translatedText, "async-resolve");
   }
 
@@ -569,29 +753,12 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
 
     translatedText = lookup.TranslatedText!;
     replacementText = this.NormalizeForReplacement(translatedText);
+    this.RecordDiagnosticsSnapshot(
+        VisibleStorySurfaceProvenanceKind.DbReuse,
+        originalText,
+        translatedText,
+        lookup.TranslationEngine ?? this.GetDialogueTranslationEngineId());
     return true;
-  }
-
-  /// <summary>
-  ///     Determines whether a stored gimmick-hint row still represents a usable
-  ///     translation for the current source line.
-  /// </summary>
-  /// <param name="textGimmickHintMessage">The stored gimmick-hint row to validate.</param>
-  /// <param name="originalText">The expected original gimmick-hint text.</param>
-  /// <returns>
-  ///     <see langword="true" /> when the stored row contains a non-empty
-  ///     translation for the same source line; otherwise, <see langword="false" />.
-  /// </returns>
-  private bool IsStoredTranslationUsable(
-      TextGimmickHintMessage? textGimmickHintMessage,
-      string originalText)
-  {
-    return textGimmickHintMessage != null &&
-           string.Equals(
-               textGimmickHintMessage.OriginalText,
-               originalText,
-               StringComparison.Ordinal) &&
-           !string.IsNullOrWhiteSpace(textGimmickHintMessage.TranslatedText);
   }
 
   /// <summary>
@@ -716,6 +883,51 @@ internal sealed class TextGimmickHintHandler : IAddonTranslationHandler
     // PluginRuntimeLog.Debug(
     //     $"[{TextGimmickHintAddonName}] trigger={trigger} publish overlay text='{overlayText}'");
     this.updateOverlay(string.Empty, overlayText, string.Empty);
+  }
+
+  /// <summary>
+  ///     Records the latest visible TextGimmickHint provenance snapshot for
+  ///     the debugger.
+  /// </summary>
+  /// <param name="provenance">The provenance label kind to expose.</param>
+  /// <param name="originalText">The original gimmick-hint text.</param>
+  /// <param name="translatedText">The translated gimmick-hint text.</param>
+  /// <param name="effectiveTranslationEngineId">
+  /// The effective dialogue translation engine identifier.
+  /// </param>
+  private void RecordDiagnosticsSnapshot(
+      VisibleStorySurfaceProvenanceKind provenance,
+      string originalText,
+      string translatedText,
+      int effectiveTranslationEngineId)
+  {
+    VisibleStorySurfaceDiagnosticsStore.Record(
+        new VisibleStorySurfaceDiagnosticsSnapshot(
+            VisibleStorySurfaceKind.TextGimmickHint,
+            provenance,
+            VisibleStorySurfaceTableMap.Resolve(
+                VisibleStorySurfaceKind.TextGimmickHint),
+            string.Empty,
+            originalText,
+            string.Empty,
+            string.Empty,
+            translatedText,
+            string.Empty,
+            false,
+            effectiveTranslationEngineId,
+            DateTime.UtcNow,
+            null,
+            null));
+  }
+
+  /// <summary>
+  ///     Resolves the effective dialogue translation engine identifier.
+  /// </summary>
+  /// <returns>The effective dialogue translation engine identifier.</returns>
+  private int GetDialogueTranslationEngineId()
+  {
+    return this.translationService.GetEffectiveTranslationEngineId(
+        TranslationSurfaceGroup.Dialogue);
   }
 
   /// <summary>

--- a/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsSnapshot.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsSnapshot.cs
@@ -1,0 +1,48 @@
+// <copyright file="VisibleStorySurfaceDiagnosticsSnapshot.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Represents one runtime-only diagnostic snapshot for the most recently
+///     resolved visible story-facing surface.
+/// </summary>
+/// <param name="Surface">The active story surface.</param>
+/// <param name="Provenance">The provenance label kind shown to operators.</param>
+/// <param name="TableName">The effective DB manager table name for handoff.</param>
+/// <param name="OriginalSpeakerText">The original speaker text when applicable.</param>
+/// <param name="OriginalText">The primary original text payload.</param>
+/// <param name="OriginalOptionsText">The original options payload when applicable.</param>
+/// <param name="TranslatedSpeakerText">The translated speaker text when applicable.</param>
+/// <param name="TranslatedText">The primary translated text payload.</param>
+/// <param name="TranslatedOptionsText">The translated options payload when applicable.</param>
+/// <param name="UsedRuntimeOnlyDialogueContext">
+/// Whether runtime-only dialogue context influenced the live translation.
+/// </param>
+/// <param name="EffectiveTranslationEngineId">
+/// The effective translation engine identifier used for the snapshot.
+/// </param>
+/// <param name="ObservedAtUtc">The UTC timestamp when the snapshot was observed.</param>
+/// <param name="LastRetranslationSuccess">
+/// The latest explicit retranslation success flag for this surface.
+/// </param>
+/// <param name="LastRetranslationMessage">
+/// The latest explicit retranslation outcome message for this surface.
+/// </param>
+public readonly record struct VisibleStorySurfaceDiagnosticsSnapshot(
+    VisibleStorySurfaceKind Surface,
+    VisibleStorySurfaceProvenanceKind Provenance,
+    string TableName,
+    string OriginalSpeakerText,
+    string OriginalText,
+    string OriginalOptionsText,
+    string TranslatedSpeakerText,
+    string TranslatedText,
+    string TranslatedOptionsText,
+    bool UsedRuntimeOnlyDialogueContext,
+    int EffectiveTranslationEngineId,
+    DateTime ObservedAtUtc,
+    bool? LastRetranslationSuccess,
+    string? LastRetranslationMessage);

--- a/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsSnapshot.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsSnapshot.cs
@@ -24,7 +24,10 @@ namespace Echoglossian.NativeUI.Helpers;
 /// <param name="EffectiveTranslationEngineId">
 /// The effective translation engine identifier used for the snapshot.
 /// </param>
-/// <param name="ObservedAtUtc">The UTC timestamp when the snapshot was observed.</param>
+/// <param name="ObservedAtUtc">
+/// The UTC timestamp when this snapshot was last updated, either from a live
+/// observation or from an explicit retranslation outcome.
+/// </param>
 /// <param name="LastRetranslationSuccess">
 /// The latest explicit retranslation success flag for this surface.
 /// </param>

--- a/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs
@@ -74,7 +74,10 @@ public static class VisibleStorySurfaceDiagnosticsStore
   /// <param name="surface">The surface that handled the request.</param>
   /// <param name="success">Whether the explicit retranslation succeeded.</param>
   /// <param name="message">The user-facing outcome message.</param>
-  /// <param name="observedAtUtc">The UTC timestamp for the outcome.</param>
+  /// <param name="observedAtUtc">
+  /// The UTC timestamp to store as the snapshot's latest update time for the
+  /// explicit retranslation outcome.
+  /// </param>
   public static void SetRetranslationOutcome(
       VisibleStorySurfaceKind surface,
       bool success,

--- a/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs
@@ -39,7 +39,7 @@ public static class VisibleStorySurfaceDiagnosticsStore
       SnapshotsBySurface.Remove(surface);
       if (latestSurface == surface)
       {
-        latestSurface = null;
+        latestSurface = ResolveLatestSurfaceUnsafe();
       }
     }
   }
@@ -94,6 +94,7 @@ public static class VisibleStorySurfaceDiagnosticsStore
         LastRetranslationMessage = message,
         ObservedAtUtc = observedAtUtc,
       };
+      latestSurface = surface;
     }
   }
 
@@ -108,10 +109,41 @@ public static class VisibleStorySurfaceDiagnosticsStore
       if (latestSurface == null ||
           !SnapshotsBySurface.TryGetValue(latestSurface.Value, out var snapshot))
       {
-        return null;
+        latestSurface = ResolveLatestSurfaceUnsafe();
+        if (latestSurface == null ||
+            !SnapshotsBySurface.TryGetValue(latestSurface.Value, out snapshot))
+        {
+          return null;
+        }
       }
 
       return snapshot;
     }
+  }
+
+  /// <summary>
+  ///     Resolves the retained surface with the most recent observed snapshot
+  ///     timestamp.
+  /// </summary>
+  /// <returns>
+  ///     The latest retained surface, or <see langword="null"/> when none
+  ///     remain.
+  /// </returns>
+  private static VisibleStorySurfaceKind? ResolveLatestSurfaceUnsafe()
+  {
+    VisibleStorySurfaceKind? resolvedSurface = null;
+    var latestObservedAtUtc = DateTime.MinValue;
+
+    foreach (var snapshotEntry in SnapshotsBySurface)
+    {
+      if (resolvedSurface == null ||
+          snapshotEntry.Value.ObservedAtUtc > latestObservedAtUtc)
+      {
+        resolvedSurface = snapshotEntry.Key;
+        latestObservedAtUtc = snapshotEntry.Value.ObservedAtUtc;
+      }
+    }
+
+    return resolvedSurface;
   }
 }

--- a/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs
@@ -1,0 +1,117 @@
+// <copyright file="VisibleStorySurfaceDiagnosticsStore.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Stores runtime-only visible story-surface diagnostics for the debugger.
+/// </summary>
+public static class VisibleStorySurfaceDiagnosticsStore
+{
+  private static readonly object SyncRoot = new();
+  private static readonly Dictionary<VisibleStorySurfaceKind, VisibleStorySurfaceDiagnosticsSnapshot>
+      SnapshotsBySurface = new();
+
+  private static VisibleStorySurfaceKind? latestSurface;
+
+  /// <summary>
+  /// Clears all retained diagnostics snapshots.
+  /// </summary>
+  public static void Clear()
+  {
+    lock (SyncRoot)
+    {
+      SnapshotsBySurface.Clear();
+      latestSurface = null;
+    }
+  }
+
+  /// <summary>
+  /// Clears the retained diagnostics snapshot for one visible story surface.
+  /// </summary>
+  /// <param name="surface">The surface to clear.</param>
+  public static void Clear(VisibleStorySurfaceKind surface)
+  {
+    lock (SyncRoot)
+    {
+      SnapshotsBySurface.Remove(surface);
+      if (latestSurface == surface)
+      {
+        latestSurface = null;
+      }
+    }
+  }
+
+  /// <summary>
+  /// Records the latest diagnostics snapshot for a visible story surface.
+  /// </summary>
+  /// <param name="snapshot">The snapshot to retain.</param>
+  public static void Record(VisibleStorySurfaceDiagnosticsSnapshot snapshot)
+  {
+    lock (SyncRoot)
+    {
+      if (SnapshotsBySurface.TryGetValue(snapshot.Surface, out var existingSnapshot) &&
+          snapshot.LastRetranslationSuccess == null &&
+          string.IsNullOrWhiteSpace(snapshot.LastRetranslationMessage))
+      {
+        snapshot = snapshot with
+        {
+          LastRetranslationSuccess = existingSnapshot.LastRetranslationSuccess,
+          LastRetranslationMessage = existingSnapshot.LastRetranslationMessage,
+        };
+      }
+
+      SnapshotsBySurface[snapshot.Surface] = snapshot;
+      latestSurface = snapshot.Surface;
+    }
+  }
+
+  /// <summary>
+  /// Updates the latest explicit retranslation outcome for one story surface.
+  /// </summary>
+  /// <param name="surface">The surface that handled the request.</param>
+  /// <param name="success">Whether the explicit retranslation succeeded.</param>
+  /// <param name="message">The user-facing outcome message.</param>
+  /// <param name="observedAtUtc">The UTC timestamp for the outcome.</param>
+  public static void SetRetranslationOutcome(
+      VisibleStorySurfaceKind surface,
+      bool success,
+      string message,
+      DateTime observedAtUtc)
+  {
+    lock (SyncRoot)
+    {
+      if (!SnapshotsBySurface.TryGetValue(surface, out var snapshot))
+      {
+        return;
+      }
+
+      SnapshotsBySurface[surface] = snapshot with
+      {
+        LastRetranslationSuccess = success,
+        LastRetranslationMessage = message,
+        ObservedAtUtc = observedAtUtc,
+      };
+    }
+  }
+
+  /// <summary>
+  /// Gets the latest snapshot across all visible story surfaces.
+  /// </summary>
+  /// <returns>The latest snapshot, or <see langword="null"/> when none exist.</returns>
+  public static VisibleStorySurfaceDiagnosticsSnapshot? GetLatestSnapshot()
+  {
+    lock (SyncRoot)
+    {
+      if (latestSurface == null ||
+          !SnapshotsBySurface.TryGetValue(latestSurface.Value, out var snapshot))
+      {
+        return null;
+      }
+
+      return snapshot;
+    }
+  }
+}

--- a/NativeUI/Helpers/VisibleStorySurfaceKind.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceKind.cs
@@ -1,0 +1,38 @@
+// <copyright file="VisibleStorySurfaceKind.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Identifies a player-visible story-facing surface that can expose
+///     provenance and explicit retranslation diagnostics.
+/// </summary>
+public enum VisibleStorySurfaceKind
+{
+  /// <summary>
+  /// The standard Talk addon.
+  /// </summary>
+  Talk,
+
+  /// <summary>
+  /// The BattleTalk addon.
+  /// </summary>
+  BattleTalk,
+
+  /// <summary>
+  /// The TalkSubtitle addon.
+  /// </summary>
+  TalkSubtitle,
+
+  /// <summary>
+  /// The CutSceneSelectString addon.
+  /// </summary>
+  CutSceneSelectString,
+
+  /// <summary>
+  /// The TextGimmickHint addon.
+  /// </summary>
+  TextGimmickHint,
+}

--- a/NativeUI/Helpers/VisibleStorySurfaceProvenanceKind.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceProvenanceKind.cs
@@ -1,0 +1,30 @@
+// <copyright file="VisibleStorySurfaceProvenanceKind.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Identifies where the currently visible story-surface translation came
+///     from for debugger provenance display.
+/// </summary>
+public enum VisibleStorySurfaceProvenanceKind
+{
+  /// <summary>
+  /// The visible translation came from an existing DB row.
+  /// </summary>
+  DbReuse,
+
+  /// <summary>
+  /// The visible translation came from a fresh live translation.
+  /// </summary>
+  FreshLiveTranslation,
+
+  /// <summary>
+  /// The visible translation came from a fresh live translation that used
+  /// runtime-only dialogue context and therefore should not be persisted as a
+  /// canonical DB row.
+  /// </summary>
+  FreshLiveTranslationRuntimeOnlyDialogueContext,
+}

--- a/NativeUI/Helpers/VisibleStorySurfaceTableMap.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceTableMap.cs
@@ -24,7 +24,7 @@ public static class VisibleStorySurfaceTableMap
       VisibleStorySurfaceKind.TalkSubtitle => nameof(TalkSubtitleMessage),
       VisibleStorySurfaceKind.CutSceneSelectString => nameof(SelectString),
       VisibleStorySurfaceKind.TextGimmickHint => nameof(TextGimmickHintMessage),
-      _ => nameof(TalkMessage),
+      _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null),
     };
   }
 }

--- a/NativeUI/Helpers/VisibleStorySurfaceTableMap.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceTableMap.cs
@@ -1,0 +1,30 @@
+// <copyright file="VisibleStorySurfaceTableMap.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Maps visible story surfaces to their DB manager table names.
+/// </summary>
+public static class VisibleStorySurfaceTableMap
+{
+  /// <summary>
+  /// Resolves the DB manager table name for one visible story surface.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The matching DB manager table name.</returns>
+  public static string Resolve(VisibleStorySurfaceKind surface)
+  {
+    return surface switch
+    {
+      VisibleStorySurfaceKind.Talk => nameof(TalkMessage),
+      VisibleStorySurfaceKind.BattleTalk => nameof(BattleTalkMessage),
+      VisibleStorySurfaceKind.TalkSubtitle => nameof(TalkSubtitleMessage),
+      VisibleStorySurfaceKind.CutSceneSelectString => nameof(SelectString),
+      VisibleStorySurfaceKind.TextGimmickHint => nameof(TextGimmickHintMessage),
+      _ => nameof(TalkMessage),
+    };
+  }
+}

--- a/NativeUI/Helpers/VisibleStorySurfaceText.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceText.cs
@@ -1,0 +1,180 @@
+// <copyright file="VisibleStorySurfaceText.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Globalization;
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Resolves localized user-facing strings for visible story-surface
+///     debugger and explicit retranslation flows.
+/// </summary>
+public static class VisibleStorySurfaceText
+{
+  /// <summary>
+  ///     Resolves the localized display name for one visible story surface.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The localized surface display name.</returns>
+  public static string ResolveSurfaceName(VisibleStorySurfaceKind surface)
+  {
+    return surface switch
+    {
+      VisibleStorySurfaceKind.Talk =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceNameTalk,
+      VisibleStorySurfaceKind.BattleTalk =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceNameBattleTalk,
+      VisibleStorySurfaceKind.TalkSubtitle =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceNameTalkSubtitle,
+      VisibleStorySurfaceKind.CutSceneSelectString =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString,
+      VisibleStorySurfaceKind.TextGimmickHint =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceNameTextGimmickHint,
+      _ => Resources.TranslatorDebuggerVisibleStorySurfaceNameTalk,
+    };
+  }
+
+  /// <summary>
+  ///     Resolves the localized provenance label for one diagnostics snapshot.
+  /// </summary>
+  /// <param name="provenance">The provenance kind to format.</param>
+  /// <returns>The localized provenance label.</returns>
+  public static string ResolveProvenanceLabel(
+      VisibleStorySurfaceProvenanceKind provenance)
+  {
+    return provenance switch
+    {
+      VisibleStorySurfaceProvenanceKind.DbReuse =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceDbReuse,
+      VisibleStorySurfaceProvenanceKind.FreshLiveTranslation =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation,
+      VisibleStorySurfaceProvenanceKind.FreshLiveTranslationRuntimeOnlyDialogueContext =>
+          Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslationRuntimeOnlyContext,
+      _ => Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation,
+    };
+  }
+
+  /// <summary>
+  ///     Builds the user-facing message shown when no visible text is available
+  ///     for one story surface.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The localized unavailable message.</returns>
+  public static string GetNoVisibleTextMessage(VisibleStorySurfaceKind surface)
+  {
+    return string.Format(
+        CultureInfo.CurrentCulture,
+        Resources.TranslatorDebuggerVisibleStorySurfaceNoVisibleText,
+        ResolveSurfaceName(surface));
+  }
+
+  /// <summary>
+  ///     Builds the user-facing message shown when a visible retranslation did
+  ///     not produce usable translated content.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The localized unusable-result message.</returns>
+  public static string GetNoUsableTranslationMessage(
+      VisibleStorySurfaceKind surface)
+  {
+    return string.Format(
+        CultureInfo.CurrentCulture,
+        Resources.TranslatorDebuggerVisibleStorySurfaceNoUsableTranslation,
+        ResolveSurfaceName(surface));
+  }
+
+  /// <summary>
+  ///     Builds the user-facing message shown when a live refresh applied but
+  ///     persistence failed.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <param name="persistenceResult">The persistence-layer detail.</param>
+  /// <returns>The localized persistence failure message.</returns>
+  public static string GetPersistenceFailedMessage(
+      VisibleStorySurfaceKind surface,
+      string persistenceResult)
+  {
+    return string.Format(
+        CultureInfo.CurrentCulture,
+        Resources.TranslatorDebuggerVisibleStorySurfacePersistenceFailed,
+        ResolveSurfaceName(surface),
+        persistenceResult);
+  }
+
+  /// <summary>
+  ///     Builds the user-facing message shown when a refreshed result was
+  ///     persisted but the visible source changed before apply.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The localized stale-apply message.</returns>
+  public static string GetPersistedButVisibleChangedMessage(
+      VisibleStorySurfaceKind surface)
+  {
+    return string.Format(
+        CultureInfo.CurrentCulture,
+        Resources.TranslatorDebuggerVisibleStorySurfacePersistedButVisibleChanged,
+        ResolveSurfaceName(surface));
+  }
+
+  /// <summary>
+  ///     Builds the user-facing message shown when explicit retranslation
+  ///     succeeds and is persisted.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The localized success message.</returns>
+  public static string GetRetranslatedAndPersistedMessage(
+      VisibleStorySurfaceKind surface)
+  {
+    return string.Format(
+        CultureInfo.CurrentCulture,
+        Resources.TranslatorDebuggerVisibleStorySurfaceRetranslatedAndPersisted,
+        ResolveSurfaceName(surface));
+  }
+
+  /// <summary>
+  ///     Builds the user-facing message shown when explicit retranslation
+  ///     fails before a usable result can be applied.
+  /// </summary>
+  /// <param name="surface">The visible story surface.</param>
+  /// <returns>The localized failure message.</returns>
+  public static string GetRetranslationFailedMessage(
+      VisibleStorySurfaceKind surface)
+  {
+    return string.Format(
+        CultureInfo.CurrentCulture,
+        Resources.TranslatorDebuggerVisibleStorySurfaceRetranslationFailed,
+        ResolveSurfaceName(surface));
+  }
+
+  /// <summary>
+  ///     Gets the user-facing message shown when no visible story surface is
+  ///     currently available for explicit retranslation.
+  /// </summary>
+  /// <returns>The localized unavailable message.</returns>
+  public static string GetNoVisibleSurfaceAvailableMessage()
+  {
+    return Resources.TranslatorDebuggerVisibleStorySurfaceNoVisibleSurfaceAvailable;
+  }
+
+  /// <summary>
+  ///     Gets the user-facing message shown when a visible retranslation task
+  ///     faults before it returns a structured result.
+  /// </summary>
+  /// <returns>The localized unexpected-failure message.</returns>
+  public static string GetUnexpectedFailureMessage()
+  {
+    return Resources.TranslatorDebuggerVisibleStorySurfaceUnexpectedFailure;
+  }
+
+  /// <summary>
+  ///     Gets the user-facing message shown when a visible retranslation task
+  ///     is canceled.
+  /// </summary>
+  /// <returns>The localized cancellation message.</returns>
+  public static string GetCanceledMessage()
+  {
+    return Resources.TranslatorDebuggerVisibleStorySurfaceCanceled;
+  }
+}

--- a/NativeUI/Helpers/VisibleStorySurfaceText.cs
+++ b/NativeUI/Helpers/VisibleStorySurfaceText.cs
@@ -32,7 +32,7 @@ public static class VisibleStorySurfaceText
           Resources.TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString,
       VisibleStorySurfaceKind.TextGimmickHint =>
           Resources.TranslatorDebuggerVisibleStorySurfaceNameTextGimmickHint,
-      _ => Resources.TranslatorDebuggerVisibleStorySurfaceNameTalk,
+      _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null),
     };
   }
 
@@ -52,7 +52,10 @@ public static class VisibleStorySurfaceText
           Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation,
       VisibleStorySurfaceProvenanceKind.FreshLiveTranslationRuntimeOnlyDialogueContext =>
           Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslationRuntimeOnlyContext,
-      _ => Resources.TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation,
+      _ => throw new ArgumentOutOfRangeException(
+          nameof(provenance),
+          provenance,
+          null),
     };
   }
 

--- a/PluginUI/Helpers/VisibleStorySurfaceInspectionModelBuilder.cs
+++ b/PluginUI/Helpers/VisibleStorySurfaceInspectionModelBuilder.cs
@@ -1,0 +1,137 @@
+// <copyright file="VisibleStorySurfaceInspectionModelBuilder.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.PluginUI.Helpers;
+
+/// <summary>
+///     Builds reusable inspection-table models for the latest visible
+///     story-surface diagnostics snapshot.
+/// </summary>
+public static class VisibleStorySurfaceInspectionModelBuilder
+{
+  /// <summary>
+  /// Builds the shared inspection table columns used by the debugger.
+  /// </summary>
+  /// <returns>The shared debugger columns.</returns>
+  public static IReadOnlyList<InspectionColumnDefinition> BuildColumns()
+  {
+    return
+    [
+      new InspectionColumnDefinition(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldColumn),
+      new InspectionColumnDefinition(
+          Resources.TranslatorDebuggerVisibleStorySurfaceValueColumn,
+          ImGuiTableColumnFlags.WidthStretch),
+    ];
+  }
+
+  /// <summary>
+  /// Builds display-ready rows for a visible story-surface diagnostics snapshot.
+  /// </summary>
+  /// <param name="snapshot">The snapshot to render.</param>
+  /// <returns>The display-ready inspection rows.</returns>
+  public static IReadOnlyList<InspectionRow> BuildRows(
+      VisibleStorySurfaceDiagnosticsSnapshot snapshot)
+  {
+    var rows = new List<InspectionRow>
+    {
+      BuildRow(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldSurface,
+          VisibleStorySurfaceText.ResolveSurfaceName(snapshot.Surface)),
+      BuildRow(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldProvenance,
+          VisibleStorySurfaceText.ResolveProvenanceLabel(snapshot.Provenance)),
+      BuildRow(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldDbTable,
+          snapshot.TableName),
+      BuildRow(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldEffectiveEngine,
+          snapshot.EffectiveTranslationEngineId.ToString(CultureInfo.InvariantCulture)),
+      BuildRow(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldRuntimeOnlyDialogueContext,
+          snapshot.UsedRuntimeOnlyDialogueContext
+              ? Resources.TranslatorDebuggerYes
+              : Resources.TranslatorDebuggerNo),
+      BuildRow(
+          Resources.TranslatorDebuggerVisibleStorySurfaceFieldObservedUtc,
+          snapshot.ObservedAtUtc.ToString("u", CultureInfo.InvariantCulture)),
+    };
+
+    AddOptionalRow(
+        rows,
+        Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalSpeaker,
+        snapshot.OriginalSpeakerText);
+    AddOptionalRow(
+        rows,
+        Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalText,
+        snapshot.OriginalText);
+    AddOptionalRow(
+        rows,
+        Resources.TranslatorDebuggerVisibleStorySurfaceFieldOriginalOptions,
+        snapshot.OriginalOptionsText);
+    AddOptionalRow(
+        rows,
+        Resources.TranslatorDebuggerVisibleStorySurfaceFieldTranslatedSpeaker,
+        snapshot.TranslatedSpeakerText);
+    AddOptionalRow(
+        rows,
+        Resources.TranslatorDebuggerVisibleStorySurfaceFieldTranslatedText,
+        snapshot.TranslatedText);
+    AddOptionalRow(
+        rows,
+        Resources.TranslatorDebuggerVisibleStorySurfaceFieldTranslatedOptions,
+        snapshot.TranslatedOptionsText);
+
+    if (!string.IsNullOrWhiteSpace(snapshot.LastRetranslationMessage))
+    {
+      var retranslationStatus = snapshot.LastRetranslationSuccess switch
+      {
+        true => Resources.TranslatorDebuggerSucceeded,
+        false => Resources.TranslatorDebuggerFailed,
+        _ => Resources.TranslatorDebuggerUnknown,
+      };
+      rows.Add(
+          BuildRow(
+              Resources.TranslatorDebuggerVisibleStorySurfaceFieldLastRetranslation,
+              $"{retranslationStatus}: {snapshot.LastRetranslationMessage}"));
+    }
+
+    return rows;
+  }
+
+  /// <summary>
+  /// Builds one debugger inspection row.
+  /// </summary>
+  /// <param name="field">The field label.</param>
+  /// <param name="value">The field value.</param>
+  /// <returns>The display-ready row.</returns>
+  private static InspectionRow BuildRow(string field, string value)
+  {
+    return new InspectionRow(
+      [
+        new InspectionCell(field),
+        InspectionCellFormatter.Format(value),
+      ]);
+  }
+
+  /// <summary>
+  /// Adds one optional debugger inspection row when a value is available.
+  /// </summary>
+  /// <param name="rows">The row list to append to.</param>
+  /// <param name="field">The field label.</param>
+  /// <param name="value">The optional field value.</param>
+  private static void AddOptionalRow(
+      ICollection<InspectionRow> rows,
+      string field,
+      string value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return;
+    }
+
+    rows.Add(BuildRow(field, value));
+  }
+}

--- a/PluginUI/Helpers/VisibleStorySurfaceRetranslationDispatcher.cs
+++ b/PluginUI/Helpers/VisibleStorySurfaceRetranslationDispatcher.cs
@@ -1,0 +1,53 @@
+// <copyright file="VisibleStorySurfaceRetranslationDispatcher.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.AddonHandlers.Talk;
+using Echoglossian.NativeUI.Handlers;
+
+namespace Echoglossian.PluginUI.Helpers;
+
+/// <summary>
+///     Dispatches explicit visible retranslation requests across registered
+///     story-facing addon handlers.
+/// </summary>
+public sealed class VisibleStorySurfaceRetranslationDispatcher
+{
+  /// <summary>
+  ///     Dispatches the explicit retranslation request to the first applicable
+  ///     visible story-surface handler.
+  /// </summary>
+  /// <param name="handlers">The registered addon handlers to inspect.</param>
+  /// <returns>
+  ///     The first applicable visible retranslation result, or a non-applicable
+  ///     result when no visible story surface is currently available.
+  /// </returns>
+  public async Task<VisibleDialogueRetranslationResult> DispatchAsync(
+      IEnumerable<(string AddonName, IAddonTranslationHandler Handler)> handlers)
+  {
+    foreach (var (_, handler) in handlers)
+    {
+      if (handler is not IVisibleDialogueRetranslationHandler
+          visibleDialogueRetranslationHandler)
+      {
+        continue;
+      }
+
+      var result = await visibleDialogueRetranslationHandler
+          .RetranslateVisibleTextAndPersistAsync()
+          .ConfigureAwait(false);
+      if (result.IsApplicable)
+      {
+        return result;
+      }
+    }
+
+    return new VisibleDialogueRetranslationResult(
+        false,
+        false,
+        null,
+        Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle,
+        VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
+  }
+}

--- a/PluginUI/Helpers/VisibleStorySurfaceRetranslationDispatcher.cs
+++ b/PluginUI/Helpers/VisibleStorySurfaceRetranslationDispatcher.cs
@@ -47,7 +47,7 @@ public sealed class VisibleStorySurfaceRetranslationDispatcher
         false,
         false,
         null,
-        Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle,
+        Resources.TranslatorDebuggerUnknown,
         VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
   }
 }

--- a/PluginUI/PluginRuntimeUi.cs
+++ b/PluginUI/PluginRuntimeUi.cs
@@ -180,7 +180,7 @@ public partial class Echoglossian
           false,
           false,
           null,
-          Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle,
+          Resources.TranslatorDebuggerUnknown,
           VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
     }
 
@@ -206,7 +206,7 @@ public partial class Echoglossian
         false,
         false,
         null,
-        Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle,
+        Resources.TranslatorDebuggerUnknown,
         VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
   }
 

--- a/PluginUI/PluginRuntimeUi.cs
+++ b/PluginUI/PluginRuntimeUi.cs
@@ -174,18 +174,10 @@ public partial class Echoglossian
   private async Task<NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult>
       RetranslateVisibleDialogueAndPersistAsync()
   {
-    if (this.registeredAddonHandlers == null || this.registeredAddonHandlers.Count == 0)
-    {
-      return new NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult(
-          false,
-          false,
-          null,
-          Resources.TranslatorDebuggerUnknown,
-          VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
-    }
-
+    IReadOnlyList<(string AddonName, IAddonTranslationHandler Handler)> handlers =
+        this.registeredAddonHandlers ?? [];
     var result = await this.visibleStorySurfaceRetranslationDispatcher
-        .DispatchAsync(this.registeredAddonHandlers)
+        .DispatchAsync(handlers)
         .ConfigureAwait(false);
 
     if (result.IsApplicable && result.Surface != null)
@@ -197,17 +189,7 @@ public partial class Echoglossian
           DateTime.UtcNow);
     }
 
-    if (result.IsApplicable)
-    {
-      return result;
-    }
-
-    return new NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult(
-        false,
-        false,
-        null,
-        Resources.TranslatorDebuggerUnknown,
-        VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
+    return result;
   }
 
   /// <summary>

--- a/PluginUI/PluginRuntimeUi.cs
+++ b/PluginUI/PluginRuntimeUi.cs
@@ -7,6 +7,9 @@ namespace Echoglossian;
 
 public partial class Echoglossian
 {
+  private readonly VisibleStorySurfaceRetranslationDispatcher
+      visibleStorySurfaceRetranslationDispatcher = new();
+
   /// <summary>
   /// Updates the plugin's state on each tick.
   /// </summary>
@@ -160,13 +163,13 @@ public partial class Echoglossian
   }
 
   /// <summary>
-  ///     Retranslates the currently visible Talk or BattleTalk line using the
-  ///     active engine and persists the refreshed result when a dialogue handler
-  ///     can resolve a live source line.
+  ///     Retranslates the currently visible story-facing text using the active
+  ///     engine and persists the refreshed result when a registered handler can
+  ///     resolve a live source payload.
   /// </summary>
   /// <returns>
-  ///     A result describing whether a visible dialogue line was available and
-  ///     whether the explicit retranslation succeeded.
+  ///     A result describing whether a visible story-facing surface was
+  ///     available and whether the explicit retranslation succeeded.
   /// </returns>
   private async Task<NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult>
       RetranslateVisibleDialogueAndPersistAsync()
@@ -176,32 +179,49 @@ public partial class Echoglossian
       return new NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult(
           false,
           false,
-          "Dialogue",
-          "No registered dialogue handler is currently available to retranslate visible text.");
+          null,
+          Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle,
+          VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
     }
 
-    foreach (var (_, handler) in this.registeredAddonHandlers)
-    {
-      if (handler is not NativeUI.AddonHandlers.Talk.IVisibleDialogueRetranslationHandler
-          visibleDialogueRetranslationHandler)
-      {
-        continue;
-      }
+    var result = await this.visibleStorySurfaceRetranslationDispatcher
+        .DispatchAsync(this.registeredAddonHandlers)
+        .ConfigureAwait(false);
 
-      var result = await visibleDialogueRetranslationHandler
-          .RetranslateVisibleTextAndPersistAsync()
-          .ConfigureAwait(false);
-      if (result.IsApplicable)
-      {
-        return result;
-      }
+    if (result.IsApplicable && result.Surface != null)
+    {
+      VisibleStorySurfaceDiagnosticsStore.SetRetranslationOutcome(
+          result.Surface.Value,
+          result.Success,
+          result.Message,
+          DateTime.UtcNow);
+    }
+
+    if (result.IsApplicable)
+    {
+      return result;
     }
 
     return new NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult(
         false,
         false,
-        "Dialogue",
-        "No visible Talk or BattleTalk line is currently available to retranslate.");
+        null,
+        Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle,
+        VisibleStorySurfaceText.GetNoVisibleSurfaceAvailableMessage());
+  }
+
+  /// <summary>
+  /// Opens the DB editor and preselects a requested table.
+  /// </summary>
+  /// <param name="tableName">The requested DB manager table name.</param>
+  private void OpenDbEditorForTable(string tableName)
+  {
+    if (this.dbEditorWindow == null)
+    {
+      return;
+    }
+
+    this.dbEditorWindow.OpenAndSelectTable(tableName);
   }
 
   /// <summary>

--- a/PluginUI/TranslatorMetricsWindow.cs
+++ b/PluginUI/TranslatorMetricsWindow.cs
@@ -31,9 +31,12 @@ public sealed class TranslatorMetricsWindow
   ///     class.
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
+  /// <param name="openDbEditorForTable">
+  ///     Delegate used to open the DB manager on the requested table.
+  /// </param>
   /// <param name="retranslateVisibleDialogueAsync">
-  ///     Delegate used to explicitly retranslate the currently visible dialogue
-  ///     line and persist the refreshed result.
+  ///     Delegate used to explicitly retranslate the currently visible
+  ///     story-facing text and persist the refreshed result.
   /// </param>
   public TranslatorMetricsWindow(
       Config config,

--- a/PluginUI/TranslatorMetricsWindow.cs
+++ b/PluginUI/TranslatorMetricsWindow.cs
@@ -23,6 +23,7 @@ public sealed class TranslatorMetricsWindow
   private readonly InspectionTableView visibleStorySurfaceInspectionTable;
   private Task<NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult>?
       activeRetranslationTask;
+  private VisibleStorySurfaceDiagnosticsSnapshot? activeVisibleStorySurfaceSnapshot;
   private string? lastRetranslationMessage;
   private bool? lastRetranslationSucceeded;
 
@@ -357,7 +358,8 @@ public sealed class TranslatorMetricsWindow
   /// <returns>The reusable inspection rows for the latest snapshot.</returns>
   private IReadOnlyList<InspectionRow> BuildVisibleStorySurfaceInspectionRows()
   {
-    var snapshot = VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot();
+    var snapshot = this.activeVisibleStorySurfaceSnapshot ??
+        VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot();
     if (snapshot == null)
     {
       return [];
@@ -386,11 +388,19 @@ public sealed class TranslatorMetricsWindow
       return;
     }
 
-    this.visibleStorySurfaceInspectionTable.Draw();
-    if (ImGui.Button(
-            Resources.TranslatorDebuggerVisibleStorySurfaceViewInDbManager))
+    this.activeVisibleStorySurfaceSnapshot = snapshot;
+    try
     {
-      this.openDbEditorForTable(snapshot.Value.TableName);
+      this.visibleStorySurfaceInspectionTable.Draw();
+      if (ImGui.Button(
+              Resources.TranslatorDebuggerVisibleStorySurfaceViewInDbManager))
+      {
+        this.openDbEditorForTable(snapshot.Value.TableName);
+      }
+    }
+    finally
+    {
+      this.activeVisibleStorySurfaceSnapshot = null;
     }
   }
 

--- a/PluginUI/TranslatorMetricsWindow.cs
+++ b/PluginUI/TranslatorMetricsWindow.cs
@@ -17,8 +17,10 @@ namespace Echoglossian;
 public sealed class TranslatorMetricsWindow
 {
   private readonly Config config;
+  private readonly Action<string> openDbEditorForTable;
   private readonly Func<Task<NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult>>
       retranslateVisibleDialogueAsync;
+  private readonly InspectionTableView visibleStorySurfaceInspectionTable;
   private Task<NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult>?
       activeRetranslationTask;
   private string? lastRetranslationMessage;
@@ -35,11 +37,20 @@ public sealed class TranslatorMetricsWindow
   /// </param>
   public TranslatorMetricsWindow(
       Config config,
+      Action<string> openDbEditorForTable,
       Func<Task<NativeUI.AddonHandlers.Talk.VisibleDialogueRetranslationResult>>
           retranslateVisibleDialogueAsync)
   {
     this.config = config;
+    this.openDbEditorForTable = openDbEditorForTable;
     this.retranslateVisibleDialogueAsync = retranslateVisibleDialogueAsync;
+    this.visibleStorySurfaceInspectionTable = new InspectionTableView(
+        tableId: "visibleStorySurfaceInspection",
+        getColumns: VisibleStorySurfaceInspectionModelBuilder.BuildColumns,
+        getRows: this.BuildVisibleStorySurfaceInspectionRows,
+        noRecordsLoadedMessage: Resources.TranslatorDebuggerVisibleStorySurfaceNoSnapshot,
+        noRecordsFoundMessage: Resources.TranslatorDebuggerVisibleStorySurfaceNoSnapshot,
+        noColumnsMessage: Resources.TranslatorDebuggerVisibleStorySurfaceNoColumns);
   }
 
   /// <summary>
@@ -129,6 +140,10 @@ public sealed class TranslatorMetricsWindow
       ImGui.TextWrapped(this.lastRetranslationMessage);
       ImGui.PopStyleColor();
     }
+
+    ImGui.Spacing();
+    this.DrawVisibleStorySurfaceDiagnostics();
+    ImGui.Separator();
 
     var snapshots = TranslatorMetricsCollector.GetSnapshots();
     if (snapshots.Count == 0)
@@ -315,7 +330,7 @@ public sealed class TranslatorMetricsWindow
     {
       this.lastRetranslationSucceeded = false;
       this.lastRetranslationMessage =
-          "Visible dialogue retranslation failed unexpectedly before a result could be reported.";
+          VisibleStorySurfaceText.GetUnexpectedFailureMessage();
       return;
     }
 
@@ -323,13 +338,57 @@ public sealed class TranslatorMetricsWindow
     {
       this.lastRetranslationSucceeded = false;
       this.lastRetranslationMessage =
-          "Visible dialogue retranslation was canceled before completion.";
+          VisibleStorySurfaceText.GetCanceledMessage();
       return;
     }
 
     var result = completedTask.GetAwaiter().GetResult();
     this.lastRetranslationSucceeded = result.Success;
     this.lastRetranslationMessage = result.Message;
+  }
+
+  /// <summary>
+  ///     Builds the reusable inspection rows for the latest retained visible
+  ///     story-surface diagnostics snapshot.
+  /// </summary>
+  /// <returns>The reusable inspection rows for the latest snapshot.</returns>
+  private IReadOnlyList<InspectionRow> BuildVisibleStorySurfaceInspectionRows()
+  {
+    var snapshot = VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot();
+    if (snapshot == null)
+    {
+      return [];
+    }
+
+    return VisibleStorySurfaceInspectionModelBuilder.BuildRows(
+        snapshot.Value);
+  }
+
+  /// <summary>
+  ///     Draws the latest visible story-surface provenance snapshot and DB
+  ///     manager handoff controls.
+  /// </summary>
+  private void DrawVisibleStorySurfaceDiagnostics()
+  {
+    ImGui.TextWrapped(
+        Resources.TranslatorDebuggerVisibleStorySurfaceSectionTitle);
+    ImGui.TextWrapped(
+        Resources.TranslatorDebuggerVisibleStorySurfaceDescription);
+
+    var snapshot = VisibleStorySurfaceDiagnosticsStore.GetLatestSnapshot();
+    if (snapshot == null)
+    {
+      ImGui.TextWrapped(
+          Resources.TranslatorDebuggerVisibleStorySurfaceNoSnapshot);
+      return;
+    }
+
+    this.visibleStorySurfaceInspectionTable.Draw();
+    if (ImGui.Button(
+            Resources.TranslatorDebuggerVisibleStorySurfaceViewInDbManager))
+    {
+      this.openDbEditorForTable(snapshot.Value.TableName);
+    }
   }
 
   /// <summary>

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -5124,5 +5124,423 @@ namespace Echoglossian.Properties
                 return ResourceManager.GetString("AddonProbeDurationSecondsFormat", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerUnknown
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerUnknown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceCanceled
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceCanceled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldColumn
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldDbTable
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldDbTable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldEffectiveEngine
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldEffectiveEngine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldLastRetranslation
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldLastRetranslation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldObservedUtc
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldObservedUtc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldOriginalOptions
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldOriginalOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldOriginalSpeaker
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldOriginalSpeaker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldOriginalText
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldOriginalText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldProvenance
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldProvenance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldRuntimeOnlyDialogueContext
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldRuntimeOnlyDialogueContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldSurface
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldSurface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldTranslatedOptions
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldTranslatedOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldTranslatedSpeaker
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldTranslatedSpeaker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceFieldTranslatedText
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceFieldTranslatedText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNameBattleTalk
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNameBattleTalk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNameTalk
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNameTalk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNameTalkSubtitle
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNameTalkSubtitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNameTextGimmickHint
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNameTextGimmickHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNoColumns
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNoColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNoSnapshot
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNoSnapshot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNoUsableTranslation
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNoUsableTranslation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNoVisibleSurfaceAvailable
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNoVisibleSurfaceAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceNoVisibleText
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceNoVisibleText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfacePersistenceFailed
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfacePersistenceFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfacePersistedButVisibleChanged
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfacePersistedButVisibleChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceProvenanceDbReuse
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceProvenanceDbReuse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslationRuntimeOnlyContext
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslationRuntimeOnlyContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceRetranslatedAndPersisted
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceRetranslatedAndPersisted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceRetranslationFailed
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceRetranslationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceSectionTitle
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceSectionTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceUnexpectedFailure
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceUnexpectedFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceValueColumn
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceValueColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///     Pesquisa uma cadeia de caracteres localizada.
+        /// </summary>
+        public static string TranslatorDebuggerVisibleStorySurfaceViewInDbManager
+        {
+            get
+            {
+                return ResourceManager.GetString("TranslatorDebuggerVisibleStorySurfaceViewInDbManager", resourceCulture);
+            }
+        }
     }
 }

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -1454,7 +1454,7 @@
     <value>Runtime-only dialogue context</value>
   </data>
   <data name="TranslatorDebuggerVisibleStorySurfaceFieldObservedUtc" xml:space="preserve">
-    <value>Observed (UTC)</value>
+    <value>Last updated (UTC)</value>
   </data>
   <data name="TranslatorDebuggerVisibleStorySurfaceFieldOriginalSpeaker" xml:space="preserve">
     <value>Original speaker</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -1244,10 +1244,10 @@
     <value>Translator Debugger and Metrics</value>
   </data>
   <data name="TranslatorDebuggerWindowDescription" xml:space="preserve">
-    <value>Aggregated runtime metrics for translator activity in this session.</value>
+    <value>Aggregated runtime metrics and latest visible story-surface provenance for this session.</value>
   </data>
   <data name="TranslatorDebuggerRetranslateVisibleDialogueAndPersist" xml:space="preserve">
-    <value>Retranslate Visible Dialogue And Persist</value>
+    <value>Retranslate Visible Story Text And Persist</value>
   </data>
   <data name="TranslatorDebuggerClearMetrics" xml:space="preserve">
     <value>Clear Metrics</value>
@@ -1256,7 +1256,7 @@
     <value>Clear Dialogue Sessions</value>
   </data>
   <data name="TranslatorDebuggerRetranslatingVisibleDialogue" xml:space="preserve">
-    <value>Retranslating the currently visible dialogue line...</value>
+    <value>Retranslating the currently visible story-facing text...</value>
   </data>
   <data name="TranslatorDebuggerNoMetricsRecorded" xml:space="preserve">
     <value>No translator metrics have been recorded in this session yet.</value>
@@ -1413,6 +1413,120 @@
   </data>
   <data name="TranslatorDebuggerNeverAttempted" xml:space="preserve">
     <value>Never attempted</value>
+  </data>
+  <data name="TranslatorDebuggerUnknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceSectionTitle" xml:space="preserve">
+    <value>Latest Visible Story Surface</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceDescription" xml:space="preserve">
+    <value>Most recent visible story-facing source and translated payload retained for debugger inspection.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNoSnapshot" xml:space="preserve">
+    <value>No visible story-surface snapshot is currently retained.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceViewInDbManager" xml:space="preserve">
+    <value>View In DB Manager</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNoColumns" xml:space="preserve">
+    <value>No visible story-surface fields are available to display.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldColumn" xml:space="preserve">
+    <value>Field</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceValueColumn" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldSurface" xml:space="preserve">
+    <value>Surface</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldProvenance" xml:space="preserve">
+    <value>Provenance</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldDbTable" xml:space="preserve">
+    <value>DB table</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldEffectiveEngine" xml:space="preserve">
+    <value>Effective engine</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldRuntimeOnlyDialogueContext" xml:space="preserve">
+    <value>Runtime-only dialogue context</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldObservedUtc" xml:space="preserve">
+    <value>Observed (UTC)</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldOriginalSpeaker" xml:space="preserve">
+    <value>Original speaker</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldOriginalText" xml:space="preserve">
+    <value>Original text</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldOriginalOptions" xml:space="preserve">
+    <value>Original options</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldTranslatedSpeaker" xml:space="preserve">
+    <value>Translated speaker</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldTranslatedText" xml:space="preserve">
+    <value>Translated text</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldTranslatedOptions" xml:space="preserve">
+    <value>Translated options</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceFieldLastRetranslation" xml:space="preserve">
+    <value>Last retranslation</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNameTalk" xml:space="preserve">
+    <value>Talk</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNameBattleTalk" xml:space="preserve">
+    <value>BattleTalk</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNameTalkSubtitle" xml:space="preserve">
+    <value>TalkSubtitle</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString" xml:space="preserve">
+    <value>CutSceneSelectString</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNameTextGimmickHint" xml:space="preserve">
+    <value>TextGimmickHint</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceProvenanceDbReuse" xml:space="preserve">
+    <value>DB reuse</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslation" xml:space="preserve">
+    <value>Fresh live translation</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceProvenanceFreshLiveTranslationRuntimeOnlyContext" xml:space="preserve">
+    <value>Fresh live translation (runtime-only dialogue context)</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNoVisibleText" xml:space="preserve">
+    <value>No visible {0} text is available to retranslate.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNoUsableTranslation" xml:space="preserve">
+    <value>The visible {0} text did not produce a usable translated result.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfacePersistenceFailed" xml:space="preserve">
+    <value>The visible {0} text was refreshed, but persistence failed: {1}</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfacePersistedButVisibleChanged" xml:space="preserve">
+    <value>The refreshed {0} text was persisted, but the visible content changed before it could be applied.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceRetranslatedAndPersisted" xml:space="preserve">
+    <value>The visible {0} text was retranslated and persisted.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceRetranslationFailed" xml:space="preserve">
+    <value>Retranslating the visible {0} text failed before a usable result could be applied.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceNoVisibleSurfaceAvailable" xml:space="preserve">
+    <value>No visible story-facing text is currently available to retranslate.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceUnexpectedFailure" xml:space="preserve">
+    <value>Visible story-surface retranslation failed unexpectedly before a result could be reported.</value>
+  </data>
+  <data name="TranslatorDebuggerVisibleStorySurfaceCanceled" xml:space="preserve">
+    <value>Visible story-surface retranslation was canceled before completion.</value>
   </data>
   <data name="GeminiModelTooltipPro" xml:space="preserve">
     <value>🔷 Legacy Gemini Pro model (default)</value>

--- a/docs/commands/eglodbmanager.md
+++ b/docs/commands/eglodbmanager.md
@@ -25,3 +25,10 @@ Use this command when you want to:
 
 - This command is a UI entry point for database inspection.
 - Any destructive or bulk data operation should be treated carefully and only done with a clear understanding of the current schema.
+- `/eglotranslatordebugger` can now open this window on the table that owns the
+  latest visible supported story surface.
+
+## Related Guide
+
+For the shared debugger handoff and reusable inspection-table flow, see
+[`docs/story-surface-debugger-db-manager-guide.md`](../story-surface-debugger-db-manager-guide.md).

--- a/docs/commands/eglotranslatordebugger.md
+++ b/docs/commands/eglotranslatordebugger.md
@@ -22,6 +22,10 @@ create hot-path per-request logs.
 It also exposes a `Clear Dialogue Sessions` action that clears the retained
 runtime-only `Talk` / `BattleTalk` history used for context-aware translation.
 
+It now also shows the latest visible story-surface snapshot for supported
+story-facing surfaces and can hand the operator off directly to
+`/eglodbmanager`.
+
 When the dialogue-family LLM override is enabled, the window also shows:
 
 - the current primary engine
@@ -30,18 +34,26 @@ When the dialogue-family LLM override is enabled, the window also shows:
 
 ## Operator Action
 
-The window also exposes an explicit `Retranslate Visible Dialogue And Persist`
-button.
+The window also exposes an explicit
+`Retranslate Visible Story Text And Persist` button.
 
-Current first-pass scope:
+Current scope:
 
 - `Talk`
 - `BattleTalk`
+- `TalkSubtitle`
+- `CutSceneSelectString`
+- `TextGimmickHint`
 
 Behavior:
 
-- forces a fresh live translation for the currently visible dialogue line
-- persists the refreshed result through the dialogue DB path
-- prefers the refreshed row on later lookups by making it the newest matching
-  dialogue row
-- keeps session-aware runtime dialogue context out of the persisted row
+- forces a fresh live translation for the currently visible story-facing text
+- persists the refreshed result through the owning DB path when allowed
+- shows the latest visible provenance snapshot in the debugger
+- can open the owning table in `/eglodbmanager`
+- keeps runtime-only dialogue-context output out of canonical persisted rows
+
+## Related Guide
+
+For the shared debugger-to-DB-manager flow and extension rules, see
+[`docs/story-surface-debugger-db-manager-guide.md`](../story-surface-debugger-db-manager-guide.md).

--- a/docs/story-surface-debugger-db-manager-guide.md
+++ b/docs/story-surface-debugger-db-manager-guide.md
@@ -1,0 +1,184 @@
+# Story-Surface Debugger and DB Manager Guide
+
+This guide documents the shared operator and developer flow added for
+story-facing surfaces that are shown directly to the player.
+
+Current covered surfaces:
+
+- `Talk`
+- `BattleTalk`
+- `TalkSubtitle`
+- `CutSceneSelectString`
+- `TextGimmickHint`
+
+The goal of this flow is narrow:
+
+- show the latest visible story-surface payload in `/eglotranslatordebugger`
+- let the operator force a fresh visible retranslation and persistence
+- show where the current visible result came from
+- hand the operator off to `/eglodbmanager` on the matching table
+- reuse one read-only display layer between debugger and DB manager
+- keep DB CRUD and EF metadata handling inside the DB manager only
+
+## Runtime Pieces
+
+The flow is split across a few small runtime-specific components.
+
+### Handler contract
+
+Visible story-facing handlers that support explicit retranslation implement
+[`IVisibleDialogueRetranslationHandler`](../NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs).
+
+That contract is responsible for:
+
+- deciding whether the handler currently has a visible applicable payload
+- forcing a fresh live translation for that visible payload
+- persisting the refreshed result when it is valid and allowed to persist
+- returning a user-facing result message for the debugger
+
+### Diagnostics snapshot store
+
+[`VisibleStorySurfaceDiagnosticsStore`](../NativeUI/Helpers/VisibleStorySurfaceDiagnosticsStore.cs)
+holds the latest in-memory snapshot per supported surface.
+
+Each snapshot records:
+
+- the story surface kind
+- provenance
+- effective DB table name
+- original payload
+- translated payload
+- runtime-only dialogue-context usage
+- effective translation engine id
+- last explicit retranslation result
+
+This store is runtime-only. It is not persisted.
+
+### Surface metadata helpers
+
+These helpers keep surface-specific labels and routing out of the handlers:
+
+- [`VisibleStorySurfaceKind`](../NativeUI/Helpers/VisibleStorySurfaceKind.cs)
+- [`VisibleStorySurfaceProvenanceKind`](../NativeUI/Helpers/VisibleStorySurfaceProvenanceKind.cs)
+- [`VisibleStorySurfaceTableMap`](../NativeUI/Helpers/VisibleStorySurfaceTableMap.cs)
+- [`VisibleStorySurfaceText`](../NativeUI/Helpers/VisibleStorySurfaceText.cs)
+
+If a new supported story surface is added later, update all four.
+
+### Retranslation dispatcher
+
+[`VisibleStorySurfaceRetranslationDispatcher`](../PluginUI/Helpers/VisibleStorySurfaceRetranslationDispatcher.cs)
+walks the registered addon handlers and sends the explicit retranslation request
+to the first applicable visible story surface.
+
+This keeps `/eglotranslatordebugger` decoupled from individual handler types.
+
+## Shared Read-Only UI Layer
+
+The reusable read-only display layer lives under
+[`DBManagerUI/Components`](../DBManagerUI/Components).
+
+Shared components:
+
+- [`InspectionCell`](../DBManagerUI/Components/InspectionCell.cs)
+- [`InspectionRow`](../DBManagerUI/Components/InspectionRow.cs)
+- [`InspectionColumnDefinition`](../DBManagerUI/Components/InspectionColumnDefinition.cs)
+- [`InspectionCellFormatter`](../DBManagerUI/Components/InspectionCellFormatter.cs)
+- [`InspectionTableView`](../DBManagerUI/Components/InspectionTableView.cs)
+
+Usage split:
+
+- `/eglodbmanager` still owns EF metadata, paging, selection, editing, export,
+  and deletion
+- `/eglotranslatordebugger` only builds rows and columns for display
+
+This was intentional. The table renderer is generic enough for read-only
+inspection, but the data providers remain context-specific.
+
+## Debugger Flow
+
+[`TranslatorMetricsWindow`](../PluginUI/TranslatorMetricsWindow.cs) now shows a
+`Latest Visible Story Surface` section.
+
+That section:
+
+- reads the latest snapshot from `VisibleStorySurfaceDiagnosticsStore`
+- renders the snapshot through `InspectionTableView`
+- exposes the explicit `Retranslate Visible Story Text And Persist` action
+- exposes `View In DB Manager`
+
+The debugger-specific row builder lives in
+[`VisibleStorySurfaceInspectionModelBuilder`](../PluginUI/Helpers/VisibleStorySurfaceInspectionModelBuilder.cs).
+
+## DB Manager Handoff
+
+[`DbEditorWindow`](../DBManagerUI/DBEditorWindow.cs) exposes
+`OpenAndSelectTable(string tableName)`.
+
+The debugger uses that handoff to:
+
+- open `/eglodbmanager`
+- resolve the matching table name
+- select the table without reimplementing DB manager navigation logic
+
+The table-name matching helper lives in
+[`DbTableNameMatcher`](../DBManagerUI/Services/DbTableNameMatcher.cs).
+
+## Provenance Rules
+
+Current provenance values are:
+
+- `DB reuse`
+- `Fresh live translation`
+- `Fresh live translation (runtime-only dialogue context)`
+
+Meaning:
+
+- `DB reuse`: the visible translated result came from an existing persisted row
+- `Fresh live translation`: the visible translated result came from a fresh live
+  translation and is safe to persist
+- `Fresh live translation (runtime-only dialogue context)`: the live result used
+  bounded runtime-only dialogue context and must not become canonical persisted
+  history unless the handler explicitly reruns a persistence-safe path
+
+Do not collapse the runtime-only dialogue-context case into normal persistence.
+
+## Rules for Adding Another Story Surface
+
+When extending this flow to another player-visible story surface:
+
+1. Add the surface to `VisibleStorySurfaceKind`.
+2. Add its localized display name in `VisibleStorySurfaceText`.
+3. Map it to the correct DB table in `VisibleStorySurfaceTableMap`.
+4. Implement `IVisibleDialogueRetranslationHandler` on the handler.
+5. Record snapshots when the visible result comes from:
+   - a stored DB row
+   - a fresh live translation
+   - a runtime-only dialogue-context live translation, if that surface really
+     uses dialogue context
+6. Clear the surface snapshot on hide/reset/finalize.
+7. Reuse `Resources.*` for every new user-facing string.
+8. Add focused tests for the new routing or snapshot behavior.
+
+## Persistence Rules
+
+Keep these semantics unchanged:
+
+- DB remains the source of truth for persisted rows
+- runtime-only dialogue context may improve live translation quality, but it
+  should not silently redefine canonical persisted text
+- the explicit visible retranslation path should persist only usable translated
+  results
+- the debugger should report persistence failure separately from live refresh
+
+## Validation Checklist
+
+When touching this area, validate at least:
+
+1. `dotnet build Echoglossian.sln -c Debug --no-restore`
+2. `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+3. In game, for each touched surface:
+   - the latest snapshot appears in `/eglotranslatordebugger`
+   - explicit retranslation reports the correct outcome
+   - `View In DB Manager` opens the expected table
+   - later lookups show `DB reuse` when the persisted row is reused

--- a/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
@@ -14,6 +14,7 @@ or from a fresh live translation request.
 The approved next slice is therefore a diagnostics-first follow-up:
 
 - expose visible dialogue provenance in `/eglotranslatordebugger`
+- add a non-destructive `View In DB Manager` handoff from the debugger
 - keep scope limited to `Talk` and `BattleTalk`
 - do not change non-dialogue DB semantics
 - do not add DB deletion or purge actions in this slice
@@ -60,7 +61,9 @@ Current limitation:
 1. Make DB reuse for visible `Talk` and `BattleTalk` lines explicit.
 2. Reduce operator confusion during engine, model, and prompt experiments.
 3. Reuse the existing debugger and dialogue handler architecture.
-4. Keep the change narrow and safe for the published branch line.
+4. Hand the operator off to the existing DB manager without adding destructive
+   controls to the debugger.
+5. Keep the change narrow and safe for the published branch line.
 
 ## Non-Goals
 
@@ -81,16 +84,20 @@ Add a small current-line diagnostics section that reports:
 - source: `DB`, `Live translation`, or `Runtime-only context`
 - effective engine id or label
 - whether the most recent explicit retranslate persisted successfully
+- a `View In DB Manager` action that opens the existing DB manager on the
+  relevant dialogue table
 
 Pros:
 
 - smallest code change that directly addresses the remaining user confusion
 - no DB semantics change
+- reuses the existing DB-management surface instead of creating another one
 - easy to validate in-game
 
 Cons:
 
 - does not itself remove stale rows
+- first cut may only preselect the table, not deep-link to an exact row
 
 ### Option B: Targeted purge for the current visible dialogue row
 
@@ -150,6 +157,11 @@ visible dialogue line. It should capture only what the debugger needs:
 
 This state stays in memory only.
 
+The snapshot should also expose enough coarse identity for UI handoff:
+
+- addon family
+- effective dialogue table name
+
 ### 2. Record provenance in `TalkHandler`
 
 When `TalkHandler` resolves a line:
@@ -185,12 +197,25 @@ Suggested fields:
 - context-aware runtime-only flag
 - last explicit retranslate result
 - observation timestamp
+- `View In DB Manager`
 
 The debugger should clearly distinguish:
 
 - `DB reuse`
 - `Fresh live translation`
 - `Fresh live translation (runtime-only dialogue context)`
+
+The `View In DB Manager` action should:
+
+- open the existing DB manager window
+- preselect `TalkMessage` when the current snapshot is `Talk`
+- preselect `BattleTalkMessage` when the current snapshot is `BattleTalk`
+
+First-pass limit:
+
+- no exact-row filter
+- no auto-delete
+- no mutation from the debugger itself
 
 ### 5. Keep failure behavior simple
 
@@ -209,7 +234,9 @@ Only show what the handlers actually observed while resolving the visible line.
    - live translation with runtime-only context
 3. The handler writes one in-memory visible dialogue diagnostics snapshot.
 4. `/eglotranslatordebugger` reads and renders the latest snapshot.
-5. The explicit retranslate action updates the last retranslate result in the
+5. When requested, the debugger opens `/eglodbmanager` against the relevant
+   dialogue table for the current snapshot.
+6. The explicit retranslate action updates the last retranslate result in the
    same in-memory state.
 
 ## Files Expected To Change
@@ -219,11 +246,17 @@ Smallest expected touch set:
 - `NativeUI/AddonHandlers/Talk/TalkHandler.cs`
 - `NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs`
 - `PluginUI/TranslatorMetricsWindow.cs`
+- `DBManagerUI/DBEditorWindow.cs`
 
 Possible new helper file if needed:
 
 - one small runtime-only visible dialogue diagnostics store under an existing
   runtime or translator-adjacent namespace
+
+Possible small plugin-runtime touch:
+
+- a narrow handoff method or delegate that opens the DB manager and selects the
+  requested dialogue table
 
 Avoid touching `DbOperations.cs` unless the implementation proves it is needed
 for clearer engine labels only.
@@ -277,6 +310,10 @@ Recommended in-game:
   it shows the runtime-only provenance
 - use `Retranslate Visible Dialogue And Persist` and verify the retranslate
   outcome updates clearly
+- use `View In DB Manager` from a visible `Talk` snapshot and verify
+  `/eglodbmanager` opens on `TalkMessage`
+- use `View In DB Manager` from a visible `BattleTalk` snapshot and verify
+  `/eglodbmanager` opens on `BattleTalkMessage`
 - repeat the same checks for `BattleTalk`
 
 ## Success Criteria

--- a/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
@@ -21,6 +21,8 @@ The approved next slice is therefore a diagnostics-first follow-up:
 - extend explicit `Retranslate Visible ... And Persist` support to every
   supported story-facing surface in this slice
 - add a non-destructive `View In DB Manager` handoff from the debugger
+- extract reusable read-only inspection display components from `DBManagerUI`
+  so both the debugger and DB manager can use the same presentation layer
 - cover:
   - `Talk`
   - `BattleTalk`
@@ -79,7 +81,9 @@ Current limitation:
    story-facing surfaces in this slice.
 4. Hand the operator off to the existing DB manager without adding destructive
    controls to the debugger.
-5. Keep the change narrow and safe for the published branch line.
+5. Reuse one shared read-only display layer across debugger and DB manager
+   while keeping data providers context-specific.
+6. Keep the change narrow and safe for the published branch line.
 
 ## Non-Goals
 
@@ -89,6 +93,7 @@ Current limitation:
 - no change to runtime-only dialogue-context persistence rules
 - no latency optimization work for `#176`
 - no metadata/glossary expansion work for `#148`
+- no attempt to make the entire DB manager generic or context-free
 
 ## Options Considered
 
@@ -306,7 +311,56 @@ First-pass limit:
 - no auto-delete
 - no mutation from the debugger itself
 
-### 8. Broaden the runtime retranslate contract
+### 8. Extract reusable read-only inspection UI components
+
+The existing DB manager already has useful display-oriented pieces, but they
+are still too tied to EF metadata and DB-editor workflow to drop directly into
+the debugger.
+
+For this slice, extract the read-only presentation layer so both contexts can
+reuse it while keeping their own data providers.
+
+Recommended boundary:
+
+- shared reusable UI:
+  - read-only inspection table
+  - read-only row or field-value presenter
+  - shared cell rendering behavior:
+    - wrap
+    - truncation
+    - tooltip for long values
+    - null or blob formatting when applicable
+- DB-manager-specific:
+  - EF metadata discovery
+  - `DbSet` access
+  - paging/export/delete toolbar behavior
+  - edit modal and CRUD actions
+- debugger-specific:
+  - visible story-surface diagnostics snapshot
+  - provenance labels
+  - retranslate action
+  - DB-manager handoff action
+
+Data-provider direction:
+
+- `DBEditorWindow` should continue to provide DB rows and EF-derived metadata
+  into the shared display structures
+- `/eglotranslatordebugger` should provide visible runtime diagnostics and any
+  optional persisted-row preview into the same shared display structures
+- the shared display layer should not require EF `IProperty` metadata in order
+  to render debugger content
+
+Smallest acceptable shared structures:
+
+- one column descriptor type
+- one row or item descriptor type
+- one cell renderer path for long text and wrapped text
+- optional row action callback support
+
+This keeps the component layer agnostic enough for reuse without forcing the
+debugger to pretend it is browsing EF entities.
+
+### 9. Broaden the runtime retranslate contract
 
 The current runtime contract is centered on
 `IVisibleDialogueRetranslationHandler` and
@@ -328,7 +382,7 @@ Smallest acceptable implementation direction:
 - update the plugin-runtime dispatcher so the debugger action can probe the
   expanded handler set, not only `Talk` and `BattleTalk`
 
-### 9. Keep failure behavior simple
+### 10. Keep failure behavior simple
 
 If no visible story-surface snapshot is available, the debugger should say so
 plainly instead of inferring anything from aggregate metrics.
@@ -349,7 +403,9 @@ Only show what the handlers actually observed while resolving the visible line.
    for the currently applicable supported surface and records the outcome.
 6. When requested, the debugger opens `/eglodbmanager` against the relevant
    table for the current snapshot.
-7. The explicit retranslate action updates the last retranslate result in the
+7. The debugger and DB manager both render through the shared read-only
+   inspection display layer, while each context supplies its own data model.
+8. The explicit retranslate action updates the last retranslate result in the
    same in-memory state for every supported surface.
 
 ## Files Expected To Change
@@ -364,12 +420,16 @@ Smallest expected touch set:
 - `NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs`
 - `PluginUI/TranslatorMetricsWindow.cs`
 - `PluginUI/PluginRuntimeUi.cs`
+- `DBManagerUI/Components/DbTableView.cs`
 - `DBManagerUI/DBEditorWindow.cs`
 
 Possible new helper file if needed:
 
-- one small runtime-only visible dialogue diagnostics store under an existing
+- one small runtime-only visible story-surface diagnostics store under an
+  existing
   runtime or translator-adjacent namespace
+- one or more shared read-only inspection UI component files extracted from the
+  current DB-manager display path
 
 Possible small plugin-runtime touch:
 
@@ -410,6 +470,17 @@ Mitigation:
 
 - add observation-only state
 - do not alter lookup order, translation routing, or persistence rules
+
+### Risk 4: Over-coupling the debugger to EF-oriented display assumptions
+
+If the shared UI layer still assumes EF metadata or DB-editor workflow, the
+debugger will inherit the wrong abstractions.
+
+Mitigation:
+
+- extract only read-only presentation primitives
+- keep EF metadata and CRUD flows outside the shared layer
+- let each caller provide its own display model
 
 ## Validation
 
@@ -469,3 +540,5 @@ This slice is successful when:
 - the explicit visible retranslate-and-persist workflow works consistently
   across every covered story-facing surface without changing DB-first rules for
   the broader plugin
+- the debugger and DB manager share read-only display primitives while their
+  data providers, EF access, and CRUD behaviors remain separate

--- a/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
@@ -17,6 +17,8 @@ The approved next slice is therefore a diagnostics-first follow-up:
 - keep scope limited to `Talk` and `BattleTalk`
 - do not change non-dialogue DB semantics
 - do not add DB deletion or purge actions in this slice
+- treat the existing `/eglodbmanager` window as the correct operator surface for
+  any future targeted DB cleanup work
 
 ## Problem
 
@@ -43,6 +45,8 @@ Current shipped behavior:
 - `/eglotranslatordebugger` already exposes aggregate metrics, dialogue
   sessions, glossary status, provider state, and the explicit retranslate
   action
+- `/eglodbmanager` already exposes the existing database editor window for
+  direct table inspection and deletion
 
 Current limitation:
 
@@ -99,6 +103,8 @@ Cons:
 - riskier semantics around engine filtering and row selection
 - easier to misuse
 - broader than needed before provenance is visible
+- should reuse `/eglodbmanager` or shared DB-manager infrastructure rather than
+  add destructive controls to `/eglotranslatordebugger`
 
 ### Option C: Broader DB cleanup workflow
 
@@ -120,7 +126,9 @@ can show whether a visible line was reused from DB or freshly translated, the
 operator can reason about experiments without wiping storage blindly.
 
 If the issue remains open after this slice, a later follow-up can add a narrow
-dialogue-row purge action with better scope and clearer operator expectations.
+dialogue-row purge action with better scope and clearer operator expectations,
+but that should build on the existing `/eglodbmanager` surface instead of
+turning `/eglotranslatordebugger` into a second DB-management window.
 
 ## Proposed Design
 
@@ -233,12 +241,15 @@ Mitigation:
 
 ### Risk 2: Scope creep into DB-management UI
 
-The presence of the DB editor makes it tempting to add deletion controls here.
+The existing `/eglodbmanager` window makes it tempting to add deletion controls
+to the debugger for convenience.
 
 Mitigation:
 
 - keep this slice debugger-only
 - do not add purge buttons or broader DB actions
+- if later work adds targeted purge, route it through `/eglodbmanager` or its
+  shared DB-manager components
 
 ### Risk 3: Unintended behavior changes in dialogue handlers
 

--- a/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
@@ -8,14 +8,20 @@ This spec defines the next smallest shippable follow-up for GitHub issue
 
 The release already shipped explicit visible dialogue retranslation and
 persistence for `Talk` and `BattleTalk`. The remaining operator gap is that
-users still cannot easily tell whether a visible line came from an old DB row
-or from a fresh live translation request.
+users still cannot easily tell whether story-facing text currently shown to the
+player came from an old DB row or from a fresh live translation request.
 
 The approved next slice is therefore a diagnostics-first follow-up:
 
-- expose visible dialogue provenance in `/eglotranslatordebugger`
+- expose visible provenance for player-facing story text in
+  `/eglotranslatordebugger`
 - add a non-destructive `View In DB Manager` handoff from the debugger
-- keep scope limited to `Talk` and `BattleTalk`
+- cover:
+  - `Talk`
+  - `BattleTalk`
+  - `TalkSubtitle`
+  - `CutSceneSelectString`
+  - `TextGimmickHint`
 - do not change non-dialogue DB semantics
 - do not add DB deletion or purge actions in this slice
 - treat the existing `/eglodbmanager` window as the correct operator surface for
@@ -32,7 +38,8 @@ translator experimentation:
 
 The stable build already improved this meaningfully by shipping
 `Retranslate Visible Dialogue And Persist`, but the issue remains open because
-the operator cannot yet answer a basic question for the currently visible line:
+the operator cannot yet answer a basic question for the currently visible
+story-facing text:
 
 `Where did this translation come from?`
 
@@ -40,7 +47,8 @@ the operator cannot yet answer a basic question for the currently visible line:
 
 Current shipped behavior:
 
-- `Talk` and `BattleTalk` first try DB lookup
+- `Talk`, `BattleTalk`, `TalkSubtitle`, `CutSceneSelectString`, and
+  `TextGimmickHint` all have DB-backed lookup paths
 - when no suitable row exists, they can issue a live translation request
 - when runtime-only dialogue context is used, the result stays non-persistent
 - `/eglotranslatordebugger` already exposes aggregate metrics, dialogue
@@ -53,12 +61,14 @@ Current limitation:
 
 - the debugger shows aggregate translator activity, not per-visible-line
   provenance
-- the retranslate action reports whether persistence succeeded, but not what
-  source the currently shown line originally came from
+- the retranslate action reports whether persistence succeeded, but only for
+  `Talk` and `BattleTalk`
+- none of these story-facing surfaces tell the operator what source the
+  currently shown text originally came from
 
 ## Goals
 
-1. Make DB reuse for visible `Talk` and `BattleTalk` lines explicit.
+1. Make DB reuse for visible player-facing story text explicit.
 2. Reduce operator confusion during engine, model, and prompt experiments.
 3. Reuse the existing debugger and dialogue handler architecture.
 4. Hand the operator off to the existing DB manager without adding destructive
@@ -69,6 +79,8 @@ Current limitation:
 
 - no broad `clear database` button
 - no bulk rewrite or purge workflow
+- no expansion of explicit visible retranslate-and-persist beyond `Talk` and
+  `BattleTalk` in this slice
 - no change to quest, tooltip, toast, or canonical game-window persistence
 - no change to runtime-only dialogue-context persistence rules
 - no latency optimization work for `#176`
@@ -76,16 +88,17 @@ Current limitation:
 
 ## Options Considered
 
-### Option A: Visible dialogue provenance in the debugger
+### Option A: Visible story-surface provenance in the debugger
 
 Add a small current-line diagnostics section that reports:
 
-- addon family: `Talk` or `BattleTalk`
+- addon family or surface kind
 - source: `DB`, `Live translation`, or `Runtime-only context`
 - effective engine id or label
-- whether the most recent explicit retranslate persisted successfully
+- whether the most recent explicit retranslate persisted successfully when the
+  surface supports it
 - a `View In DB Manager` action that opens the existing DB manager on the
-  relevant dialogue table
+  relevant table
 
 Pros:
 
@@ -98,6 +111,7 @@ Cons:
 
 - does not itself remove stale rows
 - first cut may only preselect the table, not deep-link to an exact row
+- non-dialogue story surfaces do not all support runtime-only dialogue context
 
 ### Option B: Targeted purge for the current visible dialogue row
 
@@ -129,8 +143,8 @@ Cons:
 Choose Option A first.
 
 The right next slice is not more mutation. It is visibility. Once the debugger
-can show whether a visible line was reused from DB or freshly translated, the
-operator can reason about experiments without wiping storage blindly.
+can show whether visible story text was reused from DB or freshly translated,
+the operator can reason about experiments without wiping storage blindly.
 
 If the issue remains open after this slice, a later follow-up can add a narrow
 dialogue-row purge action with better scope and clearer operator expectations,
@@ -139,28 +153,30 @@ turning `/eglotranslatordebugger` into a second DB-management window.
 
 ## Proposed Design
 
-### 1. Add a visible dialogue diagnostics snapshot
+### 1. Add a visible story-surface diagnostics snapshot
 
 Introduce a small runtime-only snapshot model for the most recently resolved
-visible dialogue line. It should capture only what the debugger needs:
+visible story-facing surface. It should capture only what the debugger needs:
 
-- addon family
+- addon family or surface kind
 - original speaker text when available
 - original line text
+- original options text when applicable
 - translated speaker text when available
 - translated line text
+- translated options text when applicable
 - provenance kind
 - effective translation engine id
 - whether runtime-only dialogue context was used
 - timestamp of the observation
-- latest explicit retranslate outcome for that addon family
+- latest explicit retranslate outcome when supported by that surface
 
 This state stays in memory only.
 
 The snapshot should also expose enough coarse identity for UI handoff:
 
-- addon family
-- effective dialogue table name
+- addon family or surface kind
+- effective table name
 
 ### 2. Record provenance in `TalkHandler`
 
@@ -184,18 +200,54 @@ Apply the same rules and same snapshot contract used by `TalkHandler`.
 Keep the namespace separate so the debugger can identify which addon family the
 current snapshot belongs to.
 
-### 4. Show the snapshot in `/eglotranslatordebugger`
+### 4. Record provenance in `TalkSubtitleHandler`
+
+When `TalkSubtitleHandler` resolves a line:
+
+- record `DB` when a stored subtitle row is accepted
+- record `Live translation` when a fresh subtitle translation is produced and
+  stored
+- do not expose a retranslate outcome because this slice does not add visible
+  subtitle retranslation
+
+Use `TalkSubtitleMessage` as the DB-manager handoff target.
+
+### 5. Record provenance in `CutSceneSelectStringHandler`
+
+When `CutSceneSelectStringHandler` resolves one question-and-options payload:
+
+- record `DB` when a stored `SelectString` row is accepted
+- record `Live translation` when the handler translates the question or options
+  live and stores the result
+- model provenance at the whole prompt-plus-options payload level, not at one
+  option row at a time
+
+Use `SelectString` as the DB-manager handoff target.
+
+### 6. Record provenance in `TextGimmickHintHandler`
+
+When `TextGimmickHintHandler` resolves a hint line:
+
+- record `DB` when a stored hint row is accepted
+- record `Live translation` when a fresh hint translation is produced and
+  stored
+- do not claim runtime-only dialogue context for this surface unless the actual
+  runtime path proves it
+
+Use `TextGimmickHintMessage` as the DB-manager handoff target.
+
+### 7. Show the snapshot in `/eglotranslatordebugger`
 
 Add a compact section near the existing retranslate controls that shows the
-current visible dialogue state when available.
+current visible story-surface state when available.
 
 Suggested fields:
 
-- current visible dialogue source
-- current visible dialogue addon family
+- current visible source
+- current visible surface
 - effective engine
 - context-aware runtime-only flag
-- last explicit retranslate result
+- last explicit retranslate result when applicable
 - observation timestamp
 - `View In DB Manager`
 
@@ -210,6 +262,10 @@ The `View In DB Manager` action should:
 - open the existing DB manager window
 - preselect `TalkMessage` when the current snapshot is `Talk`
 - preselect `BattleTalkMessage` when the current snapshot is `BattleTalk`
+- preselect `TalkSubtitleMessage` when the current snapshot is `TalkSubtitle`
+- preselect `SelectString` when the current snapshot is `CutSceneSelectString`
+- preselect `TextGimmickHintMessage` when the current snapshot is
+  `TextGimmickHint`
 
 First-pass limit:
 
@@ -217,9 +273,9 @@ First-pass limit:
 - no auto-delete
 - no mutation from the debugger itself
 
-### 5. Keep failure behavior simple
+### 8. Keep failure behavior simple
 
-If no visible dialogue snapshot is available, the debugger should say so
+If no visible story-surface snapshot is available, the debugger should say so
 plainly instead of inferring anything from aggregate metrics.
 
 Do not backfill provenance from DB queries or logs after the fact.
@@ -227,17 +283,18 @@ Only show what the handlers actually observed while resolving the visible line.
 
 ## Data Flow
 
-1. `TalkHandler` or `BattleTalkHandler` resolves one visible line.
+1. One supported story-facing handler resolves the currently visible text.
 2. The handler determines whether the result came from:
    - DB lookup
    - live translation without runtime-only context
    - live translation with runtime-only context
-3. The handler writes one in-memory visible dialogue diagnostics snapshot.
+3. The handler writes one in-memory visible story-surface diagnostics snapshot.
 4. `/eglotranslatordebugger` reads and renders the latest snapshot.
 5. When requested, the debugger opens `/eglodbmanager` against the relevant
-   dialogue table for the current snapshot.
-6. The explicit retranslate action updates the last retranslate result in the
-   same in-memory state.
+   table for the current snapshot.
+6. When the supported surface is `Talk` or `BattleTalk`, the explicit
+   retranslate action updates the last retranslate result in the same in-memory
+   state.
 
 ## Files Expected To Change
 
@@ -245,6 +302,9 @@ Smallest expected touch set:
 
 - `NativeUI/AddonHandlers/Talk/TalkHandler.cs`
 - `NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs`
+- `NativeUI/AddonHandlers/Talk/TalkSubtitleHandler.cs`
+- `NativeUI/AddonHandlers/CutSceneSelectString/CutSceneSelectStringHandler.cs`
+- `NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs`
 - `PluginUI/TranslatorMetricsWindow.cs`
 - `DBManagerUI/DBEditorWindow.cs`
 
@@ -314,15 +374,32 @@ Recommended in-game:
   `/eglodbmanager` opens on `TalkMessage`
 - use `View In DB Manager` from a visible `BattleTalk` snapshot and verify
   `/eglodbmanager` opens on `BattleTalkMessage`
-- repeat the same checks for `BattleTalk`
+- trigger one `TalkSubtitle` line already known to exist in DB and verify it
+  shows `DB reuse`
+- trigger one fresh `TalkSubtitle` line and verify it shows `Fresh live
+  translation`
+- use `View In DB Manager` from a visible `TalkSubtitle` snapshot and verify
+  `/eglodbmanager` opens on `TalkSubtitleMessage`
+- trigger one `CutSceneSelectString` prompt already known to exist in DB and
+  verify it shows `DB reuse`
+- trigger one fresh `CutSceneSelectString` prompt and verify it shows `Fresh
+  live translation`
+- use `View In DB Manager` from a visible `CutSceneSelectString` snapshot and
+  verify `/eglodbmanager` opens on `SelectString`
+- trigger one `TextGimmickHint` line already known to exist in DB and verify
+  it shows `DB reuse`
+- trigger one fresh `TextGimmickHint` line and verify it shows `Fresh live
+  translation`
+- use `View In DB Manager` from a visible `TextGimmickHint` snapshot and
+  verify `/eglodbmanager` opens on `TextGimmickHintMessage`
 
 ## Success Criteria
 
 This slice is successful when:
 
-- operators can tell how the current visible `Talk` or `BattleTalk` line was
+- operators can tell how the current visible supported story-facing surface was
   resolved
 - users no longer need to guess whether a stale DB row or a live request is
   responsible for the currently visible output
-- dialogue retranslation semantics are clearer without changing DB-first rules
-  outside dialogue
+- `Talk` and `BattleTalk` retranslation semantics are clearer without changing
+  DB-first rules for the broader plugin

--- a/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
@@ -7,14 +7,19 @@ This spec defines the next smallest shippable follow-up for GitHub issue
 `2026-07-11`.
 
 The release already shipped explicit visible dialogue retranslation and
-persistence for `Talk` and `BattleTalk`. The remaining operator gap is that
-users still cannot easily tell whether story-facing text currently shown to the
-player came from an old DB row or from a fresh live translation request.
+persistence for `Talk` and `BattleTalk`. The remaining operator gap is twofold:
+
+- users still cannot easily tell whether story-facing text currently shown to
+  the player came from an old DB row or from a fresh live translation request
+- the explicit visible retranslate-and-persist action is still limited to
+  `Talk` and `BattleTalk`
 
 The approved next slice is therefore a diagnostics-first follow-up:
 
 - expose visible provenance for player-facing story text in
   `/eglotranslatordebugger`
+- extend explicit `Retranslate Visible ... And Persist` support to every
+  supported story-facing surface in this slice
 - add a non-destructive `View In DB Manager` handoff from the debugger
 - cover:
   - `Talk`
@@ -61,8 +66,8 @@ Current limitation:
 
 - the debugger shows aggregate translator activity, not per-visible-line
   provenance
-- the retranslate action reports whether persistence succeeded, but only for
-  `Talk` and `BattleTalk`
+- the explicit retranslate action reports whether persistence succeeded, but
+  only for `Talk` and `BattleTalk`
 - none of these story-facing surfaces tell the operator what source the
   currently shown text originally came from
 
@@ -70,7 +75,8 @@ Current limitation:
 
 1. Make DB reuse for visible player-facing story text explicit.
 2. Reduce operator confusion during engine, model, and prompt experiments.
-3. Reuse the existing debugger and dialogue handler architecture.
+3. Extend explicit visible retranslate-and-persist to all supported
+   story-facing surfaces in this slice.
 4. Hand the operator off to the existing DB manager without adding destructive
    controls to the debugger.
 5. Keep the change narrow and safe for the published branch line.
@@ -79,8 +85,6 @@ Current limitation:
 
 - no broad `clear database` button
 - no bulk rewrite or purge workflow
-- no expansion of explicit visible retranslate-and-persist beyond `Talk` and
-  `BattleTalk` in this slice
 - no change to quest, tooltip, toast, or canonical game-window persistence
 - no change to runtime-only dialogue-context persistence rules
 - no latency optimization work for `#176`
@@ -95,8 +99,7 @@ Add a small current-line diagnostics section that reports:
 - addon family or surface kind
 - source: `DB`, `Live translation`, or `Runtime-only context`
 - effective engine id or label
-- whether the most recent explicit retranslate persisted successfully when the
-  surface supports it
+- whether the most recent explicit retranslate persisted successfully
 - a `View In DB Manager` action that opens the existing DB manager on the
   relevant table
 
@@ -105,6 +108,8 @@ Pros:
 - smallest code change that directly addresses the remaining user confusion
 - no DB semantics change
 - reuses the existing DB-management surface instead of creating another one
+- extends an already shipped operator workflow instead of inventing a second
+  remediation concept
 - easy to validate in-game
 
 Cons:
@@ -112,6 +117,8 @@ Cons:
 - does not itself remove stale rows
 - first cut may only preselect the table, not deep-link to an exact row
 - non-dialogue story surfaces do not all support runtime-only dialogue context
+- requires a broader runtime contract than the current Talk-only retranslation
+  interface
 
 ### Option B: Targeted purge for the current visible dialogue row
 
@@ -169,7 +176,7 @@ visible story-facing surface. It should capture only what the debugger needs:
 - effective translation engine id
 - whether runtime-only dialogue context was used
 - timestamp of the observation
-- latest explicit retranslate outcome when supported by that surface
+- latest explicit retranslate outcome
 
 This state stays in memory only.
 
@@ -207,8 +214,14 @@ When `TalkSubtitleHandler` resolves a line:
 - record `DB` when a stored subtitle row is accepted
 - record `Live translation` when a fresh subtitle translation is produced and
   stored
-- do not expose a retranslate outcome because this slice does not add visible
-  subtitle retranslation
+
+Add explicit visible retranslate-and-persist support:
+
+- capture the currently visible subtitle source text
+- request a fresh translation through the same existing subtitle translation
+  path
+- persist the refreshed `TalkSubtitleMessage`
+- update the current in-memory resolved state and latest retranslate outcome
 
 Use `TalkSubtitleMessage` as the DB-manager handoff target.
 
@@ -222,6 +235,14 @@ When `CutSceneSelectStringHandler` resolves one question-and-options payload:
 - model provenance at the whole prompt-plus-options payload level, not at one
   option row at a time
 
+Add explicit visible retranslate-and-persist support:
+
+- capture the currently visible question and option list
+- request a fresh translation through the same existing batch-or-fallback
+  CutSceneSelectString translation path
+- persist the refreshed `SelectString` payload
+- update the current in-memory resolved state and latest retranslate outcome
+
 Use `SelectString` as the DB-manager handoff target.
 
 ### 6. Record provenance in `TextGimmickHintHandler`
@@ -234,6 +255,14 @@ When `TextGimmickHintHandler` resolves a hint line:
 - do not claim runtime-only dialogue context for this surface unless the actual
   runtime path proves it
 
+Add explicit visible retranslate-and-persist support:
+
+- capture the currently visible hint source text
+- request a fresh translation through the same existing gimmick-hint
+  translation path
+- persist the refreshed `TextGimmickHintMessage`
+- update the current in-memory resolved state and latest retranslate outcome
+
 Use `TextGimmickHintMessage` as the DB-manager handoff target.
 
 ### 7. Show the snapshot in `/eglotranslatordebugger`
@@ -241,14 +270,18 @@ Use `TextGimmickHintMessage` as the DB-manager handoff target.
 Add a compact section near the existing retranslate controls that shows the
 current visible story-surface state when available.
 
+Rename or broaden the current retranslate button label so it no longer implies
+only `Talk` and `BattleTalk`.
+
 Suggested fields:
 
 - current visible source
 - current visible surface
 - effective engine
 - context-aware runtime-only flag
-- last explicit retranslate result when applicable
+- last explicit retranslate result
 - observation timestamp
+- `Retranslate Visible Text And Persist`
 - `View In DB Manager`
 
 The debugger should clearly distinguish:
@@ -273,7 +306,29 @@ First-pass limit:
 - no auto-delete
 - no mutation from the debugger itself
 
-### 8. Keep failure behavior simple
+### 8. Broaden the runtime retranslate contract
+
+The current runtime contract is centered on
+`IVisibleDialogueRetranslationHandler` and
+`VisibleDialogueRetranslationResult`, which currently read as `Talk` /
+`BattleTalk` specific.
+
+For this slice, the runtime should support the same explicit operation across
+all covered story-facing surfaces.
+
+Smallest acceptable implementation direction:
+
+- broaden the existing interface contract to include the added handlers, even
+  if the type names remain unchanged for the first pass
+- keep the same result shape:
+  - applicability
+  - success
+  - surface name
+  - user-facing message
+- update the plugin-runtime dispatcher so the debugger action can probe the
+  expanded handler set, not only `Talk` and `BattleTalk`
+
+### 9. Keep failure behavior simple
 
 If no visible story-surface snapshot is available, the debugger should say so
 plainly instead of inferring anything from aggregate metrics.
@@ -290,11 +345,12 @@ Only show what the handlers actually observed while resolving the visible line.
    - live translation with runtime-only context
 3. The handler writes one in-memory visible story-surface diagnostics snapshot.
 4. `/eglotranslatordebugger` reads and renders the latest snapshot.
-5. When requested, the debugger opens `/eglodbmanager` against the relevant
+5. When requested, the debugger invokes the explicit visible retranslate path
+   for the currently applicable supported surface and records the outcome.
+6. When requested, the debugger opens `/eglodbmanager` against the relevant
    table for the current snapshot.
-6. When the supported surface is `Talk` or `BattleTalk`, the explicit
-   retranslate action updates the last retranslate result in the same in-memory
-   state.
+7. The explicit retranslate action updates the last retranslate result in the
+   same in-memory state for every supported surface.
 
 ## Files Expected To Change
 
@@ -305,7 +361,9 @@ Smallest expected touch set:
 - `NativeUI/AddonHandlers/Talk/TalkSubtitleHandler.cs`
 - `NativeUI/AddonHandlers/CutSceneSelectString/CutSceneSelectStringHandler.cs`
 - `NativeUI/AddonHandlers/Toasts/TextGimmickHintHandler.cs`
+- `NativeUI/AddonHandlers/Talk/IVisibleDialogueRetranslationHandler.cs`
 - `PluginUI/TranslatorMetricsWindow.cs`
+- `PluginUI/PluginRuntimeUi.cs`
 - `DBManagerUI/DBEditorWindow.cs`
 
 Possible new helper file if needed:
@@ -344,7 +402,7 @@ Mitigation:
 - if later work adds targeted purge, route it through `/eglodbmanager` or its
   shared DB-manager components
 
-### Risk 3: Unintended behavior changes in dialogue handlers
+### Risk 3: Unintended behavior changes in story-surface handlers
 
 These handlers are behavior-sensitive.
 
@@ -378,18 +436,25 @@ Recommended in-game:
   shows `DB reuse`
 - trigger one fresh `TalkSubtitle` line and verify it shows `Fresh live
   translation`
+- use the debugger retranslate action on a visible `TalkSubtitle` line and
+  verify the refreshed row is persisted and the visible subtitle updates
 - use `View In DB Manager` from a visible `TalkSubtitle` snapshot and verify
   `/eglodbmanager` opens on `TalkSubtitleMessage`
 - trigger one `CutSceneSelectString` prompt already known to exist in DB and
   verify it shows `DB reuse`
 - trigger one fresh `CutSceneSelectString` prompt and verify it shows `Fresh
   live translation`
+- use the debugger retranslate action on a visible `CutSceneSelectString`
+  prompt and verify the refreshed question-and-options payload is persisted and
+  the visible prompt updates
 - use `View In DB Manager` from a visible `CutSceneSelectString` snapshot and
   verify `/eglodbmanager` opens on `SelectString`
 - trigger one `TextGimmickHint` line already known to exist in DB and verify
   it shows `DB reuse`
 - trigger one fresh `TextGimmickHint` line and verify it shows `Fresh live
   translation`
+- use the debugger retranslate action on a visible `TextGimmickHint` line and
+  verify the refreshed row is persisted and the visible hint updates
 - use `View In DB Manager` from a visible `TextGimmickHint` snapshot and
   verify `/eglodbmanager` opens on `TextGimmickHintMessage`
 
@@ -401,5 +466,6 @@ This slice is successful when:
   resolved
 - users no longer need to guess whether a stale DB row or a live request is
   responsible for the currently visible output
-- `Talk` and `BattleTalk` retranslation semantics are clearer without changing
-  DB-first rules for the broader plugin
+- the explicit visible retranslate-and-persist workflow works consistently
+  across every covered story-facing surface without changing DB-first rules for
+  the broader plugin

--- a/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-11-issue-174-dialogue-retranslation-semantics-design.md
@@ -1,0 +1,280 @@
+# Issue 174 Dialogue Retranslation Semantics Design
+
+## Summary
+
+This spec defines the next smallest shippable follow-up for GitHub issue
+`#174` on top of the stable `v4.2601.0710.1250` release published on
+`2026-07-11`.
+
+The release already shipped explicit visible dialogue retranslation and
+persistence for `Talk` and `BattleTalk`. The remaining operator gap is that
+users still cannot easily tell whether a visible line came from an old DB row
+or from a fresh live translation request.
+
+The approved next slice is therefore a diagnostics-first follow-up:
+
+- expose visible dialogue provenance in `/eglotranslatordebugger`
+- keep scope limited to `Talk` and `BattleTalk`
+- do not change non-dialogue DB semantics
+- do not add DB deletion or purge actions in this slice
+
+## Problem
+
+Issue `#174` comments on `2026-05-05` still describe user confusion after
+translator experimentation:
+
+- clearing the DB fixes the symptom
+- users do not know when old persisted rows are still winning
+- users want clearer feedback than a checkbox or a display-only refresh
+
+The stable build already improved this meaningfully by shipping
+`Retranslate Visible Dialogue And Persist`, but the issue remains open because
+the operator cannot yet answer a basic question for the currently visible line:
+
+`Where did this translation come from?`
+
+## Existing Behavior
+
+Current shipped behavior:
+
+- `Talk` and `BattleTalk` first try DB lookup
+- when no suitable row exists, they can issue a live translation request
+- when runtime-only dialogue context is used, the result stays non-persistent
+- `/eglotranslatordebugger` already exposes aggregate metrics, dialogue
+  sessions, glossary status, provider state, and the explicit retranslate
+  action
+
+Current limitation:
+
+- the debugger shows aggregate translator activity, not per-visible-line
+  provenance
+- the retranslate action reports whether persistence succeeded, but not what
+  source the currently shown line originally came from
+
+## Goals
+
+1. Make DB reuse for visible `Talk` and `BattleTalk` lines explicit.
+2. Reduce operator confusion during engine, model, and prompt experiments.
+3. Reuse the existing debugger and dialogue handler architecture.
+4. Keep the change narrow and safe for the published branch line.
+
+## Non-Goals
+
+- no broad `clear database` button
+- no bulk rewrite or purge workflow
+- no change to quest, tooltip, toast, or canonical game-window persistence
+- no change to runtime-only dialogue-context persistence rules
+- no latency optimization work for `#176`
+- no metadata/glossary expansion work for `#148`
+
+## Options Considered
+
+### Option A: Visible dialogue provenance in the debugger
+
+Add a small current-line diagnostics section that reports:
+
+- addon family: `Talk` or `BattleTalk`
+- source: `DB`, `Live translation`, or `Runtime-only context`
+- effective engine id or label
+- whether the most recent explicit retranslate persisted successfully
+
+Pros:
+
+- smallest code change that directly addresses the remaining user confusion
+- no DB semantics change
+- easy to validate in-game
+
+Cons:
+
+- does not itself remove stale rows
+
+### Option B: Targeted purge for the current visible dialogue row
+
+Pros:
+
+- stronger remediation tool for bad stored rows
+
+Cons:
+
+- riskier semantics around engine filtering and row selection
+- easier to misuse
+- broader than needed before provenance is visible
+
+### Option C: Broader DB cleanup workflow
+
+Pros:
+
+- addresses the user request for clearing cached data
+
+Cons:
+
+- too broad for the next slice
+- high risk of collateral damage to DB-first behavior
+
+## Chosen Approach
+
+Choose Option A first.
+
+The right next slice is not more mutation. It is visibility. Once the debugger
+can show whether a visible line was reused from DB or freshly translated, the
+operator can reason about experiments without wiping storage blindly.
+
+If the issue remains open after this slice, a later follow-up can add a narrow
+dialogue-row purge action with better scope and clearer operator expectations.
+
+## Proposed Design
+
+### 1. Add a visible dialogue diagnostics snapshot
+
+Introduce a small runtime-only snapshot model for the most recently resolved
+visible dialogue line. It should capture only what the debugger needs:
+
+- addon family
+- original speaker text when available
+- original line text
+- translated speaker text when available
+- translated line text
+- provenance kind
+- effective translation engine id
+- whether runtime-only dialogue context was used
+- timestamp of the observation
+- latest explicit retranslate outcome for that addon family
+
+This state stays in memory only.
+
+### 2. Record provenance in `TalkHandler`
+
+When `TalkHandler` resolves a line:
+
+- record `DB` when a stored row is accepted
+- record `Runtime-only context` when a live translation used dialogue context
+  and was therefore not persisted
+- record `Live translation` when a live translation completed without
+  runtime-only context
+
+When the explicit visible retranslate path runs:
+
+- update the latest explicit retranslate outcome after persistence succeeds or
+  fails
+
+### 3. Record provenance in `BattleTalkHandler`
+
+Apply the same rules and same snapshot contract used by `TalkHandler`.
+
+Keep the namespace separate so the debugger can identify which addon family the
+current snapshot belongs to.
+
+### 4. Show the snapshot in `/eglotranslatordebugger`
+
+Add a compact section near the existing retranslate controls that shows the
+current visible dialogue state when available.
+
+Suggested fields:
+
+- current visible dialogue source
+- current visible dialogue addon family
+- effective engine
+- context-aware runtime-only flag
+- last explicit retranslate result
+- observation timestamp
+
+The debugger should clearly distinguish:
+
+- `DB reuse`
+- `Fresh live translation`
+- `Fresh live translation (runtime-only dialogue context)`
+
+### 5. Keep failure behavior simple
+
+If no visible dialogue snapshot is available, the debugger should say so
+plainly instead of inferring anything from aggregate metrics.
+
+Do not backfill provenance from DB queries or logs after the fact.
+Only show what the handlers actually observed while resolving the visible line.
+
+## Data Flow
+
+1. `TalkHandler` or `BattleTalkHandler` resolves one visible line.
+2. The handler determines whether the result came from:
+   - DB lookup
+   - live translation without runtime-only context
+   - live translation with runtime-only context
+3. The handler writes one in-memory visible dialogue diagnostics snapshot.
+4. `/eglotranslatordebugger` reads and renders the latest snapshot.
+5. The explicit retranslate action updates the last retranslate result in the
+   same in-memory state.
+
+## Files Expected To Change
+
+Smallest expected touch set:
+
+- `NativeUI/AddonHandlers/Talk/TalkHandler.cs`
+- `NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs`
+- `PluginUI/TranslatorMetricsWindow.cs`
+
+Possible new helper file if needed:
+
+- one small runtime-only visible dialogue diagnostics store under an existing
+  runtime or translator-adjacent namespace
+
+Avoid touching `DbOperations.cs` unless the implementation proves it is needed
+for clearer engine labels only.
+
+## Risks
+
+### Risk 1: Misreporting provenance
+
+If provenance is inferred too loosely, the debugger becomes misleading.
+
+Mitigation:
+
+- record provenance only at the exact decision point in each handler
+- do not reconstruct it later from indirect clues
+
+### Risk 2: Scope creep into DB-management UI
+
+The presence of the DB editor makes it tempting to add deletion controls here.
+
+Mitigation:
+
+- keep this slice debugger-only
+- do not add purge buttons or broader DB actions
+
+### Risk 3: Unintended behavior changes in dialogue handlers
+
+These handlers are behavior-sensitive.
+
+Mitigation:
+
+- add observation-only state
+- do not alter lookup order, translation routing, or persistence rules
+
+## Validation
+
+Required:
+
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+
+Recommended in-game:
+
+- open `/eglotranslatordebugger`
+- trigger one `Talk` line already known to exist in DB and verify it shows
+  `DB reuse`
+- trigger one fresh `Talk` line and verify it shows `Fresh live translation`
+- trigger one context-aware dialogue line that remains runtime-only and verify
+  it shows the runtime-only provenance
+- use `Retranslate Visible Dialogue And Persist` and verify the retranslate
+  outcome updates clearly
+- repeat the same checks for `BattleTalk`
+
+## Success Criteria
+
+This slice is successful when:
+
+- operators can tell how the current visible `Talk` or `BattleTalk` line was
+  resolved
+- users no longer need to guess whether a stale DB row or a live request is
+  responsible for the currently visible output
+- dialogue retranslation semantics are clearer without changing DB-first rules
+  outside dialogue

--- a/docs/superpowers/specs/2026-07-12-imgui-previewer-design.md
+++ b/docs/superpowers/specs/2026-07-12-imgui-previewer-design.md
@@ -1,0 +1,356 @@
+# ImGui Previewer Design
+
+## Summary
+
+This spec defines a development-only ImGui preview workflow for Echoglossian.
+The goal is to preview and capture screenshots of the plugin's ImGui surfaces
+without building, loading, and opening the plugin inside FFXIV.
+
+Approved scope:
+
+- plugin configuration UI
+- translator metrics / debugger UI
+- DB editor UI
+- ImGui overlay surfaces such as `Talk`, `BattleTalk`, `TalkSubtitle`,
+  `MiniTalk`, `CutSceneSelectString`, and toast-family overlays
+
+Out of scope:
+
+- native FFXIV UI mutation previews
+- `AtkTextNode` / `AtkValue` previews
+- non-ImGui game UI rendering
+
+The chosen solution is a desktop C# preview host that reuses the same ImGui
+rendering code paths as the plugin wherever practical, while supplying a
+preview runtime for config, fonts, textures, assets state, viewport geometry,
+and overlay bounds.
+
+## Problem
+
+Today, validating an ImGui surface generally requires the full runtime loop:
+
+1. build the plugin
+2. start the game
+3. wait for Dalamud to load the plugin
+4. open the right game state or addon state
+5. inspect the resulting UI manually
+
+That is slow for iteration, especially when the work is only about:
+
+- layout
+- wrapping
+- font behavior
+- spacing
+- overlay sizing
+- overlay positioning
+- screenshots for comparison or documentation
+
+The repository already contains meaningful ImGui-only logic in:
+
+- `PluginUI/PluginUI.cs`
+- `PluginUI/TranslatorMetricsWindow.cs`
+- `DBManagerUI/DBEditorWindow.cs`
+- `UIOverlays/TranslationOverlay/TranslationOverlayDrawer.cs`
+
+Those surfaces should be previewable outside the game as long as the previewer
+can provide equivalent ImGui runtime inputs.
+
+## Goals
+
+1. Preview Echoglossian ImGui surfaces outside FFXIV.
+2. Reuse real rendering code instead of maintaining a second UI
+   implementation.
+3. Preserve high fidelity for fonts, wrapping, spacing, scaling, and overlay
+   sizing.
+4. Support screenshots from the preview environment.
+5. Keep plugin build, packaging, and release behavior unchanged.
+6. Keep implementation risk low by limiting refactors to UI/runtime boundaries.
+
+## Non-Goals
+
+- no preview of native game UI surfaces
+- no attempt to simulate full FFXIV addon lifecycle
+- no change to translation business logic as part of the preview feature
+- no release-time dependency on a new preview assembly
+- no web-first or browser-first implementation in the initial slice
+- no attempt to guarantee pixel-identical native game geometry outside the game
+
+## Constraints
+
+### Branch Execution Gate
+
+This design is being documented on branch
+`issue-174-dialogue-retranslation-semantics`, which already contains active UI
+and debugger work.
+
+Implementation must **not** start directly from the assumptions in this spec
+without first re-reviewing the post-merge state.
+
+Required execution gate:
+
+1. merge the current issue branch into `v4-series` first
+2. re-audit the latest UI-related files and active branch state
+3. update this spec and the eventual implementation plan if the underlying UI
+   architecture changed
+4. only then start implementation work
+
+This is intentionally a design-first, deferred-execution document.
+
+### Build / Deploy Isolation
+
+The previewer must behave like a development tool, not like a plugin runtime
+dependency.
+
+Required isolation rules:
+
+- the main plugin package continues to be produced only from
+  `Echoglossian.csproj`
+- the previewer must be `IsPackable=false`
+- the previewer must not be included in release packaging flows
+- the previewer must not require a new runtime dependency to ship with the
+  plugin artifact
+- the previewer should be kept out of the main solution file, mirroring the
+  repo's current loose coupling for `Echoglossian.Tests`
+
+## Options Considered
+
+### Option A: Desktop C# preview host reusing shared renderers
+
+Create a standalone preview app that hosts ImGui in a normal desktop window
+and calls the same renderer code used by the plugin.
+
+Pros:
+
+- best fidelity for ImGui surfaces
+- straightforward screenshot support
+- strongest code reuse
+- no need to recreate layouts in another UI technology
+
+Cons:
+
+- requires extracting some runtime dependencies away from current static and
+  plugin-owned state
+- overlay positioning still needs simulated geometry outside the game
+
+### Option B: Native renderer with optional web control surface
+
+Keep rendering native, but provide a browser or local web panel to change
+presets, sample text, viewport, and screenshot scenarios.
+
+Pros:
+
+- can remain high fidelity
+- more convenient control surface
+
+Cons:
+
+- more moving parts
+- unnecessary complexity for the first slice
+
+### Option C: Browser-only ImGui explorer
+
+Recreate the surfaces in a browser workflow similar to generic ImGui explorers.
+
+Pros:
+
+- easy to share
+- attractive as a general UX tool
+
+Cons:
+
+- does not reuse the exact Echoglossian runtime stack
+- risks drift in fonts, spacing, wrapping, and viewport behavior
+- weakest path for the user's `1:1 if possible` goal
+
+## Chosen Approach
+
+Choose Option A.
+
+Echoglossian already draws directly with `Dalamud.Bindings.ImGui`,
+`ImRaii`, custom font handles, and custom overlay layout logic. A desktop host
+that reuses those renderers is the only approach that has a realistic path to
+high-fidelity previews without building a parallel UI stack.
+
+The previewer should therefore be a developer-only desktop application that:
+
+- loads real or sample `Config` data
+- creates a preview runtime for fonts, textures, links, notifications, and
+  assets state
+- simulates overlay viewport and bounds inputs
+- calls shared ImGui renderer code
+- exports screenshots
+
+## Proposed Design
+
+### 1. Add a dev-only preview project
+
+Add a new project such as `Echoglossian.Previewer`.
+
+Rules:
+
+- `IsPackable=false`
+- not added to `Echoglossian.sln`
+- optional separate solution such as `Echoglossian.Previewer.sln`
+- references the main plugin project
+- acts only as a developer utility
+
+This keeps the plugin package and release path unchanged.
+
+### 2. Extract shared ImGui renderers inside the main plugin assembly
+
+Do not create a new shared runtime DLL in the first slice.
+
+Instead, move the minimum necessary ImGui drawing code into renderer classes
+that live inside the existing `Echoglossian` assembly and can be called by both
+the plugin runtime and the previewer.
+
+Initial renderer candidates:
+
+- `PluginConfigWindowRenderer`
+- `TranslatorMetricsWindowRenderer`
+- `DbEditorWindowRenderer`
+- `TranslationOverlayRenderer`
+
+The plugin remains the owner of real runtime orchestration. The previewer
+becomes another caller of the same draw-oriented code.
+
+### 3. Introduce small runtime interfaces
+
+The current UI code mixes draw logic with access to plugin-owned or static
+runtime state. The previewer needs narrow abstractions so it can substitute its
+own runtime safely.
+
+Expected runtime boundaries:
+
+- `IUiFontRuntime`
+- `IUiTextureRuntime`
+- `IUiActionRuntime`
+- `IAssetsStateProvider`
+- `IOverlayPreviewContext`
+
+These interfaces should stay small and UI-oriented. They are not meant to
+generalize the whole plugin runtime.
+
+Examples of what they cover:
+
+- font handles and rebuild hooks
+- image / texture handles
+- external actions such as opening a URL
+- assets downloaded / missing state
+- viewport size, overlay anchor, and simulated addon bounds
+
+### 4. Reuse real models and config where possible
+
+Prefer using existing models directly:
+
+- `Config`
+- `TranslationOverlay`
+- `TranslationWindowConfig`
+
+That keeps preview behavior aligned with the plugin's actual configuration and
+surface contracts.
+
+The previewer should support:
+
+- load current user config
+- load sample config presets
+- edit preview-only scenario inputs without mutating the user's live config
+
+### 5. Simulate overlay geometry explicitly
+
+For overlays, fidelity depends on more than text and font scale. Current
+overlay draw code uses viewport size and overlay dimensions / positions derived
+from game UI geometry.
+
+Outside the game, the previewer should provide scenario presets that define:
+
+- preview viewport resolution
+- addon bounds
+- anchor mode
+- width / height multipliers
+- sample text and optional speaker name
+
+This will not recreate native game UI. It will recreate the geometry inputs
+that the ImGui overlay renderer expects, which is enough for high-quality
+ImGui-surface preview.
+
+### 6. Support screenshots as a first-class feature
+
+The preview host should be able to:
+
+- capture the full visible viewport to `PNG`
+- capture only the currently selected surface
+- optionally batch-export multiple presets
+
+This is one of the main workflow wins for UI iteration and documentation.
+
+### 7. Start with the highest-value surfaces first
+
+Recommended implementation order:
+
+1. `TranslationOverlayRenderer`
+2. overlay preview host and scenario presets
+3. plugin config window renderer
+4. translator metrics window renderer
+5. DB editor renderer
+6. batch screenshot / compare workflows
+
+This order favors the surfaces that benefit most from fast visual iteration and
+that already have concentrated layout logic.
+
+## Risks
+
+### Runtime Coupling Risk
+
+Some draw paths currently depend on static state or Dalamud-owned services more
+deeply than is ideal. The real effort may be larger than it first appears.
+
+Mitigation:
+
+- extract only narrow UI-facing interfaces
+- avoid touching translation business logic
+- stage the work surface by surface
+
+### Font Fidelity Risk
+
+The preview is only valuable if font behavior matches plugin behavior closely.
+Current overlay sizing relies on font selection and `ImGui.CalcTextSize(...)`
+under the effective render font and scale.
+
+Mitigation:
+
+- treat shared font runtime as a first-class requirement
+- verify wrapping and width calculations against the in-plugin render
+
+### Spec Drift Risk
+
+Because this work is intentionally deferred until after the current branch
+merges, the underlying UI code may change before implementation starts.
+
+Mitigation:
+
+- require the execution gate described above
+- revise this spec and the later plan before coding starts
+
+## Validation Expectations
+
+When implementation eventually starts, validation should include:
+
+- plugin build still succeeds:
+  `dotnet build Echoglossian.sln -c Debug --no-restore`
+- plugin tests still succeed:
+  `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`
+- previewer builds independently
+- screenshots verify the expected surface layout for representative presets
+- at least one in-plugin visual comparison is performed for the same config and
+  overlay scenario
+
+## Deliverables For The Deferred Implementation
+
+- design-approved preview architecture
+- dev-only `Echoglossian.Previewer` project
+- shared renderer extraction for the targeted ImGui surfaces
+- preview runtime adapters
+- overlay scenario presets
+- screenshot export support
+- updated docs that describe how to run and re-review the previewer workflow


### PR DESCRIPTION
## Summary
- extract reusable read-only inspection table components from the DB manager and reuse them in the translator debugger
- extend visible retranslate-and-persist plus provenance snapshots across Talk, BattleTalk, TalkSubtitle, CutSceneSelectString, and TextGimmickHint
- add DB manager handoff from the debugger and document the story-surface debugger/DB-manager flow

## Validation
- dotnet build Echoglossian.sln -c Debug --no-restore
- dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build
- validated in game across the supported story surfaces, including debugger provenance and View In DB Manager handoff