### PR TITLE
docs: refresh open issue closure backlog

### DIFF
--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -1,551 +1,187 @@
 # GitHub Issue Backlog
 
-Snapshot date: 2026-07-11
-
-This document is a lightweight backlog snapshot derived from the current open
-GitHub issues. It is meant to keep release fallout separate from medium-term
-feature work.
-
-When the user asks to "read the issues" or "update the issue list", the
-default source of truth for that request is the open issue tracker in
-`lokinmodar/Echoglossian`.
-
-## Publication Update (2026-07-11)
-
-This pass is a targeted post-publication update after
-`v4.2601.0710.1250` went live through the official
-`DalamudPluginsD17` feed.
-
-It rechecked the current open issue list (27 open issues at review time) and
-re-read the issue comments for `#148`, `#174`, `#176`, `#196`, and `#201` to
-separate what is now officially published and closeable from what remains open
-as broader follow-up work.
-
-Delta since the 2026-06-20 pass:
-
-- official `v4.2601.0710.1250` is now live after
-  [PR #9006](https://github.com/goatcorp/DalamudPluginsD17/pull/9006) merged
-  on 2026-07-11
-- `#196` and `#201` move from active product-direction backlog to
-  published-and-closed release outcomes
-- `#148` remains open because the shipped structured-dialogue work is only the
-  first foundation slice, not the full glossary and metadata scope described
-  in the issue
-- `#174` and `#176` remain open because the release improved operator tooling
-  and prompt/context behavior, but the open issue comments still point at
-  broader persistence and latency follow-up rather than a clean validated
-  closure
-- no new issues were opened and 27 issues remain open
-
-### Release-validated in official `v4.2601.0531.0115` and closed
-
-- `#187` MiniTalk text extrapolates balloon size in native replacement mode
-- `#188` Text overflow in small dialogue boxes
-
-Notes:
-
-- `v4.2601.0531.0115` is now live in official `DalamudPluginsD17` after
-  [PR #8789](https://github.com/goatcorp/DalamudPluginsD17/pull/8789) merged
-  on 2026-06-01.
-- Both issues were closed with release-validation comments and explicit reopen
-  guidance for reports on `v4.2601.0531.0115` or newer.
-- Overflow/layout reports embedded in umbrella issues (`#171`, `#172`) are
-  still treated as mixed symptoms until fresh post-release repro confirms what
-  remains.
-
-### Active regression cluster still reported in comments
-
-- `#206` `{targetLanguage}` variable regression (fresh 2026-06-01 comments say
-  it still resolves to `Japanese` even after updating and refreshing resources)
-- `#207` quest tracker / ToDoList Portuguese regression on official build
-- `#203` mixed engine behavior (Google/Yandex partial recovery, Gemini/DeepL
-  failures reported)
-- `#204` OpenRouter translation failure (no new comment yet, still open)
-- `#208` Turkish rendering issue (newer report, no follow-up comments yet)
-- `#212` DeepL free-tier `TooManyRequests` report on official `4.2601.0516.1152`
-- `#171` currently mixes DeepSeek auth/runtime errors with additional quest
-  tracker progression reports
-- `#172` dynamic objective text staleness and cross-quest text mix in tracker
-
-### Product-direction backlog (not pure break/fix)
-
-- `#209` local LLM context limiting/disable controls
-- `#148` structured input/output for glossary and metadata
-
-## Recently Closed In Published `4.2601.0710.1250`
-
-This package is now live in the official Dalamud feed after
-[PR #9006](https://github.com/goatcorp/DalamudPluginsD17/pull/9006) merged on
-2026-07-11.
-
-- `#196` Add Custom OpenAI-Compatible API Support
-- `#201` Add more visible feedback about LLM API usage limits exceeded
-
-Notes:
-
-- `#196` is now represented by the shipped custom OpenAI-compatible provider
-  path, provider-aware runtime behavior, and live model-refresh / debugger
-  support in the official build.
-- `#201` is now represented by the shipped actionable LLM failure
-  notifications, provider-aware runtime failure classification, and clearer
-  debugger/runtime feedback for quota and endpoint failures.
-- `#148` stays open because the release shipped the first structured-dialogue
-  foundation, not the full glossary/metadata scope requested in that issue.
-- `#174` and `#176` stay open as improved-but-not-closed follow-up work:
-  operator retranslation / DB semantics and local-LLM latency still need
-  separate field validation and likely further iteration.
-
-### Compatibility and long-tail backlog
-
-- `#173` and `#179`: CharacterPanelRefined compatibility/crash analysis
-- older enhancement backlog remains open (`#192`, `#139`, `#104`, `#103`,
-  `#68`, `#15`)
-
-## Triage Model
-
-Priority here is sorted by two factors:
-
-1. User impact and release risk
-2. Ease of delivering a narrow, low-risk fix
-
-The first bucket is not "most important only"; it is "most important and
-likely to be the next best use of engineering time right now."
-
-## Recently Closed In `4.2600.0605`
-
-- `#168` The plugin isn't opening
-- `#170` Plugin failed to load
-- `#177` "Waiting to stored quest data" notification
-- `#180` Remove need for downloaded font assets for languages that donot use them
-- `#182` Translation inconsistent - quest tracker sometimes doesn't translate
-- `#183` Align Version numbering to goatcorp standards
-
-## Recently Closed In `4.2600.0605`
-
-- `#178` It isn't translating anything
-
-Notes:
-
-- `4.2600.0605` is the first published release that includes:
-  - hot refresh/runtime reconfig without unload/reload
-  - fix for the config UI save loop
-  - translation activation guard
-  - persistent config-fix notification flow
-  - engine selection / migration fix
-  - Amazon translator hardening
-- This makes `#178` the clearest issue now resolved by a currently published
-  build, rather than only by local code.
-
-## Previously Closed In Published `4.2600.1105.x`
-
-- `#186` Randomly stops translating to PT-BR and displays English text instead
-- `#190` Seleção de mecanismo de tradução não está funcionando corretamente
-- `#191` Talk text is translated multiple time
-- `#195` Translation stuck on Gemini engine regardless of configuration settings
-
-Notes:
-
-- `4.2600.1105.x` was the release package that addressed this engine-selection
-  and dialogue-cache cluster before the current stable line.
-- Those fixes remain part of the published release line and should no longer be
-  treated as "submitted only" backlog items.
-- That package included:
-  - engine-selection stabilization that keeps `ChosenTransEngine` and
-    `ChosenTransEngineKey` synchronized
-  - translator-local concurrency hardening for the LLM cache path
-  - `TalkHandler` DB recheck-before-insert behavior to reduce duplicate talk
-    rows
-  - transient dialogue-failure persistence guards so exact-failure placeholders
-    and cross-language original-text echoes stop becoming sticky fallbacks
-
-## Recently Closed In Published `4.2601.0516.x`
-
-This package is now live in the official Dalamud feed after
-[PR #8674](https://github.com/goatcorp/DalamudPluginsD17/pull/8674) merged on
-2026-05-16.
-
-### #198 Texts are translated multiple times when OpenAI model is changed
-
-- Priority: tracked
-- Ease: done in code
-- Status: published fix, should now be treated as release-validated unless
-  fresh field reports contradict it
-- Notes:
-  - The newer reproduction steps narrow this down to runtime-refresh listener
-    accumulation, not translator-local dictionary concurrency.
-  - The first follow-up fix stabilized register/unregister delegate identity.
-  - A second review follow-up fixed the shared-handler case where the same
-    handler instance is registered for multiple addon names and only the first
-    unregister used to succeed.
-  - Because `4.2601.0516.x` is now officially published, this item should no
-    longer sit in an "awaiting published validation" bucket.
-
-## Recently Closed In Published `4.2601.0531.0115`
-
-This package is now live in the official Dalamud feed after
-[PR #8789](https://github.com/goatcorp/DalamudPluginsD17/pull/8789) merged on
-2026-06-01.
-
-- `#187` MiniTalk text extrapolates balloon size in native replacement mode
-- `#188` Text overflow in small dialogue boxes
-
-Notes:
-
-- Both items were closed with release-validation comments and clear reopen
-  instructions for users still reproducing on `v4.2601.0531.0115` or newer.
-- Overflow reports that remain inside umbrella issues (`#171`, `#172`) should
-  now be treated as new post-release repro candidates, not as pending closure
-  blockers for `#187`/`#188`.
-
-## P0: Urgent and Likely Next Targets
-
-These are the best immediate targets because they are blocking, widespread, or
-highly visible and appear to have a narrow root cause.
-
-### #207 Quest tracker todolist not translating to Portuguese on v4.2601.0516.1152
-
-- Priority: P0
-- Ease: narrow/medium
-- Status: active post-release regression confirmed on the current official
-  build
-- Why it is first:
-  - This is the freshest tracker report and it explicitly uses the new release
-    channel field, so the report is clearly tied to the official
-    `DalamudPluginsD17` package rather than a local build.
-  - The body scopes the failure to `Quest tracker / ToDoList / ScenarioTree`
-    while also stating that the dialogue windows still translate, which makes
-    this much narrower than a generic "plugin not translating" symptom.
-  - The report explicitly calls out that it still reproduces on
-    `v4.2601.0516.1152` even though the older `#182` fix was expected to cover
-    this family.
-  - This is now the strongest current-official signal that the quest-tracker
-    cluster is not actually closed.
-  - A later 2026-06-09 comment on `#171` reports the same family again in
-    Spanish/Google, but specifically as tracker progression failing to advance
-    after quest-state changes.
-
-### #206 {targetLanguage} variable do not take Language to translate to
-
-- Priority: P0
-- Ease: narrow/medium
-- Status: active post-release regression confirmed on the current official
-  build
-- Why it is first:
-  - Two 2026-06-01 follow-up comments explicitly confirm that it still
-    reproduces after updating to the newest installed official build and after
-    forcing plugin-resource refresh.
-  - The issue narrows a vague "LLM not translating" symptom into a concrete
-    prompt-variable failure around `{targetLanguage}`.
-  - This is directly adjacent to the shared prompt-template path and may
-    explain a chunk of the broader provider-specific failures still being
-    reported.
-  - The screenshot evidence still shows `targetLanguage = Japanese`, so this
-    is no longer just "awaiting release validation"; it is a live confirmed
-    regression after the last production release.
-
-### #204 OpenRouter not translating
-
-- Priority: P0
-- Ease: medium
-- Status: active provider-specific manifestation of the same LLM prompt/runtime
-  cluster
-- Notes:
-  - The body still describes the default prompt path turning dialogue into the
-    same obviously wrong fixed string on OpenRouter after leaving the prompt
-    untouched.
-  - With `#206` now confirming a live `{targetLanguage}` variable problem on
-    the official build, this issue should be treated as potentially overlapping
-    evidence rather than a fully separate provider-only outage.
-  - It is still a P0 because users read this as "LLM support regressed" even
-    when other engines still translate.
-
-### #203 Echoglossian not translating
-
-- Priority: P0
-- Ease: medium
-- Status: active mixed engine/runtime report
-- Notes:
-  - The follow-up comment is useful because it narrows the symptom:
-    `Google` and `Yandex` can recover, but only on some quest surfaces, while
-    `Gemini API` and `DeepL-non API` still do not work at all.
-  - This now looks less like a total plugin outage and more like a combination
-    of provider gating, engine configuration UX, and uneven surface coverage.
-  - Keep this near the top until we know whether it decomposes into provider
-    runtime bugs, invalid engine/target-language support combinations, or a
-    quest-surface-only partial translation state.
-
-### #189 Barra de Próxima MSQ e Janela de Missão sem tradução
-
-- Priority: P0
-- Ease: medium
-- Status: active quest-family coverage regression
-- Why it is first:
-  - This is a visible quest-facing regression in one of the most commonly seen
-    gameplay surfaces.
-  - If coverage regressed for the next-MSQ bar / mission window cluster, users
-    read that as "quest translation is broken" even when deeper systems still
-    work.
-  - A new follow-up comment narrows this down to the quest-family surfaces
-    around `ScenarioTree`, `Recommendations`, `JournalAccept`, and related
-    mission-window coverage.
-  - This is now better scoped as a concrete quest-surface coverage regression,
-    not a generic "plugin stopped translating" report.
-  - `#207` makes it more likely that this cluster still includes the quest
-    tracker / `ToDoList` path in the current official build, not only the
-    earlier mission-window surfaces.
-
-## P1: Active LLM / IA Rework Cluster
-
-These are tightly related enough that they should be treated as one product and
-runtime direction rather than isolated one-off fixes.
-
-The first official release of this line is now published in
-`4.2601.0710.1250`, but the remaining items below still need field validation
-or broader follow-up beyond what that release shipped.
-
-### #174 Translate already saved translated texts does not work
-
-- Priority: P1
-- Ease: medium
-- Status: active, partially addressed by the in-progress LLM rework
-- Notes:
-  - Recent user comments still point at DB reuse semantics and lack of a clear
-    operator workflow for forcing retranslation after translator experiments.
-  - A fresh comment also confirms that clearing the DB resolves the bad state,
-    which makes this a real cache/persistence UX problem rather than only a
-    misunderstanding of settings.
-  - This now belongs squarely in the same operator-facing cluster as dialogue
-    retranslation controls and translator diagnostics.
-
-### #176 Overhead de ~1s entre captura do texto e exibição da tradução com LLM local
-
-- Priority: P1
-- Ease: medium/hard
-- Status: active performance and prompt-shaping issue
-- Notes:
-  - The comment trail still supports two root-cause angles:
-    raw local-LLM latency and unnecessary prompt/context overhead.
-  - The user-facing screenshots and discussion make it clear that "single
-    ongoing conversation" and filtering unnecessary text are part of the same
-    desired direction, not a separate enhancement.
-
-### #148 Structured input and output for glossary and metadata
-
-- Priority: P1
-- Ease: hard
-- Status: active architecture enhancement
-- Notes:
-  - This is no longer just "future nice-to-have" architecture; it is part of
-    the same quality and control direction as the current LLM rework.
-  - The issue remains broader than the first structured-dialogue cuts, so it
-    should stay open even as partial foundation work lands elsewhere.
-
-## P1: Urgent but Medium Investigation
-
-These are still release-quality problems, but they likely need a more careful
- runtime pass than the P0 items above.
-
-### #175 Overlay problem
-
-- Priority: P1
-- Ease: medium
-- Status: remaining open overlay-startup symptom
-- Notes:
-  - `#169` is no longer open, so this is now the only active overlay-visibility
-    report left in the release-fallout cluster.
-  - The body still points to "translation works but the overlay does not show"
-    after reinstall.
-  - The only follow-up comment is a user workaround that involves saving config
-    and toggling the plugin, which suggests this may overlap with activation /
-    refresh timing rather than a pure overlay renderer failure.
-
-### #171 Deepseek translation is not available... mission titles and descriptions are not being translated
-
-- Priority: P1
-- Ease: medium
-- Status: mixed umbrella issue, partly addressed
-- Notes:
-  - The original report mixes at least two clusters:
-    - engine / API-error behavior on DeepSeek
-    - mission-title / description coverage and layout failures on other engines
-  - A follow-up comment adds Google/Spanish screenshots of text overflowing
-    dialogue boxes, which was previously tracked by `#188` / `#187` (now closed
-    in `4.2601.0531.0115`) and should now be validated as a fresh repro only if
-    it still occurs on current official builds.
-  - A new 2026-06-09 comment shifts the freshest live symptom toward dynamic
-    quest-tracker progression not updating after quest-state changes, which is
-    much closer to `#207` / `#172` than to DeepSeek auth alone.
-  - Keep this open for now, but treat it as an umbrella report that likely
-    decomposes into `#207`, `#189`, `#174`, and residual provider/runtime
-    failures.
-
-## P2: Release Stabilization, More Involved
-
-These are serious, but they are either more specialized or more likely to
-require careful UI/runtime investigation rather than a narrow config fix.
-
-### #167 Dialogue text glitches when using overlay translation only
-
-- Priority: P2
-- Ease: medium/hard
-- Status: active regression
-- Notes:
-  - Most likely in the `Talk` / `BattleTalk` overlay-only path.
-  - Suspect native state mutation or incomplete restore.
-
-### #172 Google Translation breaks quest and NPC dialogue layout, some quest/FATE text remains untranslated
-
-- Priority: P2
-- Ease: medium/hard
-- Status: mixed umbrella issue, partially decomposed
-- Notes:
-  - The dynamic quest objective `0/3` update bug and wrong-quest slot reuse
-    comments match the quest-tracker bug family that was already addressed in
-    code and previously tracked through `#182`.
-  - A later follow-up comment adds a distinct "selection dialogs line is cut
-    off" symptom, which points at a separate small-native-box layout problem.
-  - The original body also includes the "original English text gets too many
-    line breaks" symptom, which aligns with the `#181` read-only/native-state
-    corruption investigation.
-  - Treat this as a decomposed umbrella issue rather than a single root cause:
-    remaining live parts appear to split across selection-dialog sizing and the
-    broader `#181` native-layout/runtime-state work.
-  - With `#207` now reporting current-official `ToDoList` / `ScenarioTree`
-    translation failure and `#189` already scoped to the mission-window family,
-    this issue is better kept as the broader quest-runtime umbrella than as the
-    next narrow target by itself.
-
-### #173 Plugin function incompatibility: Character panel refined
-
-- Priority: P2
-- Ease: hard
-- Status: open user report
-- Notes:
-  - Game closes when Character translation is enabled with
-    CharacterPanelRefined.
-  - This likely needs addon-shape compatibility work.
-
-### #179 Analyze compatibility with CharacterPanelRefined
-
-- Priority: P2
-- Ease: hard
-- Status: tracking issue
-- Notes:
-  - This is the explicit analysis/backlog issue created for the CPR
-    compatibility work.
-  - Keep this as the structured engineering item; `#173` is the originating
-    user bug report and may later be closed as superseded by `#179`.
-
-### #181 Prevent TextNode Flags corruption while reading them
-
-- Priority: P2
-- Ease: hard
-- Status: active deep-runtime investigation
-- Notes:
-  - Part of the read-only mutation issue has already been narrowed and fixed:
-    overlay-only / tooltip-only paths no longer rewrite native text just to
-    "restore" state they never changed.
-  - The unstable native `JournalDetail` reflow work is intentionally isolated
-    on `issue-181-journaldetail-reflow` / draft PR `#193`, outside the current
-    release branch.
-  - The remaining active problem has shifted toward native-mode layout/reflow,
-    especially in `JournalDetail`, where verbose translations require wrapper
-    and container growth rather than isolated text-node resizing.
-  - No new issue comments changed scope here, but the current `JournalDetail`
-    investigation now clearly serves as the foundation for later `MiniTalk`
-    and small-dialog native reflow fixes.
-  - Keep this open until the native reflow family is stable enough that the
-    original-text corruption and overlapping layout reports stop reproducing.
-
-## P3: Important, Not Immediate Release Blockers
-
-### #192 Add example images for the Game UI elements possible to be translated to each configuration window panel option
-
-- Priority: P3
-- Ease: easy/medium
-- Status: valid UX/documentation enhancement
-- Notes:
-  - This is useful for onboarding and configuration clarity, but it is not a
-    release-stability blocker.
-  - The new translation-surface support matrix can serve as the canonical
-    textual inventory alongside any future example-image work.
-
-## Long-Term Product Backlog
-
-These remain open on purpose and still represent real feature or architecture
-work rather than release fallout.
-
-### #139 Arabic Translation Support
-
-- Status: Phase A implemented; keep open for validation and Phase B research
-- Notes:
-  - Texture-backed, right-aligned presentation is available for plugin-owned
-    overlays and hover tooltips through `LanguagePresentationPolicy`.
-  - Rasterization is bounded before allocation/upload to `2048 px` per side and
-    `2,097,152 px` per texture; the cache also caps one entry at `48 MiB`.
-    Layout construction also stops at `32,768` source characters, a
-    height-compatible line bound, or an exceeded measured area before a target
-    bitmap is allocated.
-  - This is not universal bidi support for game-native or arbitrary ImGui
-    widgets. In-game acceptance remains unrecorded.
-  - Phase B is limited to shaped static-text and upstream ImGui research;
-    editable widgets remain separate work.
-
-### #104 Add quest translations to the Unending Journey
-
-- Status: keep open
-
-### #103 Translate Interactible WorldObjects
-
-- Status: keep open
-
-### #68 Handling of specific in-game addons
-
-- Status: keep open
-- Notes:
-  - Treat as rolling addon coverage tracker.
-  - Remaining notable items include:
-    - `SelectYesNo`
-    - `SelectOk`
-    - `CutSceneSelectString`
-    - `SelectString`
-    - `Tooltips`
-    - `ChatBubble`
-
-### #15 Move Description translation
-
-- Status: keep open
-- Notes:
-  - Intersects the currently disabled structured tooltip path.
-  - `ActionDetail` and `ItemDetail` remain off for release safety.
-
-## Tracking and Meta
-
-### #12 Current known issues
-
-- Status: keep open
-- Purpose:
-  - top-level known-issues tracker
-  - preserves the RTL limitation
-  - points users to the issue tracker plus changelog
-- Notes:
-  - This should stay a documentation/meta tracker, not compete with the real
-    engineering backlog ordering above.
-
-## Recommended Execution Order
-
-1. `#206`
-2. `#207`
-3. `#189`
-4. `#204`
-5. `#203`
-6. the remaining active LLM rework cluster: `#174`, `#176`, `#148`, `#209`
-7. `#212` as provider-limits field validation against the newer feedback path
-8. `#175`
-9. reassess `#171` only after `#207/#189/#172` and `#203/#204/#206` are clearer
-10. `#167`
-11. release-validate / decompose the remaining live parts of `#172`
-12. `#181`
-13. `#173` / `#179`
-14. `#192`
-15. long-term backlog `#139`, `#104`, `#103`, `#68`, `#15`
+Snapshot date: 2026-07-15
+
+This document is the operational snapshot for open issues in
+[`lokinmodar/Echoglossian`](https://github.com/lokinmodar/Echoglossian/issues).
+GitHub remains the source of truth for issue state and comments. Published
+release history belongs in [`CHANGELOG.md`](../CHANGELOG.md), not in this file.
+
+## Current Release Gate
+
+- Candidate release: [`v4.2601.0715.1114`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0715.1114)
+- Product commit: `b584115640c5b9b9bda53001652007a710d892b3`
+- Official submission: [`goatcorp/DalamudPluginsD17#9026`](https://github.com/goatcorp/DalamudPluginsD17/pull/9026)
+- Current status: open, mergeable, validation checks passing, review required
+- Closure rule: do not post the prepared closure comments or close release-bound
+  issues until the D17 PR is merged and the version is available in the
+  official feed
+- Open issue count at this snapshot: 27
+- Expected open count after the approved closure batch: 20
+
+## Close After Official Publication
+
+These issues have a direct implementation and validation trail in
+`v4.2601.0715.1114`. Close them only after the release gate above is satisfied.
+
+| Issue | Resolution in this release | Closure evidence |
+| --- | --- | --- |
+| [#139 Arabic Translation Support](https://github.com/lokinmodar/Echoglossian/issues/139) | Phase A texture-backed presentation supports Arabic and other RTL or complex-script languages in plugin-owned overlays and hover tooltips. It includes shaping, bidi ordering, right alignment, adaptive sizing, line-height control, and bounded memory caches. | Release implementation and RTL layout/cache tests. Native FFXIV UI RTL remains separate Phase B research and is not required for the plugin-owned presentation requested by this issue. |
+| [#174 Retranslate saved texts](https://github.com/lokinmodar/Echoglossian/issues/174) | Translation reuse is canonically scoped by client source language, target language, and engine policy. Language changes invalidate runtime caches, restore defaults, and permit explicit retranslation instead of reusing incompatible rows. | Persistence, reuse-scope, cache invalidation, and retranslation tests. |
+| [#181 TextNode flags corruption](https://github.com/lokinmodar/Echoglossian/issues/181) | Overlay-only and tooltip-only paths preserve native node ownership. `JournalDetail` and dialogue handlers no longer restore or mutate native flags and text unless that path actually changed them. | Native lifecycle and read-only ownership tests, plus the final `JournalDetail` formatting correction. |
+| [#189 MSQ bar and mission windows untranslated](https://github.com/lokinmodar/Echoglossian/issues/189) | Quest-family handlers now use source-scoped state and incremental application for `ScenarioTree`, `RecommendList`, `JournalAccept`, `JournalDetail`, and `ToDoList`. | Quest runtime, lifecycle, and partial-application tests. |
+| [#204 OpenRouter not translating](https://github.com/lokinmodar/Echoglossian/issues/204) | Shared prompt expansion no longer expands placeholder-like text introduced by a previous replacement. | Commit `36c3565` and translator contract tests cover the reported prompt corruption path. |
+| [#207 ToDoList not translating](https://github.com/lokinmodar/Echoglossian/issues/207) | `ToDoList` no longer waits for every quest translation before applying already-resolved entries. | `ToDoListRuntimeAvailabilityTests` and source-scoped runtime tests. |
+
+### Prepared Closure Comments
+
+#### #139
+
+> Implemented in official release `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`. Plugin-owned overlays and hover tooltips now
+> support Arabic and other RTL/complex scripts through texture-backed shaping,
+> bidi ordering, right alignment, adaptive sizing, and bounded caches. Native
+> FFXIV UI RTL remains separate Phase B research. If Arabic still fails on this
+> version, please open a focused report with the affected surface, display mode,
+> translation engine, font configuration, screenshot, and log.
+
+#### #174
+
+> Fixed in official release `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`. Translation reuse and persistence are now
+> scoped by client source language, target language, and engine policy. Language
+> changes invalidate runtime caches and restore default text, and the explicit
+> retranslation path no longer reuses incompatible saved results. Please open a
+> focused report with reproduction steps and DB diagnostics if a stale row still
+> survives these scope changes.
+
+#### #181
+
+> Fixed in official release `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`. Overlay-only and tooltip-only rendering now
+> leaves native text nodes and flags untouched, while native mutation paths only
+> restore state they actually changed. This also includes the `JournalDetail`
+> formatting correction and lifecycle coverage. Please report a fresh repro with
+> the exact addon and display mode if line breaks or node flags are still altered.
+
+#### #189
+
+> Fixed in official release `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`. The quest window and tracker family now uses
+> source-scoped runtime state and applies completed translations incrementally
+> across `ScenarioTree`, `RecommendList`, `JournalAccept`, `JournalDetail`, and
+> `ToDoList`. Please open a focused report naming the exact surface if one remains
+> untranslated on this version.
+
+#### #204
+
+> Fixed in official release `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`. Shared prompt expansion now performs a single
+> safe placeholder pass and does not reinterpret placeholder-like content added
+> by an earlier replacement. This path is covered by translator contract tests,
+> including OpenRouter-compatible prompts. Please attach a current log and prompt
+> template in a new issue if the provider still returns the reported fixed text.
+
+#### #207
+
+> Fixed in official release `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`. `ToDoList` now applies each available
+> translation without waiting for every visible quest to finish, and its runtime
+> state is scoped to the current client and target languages. Remaining dynamic
+> progression or slot-reuse symptoms should be reported as a focused current
+> repro rather than keeping this original all-or-nothing report open.
+
+## Administrative Closure
+
+### [#12 Current known issues](https://github.com/lokinmodar/Echoglossian/issues/12)
+
+This is an obsolete version-specific tracker. Its maintainer comment already
+states that the old tracker should be closed, but the issue remains open. Close
+it with the release batch so current status is not duplicated across an issue,
+the changelog, and this backlog.
+
+Prepared comment:
+
+> Closing this obsolete version-specific tracker. Published fixes and release
+> history are maintained in `CHANGELOG.md`; active triage is maintained in
+> `docs/github-issue-backlog.md` and in focused GitHub issues. The current release
+> line is `v4.2601.0715.1114`, published through
+> `goatcorp/DalamudPluginsD17#9026`.
+
+## Retest Before Closure
+
+The release contains adjacent hardening, but the available reports do not prove
+that their exact symptom is resolved. Request a retest after publication and do
+not auto-close them.
+
+| Issue | Why it remains open | Prepared retest request |
+| --- | --- | --- |
+| [#167 Overlay-only dialogue glitches](https://github.com/lokinmodar/Echoglossian/issues/167) | The release enforces read-only native ownership in overlay-only mode, but the report has no detailed addon or current-version reproduction. | `v4.2601.0715.1114` hardens overlay-only lifecycle behavior. Please retest and provide the exact surface (`Talk`, `BattleTalk`, or other), display mode, screenshot, and log if it still reproduces. |
+| [#175 Overlay problem](https://github.com/lokinmodar/Echoglossian/issues/175) | The original report has no diagnostics and only a configuration/reload workaround. | Please retest on `v4.2601.0715.1114` with a saved display mode. If the overlay is still absent, attach the relevant configuration fields, affected addon, and startup/runtime log. |
+| [#203 Echoglossian not translating](https://github.com/lokinmodar/Echoglossian/issues/203) | Comments report different behavior for Google, Yandex, Gemini, and DeepL. This is not one validated root cause. | Please retest each affected engine separately on `v4.2601.0715.1114` and report source language, target language, engine, surface, and the matching log excerpt. |
+
+## Mixed Issues To Narrow
+
+These issues aggregate independent symptoms. Keep them open after publication,
+record which portions were addressed, and ask for separate current reproductions
+for what remains.
+
+### [#171 DeepSeek, mission text, layout, and tracker progression](https://github.com/lokinmodar/Echoglossian/issues/171)
+
+The new release addresses source-scoped tracker state, partial translation
+application, and several layout/ownership paths. It does not prove resolution
+of DeepSeek authentication/runtime errors, selection-dialog clipping, or the
+latest dynamic progression report. After publication, comment with the shipped
+coverage and request one focused issue per remaining symptom.
+
+### [#172 Google layout and untranslated quest/FATE text](https://github.com/lokinmodar/Echoglossian/issues/172)
+
+The new release addresses quest slot reuse, stale source scoping, incremental
+tracker application, and read-only `JournalDetail` formatting. It does not prove
+resolution of untranslated FATE text or selection-dialog clipping. Keep the
+umbrella open only while collecting fresh reports, then split or close it once
+the remaining symptoms have focused issues.
+
+## Must Remain Open
+
+| Issue | Current reason |
+| --- | --- |
+| [#15 Move Description translation](https://github.com/lokinmodar/Echoglossian/issues/15) | Structured `ActionDetail` and `ItemDetail` native tooltip translation remains disabled for release safety. ActionMenu hover work does not complete this request. |
+| [#68 Specific in-game addons](https://github.com/lokinmodar/Echoglossian/issues/68) | Rolling coverage tracker still includes unsupported or incomplete addons such as selection dialogs, chat bubbles, and production native tooltips. |
+| [#103 Interactible WorldObjects](https://github.com/lokinmodar/Echoglossian/issues/103) | No delivered implementation in this release. |
+| [#104 Unending Journey](https://github.com/lokinmodar/Echoglossian/issues/104) | No delivered implementation in this release. |
+| [#148 Structured LLM input/output](https://github.com/lokinmodar/Echoglossian/issues/148) | Foundation work exists, but the requested cross-provider glossary and metadata contract is not complete. |
+| [#173 CharacterPanelRefined incompatibility](https://github.com/lokinmodar/Echoglossian/issues/173) | Originating user report remains unverified against the compatibility work requested by #179. |
+| [#176 Local LLM latency](https://github.com/lokinmodar/Echoglossian/issues/176) | The reported approximately one-second overhead has no release acceptance evidence and still needs profiling. |
+| [#179 CharacterPanelRefined analysis](https://github.com/lokinmodar/Echoglossian/issues/179) | Explicit compatibility engineering task remains incomplete. |
+| [#192 Configuration screenshots](https://github.com/lokinmodar/Echoglossian/issues/192) | Documentation and UI enhancement has not been implemented. |
+| [#206 `{targetLanguage}` preview](https://github.com/lokinmodar/Echoglossian/issues/206) | Confirmed current defect: the prompt editor preview state still initializes the target language as `Japanese`. This must not be closed with #204. |
+| [#209 Dialogue context controls](https://github.com/lokinmodar/Echoglossian/issues/209) | User-facing disable/limit controls for local LLM context are not implemented. |
+| [#212 DeepL `TooManyRequests`](https://github.com/lokinmodar/Echoglossian/issues/212) | The supplied log indicates provider rate limiting. Backoff, classification, and user-facing behavior still need focused triage. |
+| [#214 First dialogue speaker context](https://github.com/lokinmodar/Echoglossian/issues/214) | New correctness report created after the previous release; no specific implementation in this release. |
+| [#215 Dev-only ImGui preview host](https://github.com/lokinmodar/Echoglossian/issues/215) | Explicitly deferred developer tooling. |
+| [#217 Diacritics fallback metadata](https://github.com/lokinmodar/Echoglossian/issues/217) | Canonical future task for opt-in native replacement fallback. Issue #208 is already closed in favor of this issue; the comment in #217 that calls #208 open is stale. |
+
+## Complete Open-Issue Inventory
+
+This table is the countable audit of all 27 open issues at the snapshot date.
+
+| Decision | Issues | Count |
+| --- | --- | ---: |
+| Close after official publication | #139, #174, #181, #189, #204, #207 | 6 |
+| Administrative close with release batch | #12 | 1 |
+| Request retest before closure | #167, #175, #203 | 3 |
+| Keep open and narrow | #171, #172 | 2 |
+| Keep open as active or planned work | #15, #68, #103, #104, #148, #173, #176, #179, #192, #206, #209, #212, #214, #215, #217 | 15 |
+| **Total open at snapshot** |  | **27** |
+
+## Post-Publication Checklist
+
+1. Confirm `goatcorp/DalamudPluginsD17#9026` is merged.
+2. Confirm `v4.2601.0715.1114` is available in the official Dalamud feed.
+3. Post the prepared comments and close #12, #139, #174, #181, #189, #204,
+   and #207.
+4. Post retest requests on #167, #175, and #203 without closing them.
+5. Comment on #171 and #172 with the delivered scope and request focused
+   reproductions for residual symptoms.
+6. Re-run the open-issue audit and update this snapshot and its counts.


### PR DESCRIPTION
## Summary
- replace the stale historical issue snapshot with a current 27-issue audit
- prepare the release-gated closure and retest comments for v4.2601.0715.1114
- keep unresolved provider, compatibility, tooling, and product work explicitly open

## Validation
- compared the complete inventory against the live GitHub open-issue list
- confirmed commit 36c3565 is included in the release tag ancestry
- confirmed issue #206 remains reproducible in the current prompt preview state
- ran git diff --check

No issues were closed or commented on before the official D17 publication gate.