### PR TITLE
docs(#181): narrow native reflow continuation

### DIFF
--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -17,7 +17,7 @@ release history belongs in [`CHANGELOG.md`](../CHANGELOG.md), not in this file.
   issues until the D17 PR is merged and the version is available in the
   official feed
 - Open issue count at this snapshot: 27
-- Expected open count after the approved closure batch: 20
+- Expected open count after the approved closure batch: 21
 
 ## Close After Official Publication
 
@@ -28,7 +28,6 @@ These issues have a direct implementation and validation trail in
 | --- | --- | --- |
 | [#139 Arabic Translation Support](https://github.com/lokinmodar/Echoglossian/issues/139) | Phase A texture-backed presentation supports Arabic and other RTL or complex-script languages in plugin-owned overlays and hover tooltips. It includes shaping, bidi ordering, right alignment, adaptive sizing, line-height control, and bounded memory caches. | Release implementation and RTL layout/cache tests. Native FFXIV UI RTL remains separate Phase B research and is not required for the plugin-owned presentation requested by this issue. |
 | [#174 Retranslate saved texts](https://github.com/lokinmodar/Echoglossian/issues/174) | Translation reuse is canonically scoped by client source language, target language, and engine policy. Language changes invalidate runtime caches, restore defaults, and permit explicit retranslation instead of reusing incompatible rows. | Persistence, reuse-scope, cache invalidation, and retranslation tests. |
-| [#181 TextNode flags corruption](https://github.com/lokinmodar/Echoglossian/issues/181) | Overlay-only and tooltip-only paths preserve native node ownership. `JournalDetail` and dialogue handlers no longer restore or mutate native flags and text unless that path actually changed them. | Native lifecycle and read-only ownership tests, plus the final `JournalDetail` formatting correction. |
 | [#189 MSQ bar and mission windows untranslated](https://github.com/lokinmodar/Echoglossian/issues/189) | Quest-family handlers now use source-scoped state and incremental application for `ScenarioTree`, `RecommendList`, `JournalAccept`, `JournalDetail`, and `ToDoList`. | Quest runtime, lifecycle, and partial-application tests. |
 | [#204 OpenRouter not translating](https://github.com/lokinmodar/Echoglossian/issues/204) | Shared prompt expansion no longer expands placeholder-like text introduced by a previous replacement. | Commit `36c3565` and translator contract tests cover the reported prompt corruption path. |
 | [#207 ToDoList not translating](https://github.com/lokinmodar/Echoglossian/issues/207) | `ToDoList` no longer waits for every quest translation before applying already-resolved entries. | `ToDoListRuntimeAvailabilityTests` and source-scoped runtime tests. |
@@ -54,15 +53,6 @@ These issues have a direct implementation and validation trail in
 > retranslation path no longer reuses incompatible saved results. Please open a
 > focused report with reproduction steps and DB diagnostics if a stale row still
 > survives these scope changes.
-
-#### #181
-
-> Fixed in official release `v4.2601.0715.1114`, published through
-> `goatcorp/DalamudPluginsD17#9026`. Overlay-only and tooltip-only rendering now
-> leaves native text nodes and flags untouched, while native mutation paths only
-> restore state they actually changed. This also includes the `JournalDetail`
-> formatting correction and lifecycle coverage. Please report a fresh repro with
-> the exact addon and display mode if line breaks or node flags are still altered.
 
 #### #189
 
@@ -154,6 +144,7 @@ the remaining symptoms have focused issues.
 | [#173 CharacterPanelRefined incompatibility](https://github.com/lokinmodar/Echoglossian/issues/173) | Originating user report remains unverified against the compatibility work requested by #179. |
 | [#176 Local LLM latency](https://github.com/lokinmodar/Echoglossian/issues/176) | The reported approximately one-second overhead has no release acceptance evidence and still needs profiling. |
 | [#179 CharacterPanelRefined analysis](https://github.com/lokinmodar/Echoglossian/issues/179) | Explicit compatibility engineering task remains incomplete. |
+| [#181 TextNode flags and native `JournalDetail` reflow](https://github.com/lokinmodar/Echoglossian/issues/181) | The read-only corruption is fixed, but draft PR #193 remains open for the narrower native translated-text reflow. Keep this issue open until long native translations reflow and restore correctly in-game. |
 | [#192 Configuration screenshots](https://github.com/lokinmodar/Echoglossian/issues/192) | Documentation and UI enhancement has not been implemented. |
 | [#206 `{targetLanguage}` preview](https://github.com/lokinmodar/Echoglossian/issues/206) | Confirmed current defect: the prompt editor preview state still initializes the target language as `Japanese`. This must not be closed with #204. |
 | [#209 Dialogue context controls](https://github.com/lokinmodar/Echoglossian/issues/209) | User-facing disable/limit controls for local LLM context are not implemented. |
@@ -168,19 +159,18 @@ This table is the countable audit of all 27 open issues at the snapshot date.
 
 | Decision | Issues | Count |
 | --- | --- | ---: |
-| Close after official publication | #139, #174, #181, #189, #204, #207 | 6 |
+| Close after official publication | #139, #174, #189, #204, #207 | 5 |
 | Administrative close with release batch | #12 | 1 |
 | Request retest before closure | #167, #175, #203 | 3 |
 | Keep open and narrow | #171, #172 | 2 |
-| Keep open as active or planned work | #15, #68, #103, #104, #148, #173, #176, #179, #192, #206, #209, #212, #214, #215, #217 | 15 |
+| Keep open as active or planned work | #15, #68, #103, #104, #148, #173, #176, #179, #181, #192, #206, #209, #212, #214, #215, #217 | 16 |
 | **Total open at snapshot** |  | **27** |
 
 ## Post-Publication Checklist
 
 1. Confirm `goatcorp/DalamudPluginsD17#9026` is merged.
 2. Confirm `v4.2601.0715.1114` is available in the official Dalamud feed.
-3. Post the prepared comments and close #12, #139, #174, #181, #189, #204,
-   and #207.
+3. Post the prepared comments and close #12, #139, #174, #189, #204, and #207.
 4. Post retest requests on #167, #175, and #203 without closing them.
 5. Comment on #171 and #172 with the delivered scope and request focused
    reproductions for residual symptoms.

--- a/docs/handoffs/journaldetail-quest-native-reflow.md
+++ b/docs/handoffs/journaldetail-quest-native-reflow.md
@@ -1,179 +1,262 @@
-# JournalDetail And Quest Native Reflow Handoff
+# JournalDetail Native Translation Reflow Handoff
 
-Snapshot date: 2026-07-07
+Snapshot date: 2026-07-15
 
-## Scope
+## Objective
 
-This handoff is for the unstable quest-surface work around:
+Complete vertical text reflow only when translated text is written into the
+native `JournalDetail` UI.
 
-- `#181` text-node flag corruption and native reflow side effects
-- `JournalDetail` native body reflow
-- `Journal` / `JournalDetail` display-mode correctness
-- quest tooltip versus native mutation behavior
+The target behavior is:
 
-This work is intentionally isolated from `v4-series`.
+- translated native text wraps without overlap or clipping
+- later body blocks move by the cumulative growth of earlier blocks
+- the internal body or scroll extent grows enough to contain the final block
+- original geometry is restored when the handler leaves a native-writing mode
+- no work is repeated every frame once the current layout is already applied
 
-## Branch and PR state
+This is not a general quest-handler refactor and not an overlay-sizing task.
 
-- branch: `issue-181-journaldetail-reflow`
-- latest local branch commit:
+## Branch And PR State
+
+- working branch: `issue-181-journaldetail-reflow`
+- local branch head: `e9722ff5230cc9a2e42ab7e9d322e5a0874ac4d4`
+- remote branch and draft PR head:
+  `0476fa2e784dcbef84dd18d0cf5f81d861c919c9`
+- local-only commits that must be preserved:
+  - `14c0d63` `fix(journal): reset list-node cache on node reuse`
   - `e9722ff` `fix(journaldetail): restore mode-safe native apply flow`
-- open PR:
-  - [#193](https://github.com/lokinmodar/Echoglossian/pull/193)
-  - title: `fix(#181): continue journal detail native reflow investigation`
-  - state: open draft
-- divergence versus `v4-series` at snapshot time:
-  - `v4-series` unique commits: `2`
-  - `issue-181-journaldetail-reflow` unique commits: `9`
+- draft PR:
+  [#193](https://github.com/lokinmodar/Echoglossian/pull/193)
+- PR base: `v4-series`
+- state at this snapshot: open, draft, and conflicting
+- divergence before this handoff update:
+  - `v4-series`: 163 unique commits
+  - local reflow branch: 9 unique commits
 
-Interpretation:
+The new worktree must start from the local branch, not only
+`origin/issue-181-journaldetail-reflow`, or the two local-only commits will be
+lost.
 
-- this branch is ahead with its own experimental work
-- it is also behind `v4-series`
-- sync it before resuming meaningful implementation
+## Scope Boundary
 
-## Why this branch exists
+In scope:
 
-`JournalDetail` native reflow is behavior-sensitive enough that it should not
-be worked directly on `v4-series`.
+- `JournalDetail` body layout in modes that write translated text to native
+  nodes
+- original geometry snapshot and owned restoration
+- translated text measurement
+- ordered body-block flow
+- cumulative vertical delta calculation
+- internal body, canvas, or scroll-container growth
+- narrow tests for reflow calculations and native mutation ownership
+- probe-driven in-game validation of `JournalDetail`
 
-The branch exists to preserve:
+Out of scope:
 
-- native body-flow experiments
-- richer original-layout snapshots
-- probe-driven container and wrapper analysis
-- mode-restoration work that is not yet safe enough for release
+- `Journal` list behavior, except preserving already-committed behavior during
+  the merge
+- `Talk`, `BattleTalk`, `MiniTalk`, `ToDoList`, or other quest surfaces
+- hover tooltip content, hit areas, or texture-backed rendering
+- overlay sizing, RTL texture layout, or ImGui work
+- quest lookup, canonical data, translation cache, persistence, or engine work
+- broad addon traversal or handler architecture refactors
 
-## Branch-only files currently defining this front
+Tooltip-only behavior is a regression constraint, not an implementation target.
+
+## Why The Front Is Still Open
+
+The original read-only corruption reported by issue #181 is already addressed
+in current `v4-series`: handlers track native mutation ownership and do not
+restore or rewrite native nodes in read-only or tooltip-only paths.
+
+The residual work is different and narrower: when a verbose translation is
+intentionally applied to native `JournalDetail` nodes, the body still needs a
+real flow layout instead of independent `SetText(...)` and node resizing calls.
+
+Do not reintroduce the solved read-only bug while completing the native reflow.
+
+## Current `v4-series` Baseline To Preserve
+
+Current `v4-series` includes later `JournalDetail` work that is not present in
+the old draft branch:
+
+- `1ec9780` introduced the newer RTL and native-runtime baseline
+- `563dd87` scoped quest source identity per operation
+- `bda68c0` restored Character hovers and preserved `JournalDetail` formatting
+- current handler lifecycle uses explicit mode helpers and
+  `ownsJournalDetailNativeMutation`
+- restoration occurs only when the handler owns a prior native mutation
+- tooltip-only paths keep native text and flags untouched
+- current quest source-scope and lifecycle tests must continue to pass
+
+Treat the current `v4-series` `JournalDetailHandler` as the lifecycle baseline.
+Do not resolve the merge by accepting the stale handler wholesale.
+
+## Branch Work Worth Recovering
+
+The branch contains experimental material that should be reviewed and ported
+selectively:
+
+- `NativeUI/Helpers/NativeTextFlowReflowHelper.cs`
+- richer original text and geometry snapshots
+- body-block ordering and section resolution experiments
+- internal container growth experiments
+- enhanced addon probe output
+- the local mode-safe native apply correction in `e9722ff`
+
+The helper is experimental, not an accepted abstraction. Keep it only if it can
+be reduced to the narrow `JournalDetail` need and covered by deterministic
+tests. Do not generalize it to other addons during this front.
+
+## Required Branch Update
+
+Use a merge, not a rebase or force-push, because the branch already has an open
+shared PR and prior merge history.
+
+1. Start from local `issue-181-journaldetail-reflow` at `e9722ff`.
+2. Fetch `origin`.
+3. Merge `origin/v4-series` into the issue branch.
+4. Resolve `JournalDetailHandler.cs` using current `v4-series` lifecycle and
+   source-scoping behavior as the baseline, then port only the native reflow
+   behavior that is still required.
+5. Resolve `Echoglossian.xml` from the current `v4-series` side first; regenerate
+   it through the validated build after resolving source files.
+6. Preserve the already-committed `JournalHandler` node-reuse guard without
+   expanding its scope.
+7. Build, test, commit the merge resolution, and push the issue branch to update
+   PR #193.
+
+A merge-tree simulation predicts content conflicts in:
 
 - `NativeUI/AddonHandlers/Quest/JournalDetailHandler.cs`
-- `NativeUI/AddonHandlers/Quest/JournalHandler.cs`
-- `NativeUI/Helpers/NativeTextFlowReflowHelper.cs`
-- `NativeUI/Helpers/AddonStructureProbe.cs`
-- `docs/journal-journaldetail-surface-fix-iteration-log.md`
-- `docs/commands/egloaddonprobe.md`
+- `Echoglossian.xml`
 
-## What is already known and should not be re-learned
+`JournalHandler.cs` auto-merges in the simulation but still requires review.
 
-### Mode contract is strict
+## Reflow Model
 
-The three Journal-family modes must stay separated:
+Capture one layout scope for the visible `JournalDetail` body. For every mutable
+block, preserve:
 
-- `NativeUiTranslation`
-  - translated native UI
-  - no hover tooltip
-- `TooltipTranslation`
-  - original native UI
-  - translated tooltip only when the translated payload is ready
-- `NativeUiTranslationWithOriginalTooltips`
-  - translated native UI
-  - original tooltip only when the translated/native payload is ready
+- node identity and expected parent
+- original text
+- original X and Y
+- original width and height
+- original text flags and font size
+- original container heights required for restoration
 
-If the selected mode does not mutate native UI, do not touch native nodes.
+Apply native translated layout in this order:
 
-### JournalDetail is the most sensitive quest surface
+1. Restore the block to its original geometry before measuring a new payload.
+2. Apply the translated text with the required multiline and wrapping flags.
+3. Measure the resulting text-node height.
+4. Compute `deltaHeight = translatedHeight - originalHeight`.
+5. Move every later block in the same body flow by the cumulative prior delta.
+6. Grow only the internal body, canvas, or scroll extent needed to contain the
+   final block plus original bottom padding.
+7. Mark the scope as applied so identical repaint events short-circuit.
 
-The repo already treats `JournalDetail` as the highest-risk quest surface.
-Dense translated bodies need container-aware flow reflow, not just text-node
-resizing.
+Do not grow the outer viewport, root addon geometry, or unrelated controls.
 
-### Reflow target selection matters
+## Lifecycle Contract
 
-For `JournalDetail`, a healthy native layout generally keeps outer viewport
-containers fixed and grows only the internal scroll/body flow. If the outer
-body viewport or root clipped nodes start growing, the wrong container is being
-reflowed.
+`NativeUiTranslation`:
 
-### Original-state capture must be scope-safe
+- apply translated native text and reflow
+- do not add hover behavior as part of this work
 
-Mode switches and repeated repaints need a stable per-scope original snapshot
-that includes:
+`NativeUiTranslationWithOriginalTooltips`:
 
-- original texts
-- text flags and font sizes
-- ordered body-flow blocks
-- container heights
-- summary and supplemental summary nodes
+- apply the same translated native reflow
+- preserve existing original-tooltip behavior unchanged
 
-### The quest pipeline should remain canonical-first
+`TooltipTranslation`:
 
-Quest handlers should identify quest and live progress, then consume canonical
-or DB-backed quest payloads. UI text is fallback material, not canonical truth,
-when structured quest data is already available.
+- do not mutate text, flags, node geometry, or containers
+- do not run a restore unless this handler owns a previous native mutation
 
-## Canonical docs to read before editing
+On addon reuse, scope change, mode change, hide, or finalize:
 
-Start with these, in this order:
+- restore text and geometry only when the handler owns a native mutation
+- clear the applied-layout key and per-scope geometry snapshot at the correct
+  lifecycle boundary
+- never restore stale geometry into a newly reused addon scope
 
-1. [docs/quest-addon-translation-runtime-flow.md](../quest-addon-translation-runtime-flow.md)
-2. [docs/journal-quest-data-model-and-flow.md](../journal-quest-data-model-and-flow.md)
-3. [docs/quest-addon-detailed-flow-and-remediation-plan.md](../quest-addon-detailed-flow-and-remediation-plan.md)
-4. [docs/github-issue-backlog.md](../github-issue-backlog.md)
-5. [docs/commands/egloaddonprobe.md](../commands/egloaddonprobe.md)
+## Performance Constraints
 
-Then read branch-only material directly from the branch:
+- no full node-tree traversal every frame after the layout is resolved
+- no database access or translation request from the reflow helper
+- no repeated text measurement for an unchanged translated payload and scope
+- no unbounded snapshot growth across quest changes
+- no hot-path debug logging after investigation
+- use the existing addon probe rather than permanent diagnostic output
 
-- `docs/journal-journaldetail-surface-fix-iteration-log.md`
+The reflow cache key must distinguish at least addon scope and applied text or
+payload identity. A changed quest or translated body must invalidate the prior
+layout even if node addresses are reused.
 
-## What the branch currently changes
+## Tests To Preserve And Extend
 
-At a high level, this branch adds:
+Preserve the current coverage in:
 
-- a shared `NativeTextFlowReflowHelper`
-- richer `JournalDetail` original snapshot capture
-- per-scope mode-safe native apply and restore behavior
-- stronger addon-probe output for layout inspection
+- `Echoglossian.Tests/QuestAddonHandlerLifecycleTests.cs`
+- `Echoglossian.Tests/QuestOperationSourceScopeTests.cs`
+- `Echoglossian.Tests/NativeRuntimeSourceScopeTests.cs`
+- `Echoglossian.Tests/QuestAddonOriginalTextHelperTests.cs`
 
-The point is not “make text bigger”. The point is:
+Add deterministic tests for logic that does not require a live addon:
 
-- restore correctly
-- grow only the correct flow containers
-- avoid leaking mutated geometry across mode switches and repaints
+- cumulative block offsets for zero, positive, and mixed deltas
+- container growth from the final block and original bottom padding
+- idempotence for the same scope and payload
+- invalidation when the scope or translated payload changes
+- restoration action only when native mutation ownership is true
+- tooltip-only mode never selecting native apply or geometry mutation
 
-## Known unresolved concerns
+Required repository validation:
 
-- the branch is stale relative to `v4-series`
-- `JournalDetail` native mode still needs in-game validation for long body
-  translations and summary-heavy quests
-- tooltip/original pairing must remain correct in swap mode
-- any fix must avoid reintroducing the older bug where read-only or tooltip
-  modes touched native text/flags they never mutated
+```powershell
+dotnet build Echoglossian.sln -c Debug --no-restore
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build
+```
 
-## Recommended resume steps
+Commit `Echoglossian.xml` when regenerated by the validated source change.
 
-1. Switch to `issue-181-journaldetail-reflow`.
-2. Sync it with `v4-series` before new edits.
-3. Read the docs listed above plus PR `#193`.
-4. Run targeted probing on `Journal` and `JournalDetail`.
-5. Validate all three display modes in-game before broadening scope.
-6. Keep the iteration log updated on every meaningful pass.
+## In-Game Acceptance
 
-## Probe and validation guidance
+Use:
 
-Useful commands:
+```text
+/egloaddonprobe JournalDetail
+/egloaddonprobe stop
+```
 
-- `/egloaddonprobe JournalDetail`
-- `/egloaddonprobe Journal`
-- `/egloaddonprobe _ToDoList 0`
+Validate with a long, verbose translated quest body:
 
-Required validation after code changes:
+- no text overlap between objective, summary, description, and footer blocks
+- no original text leaking under translated text
+- no clipping at the internal viewport or scroll extent
+- later sections move by the correct cumulative amount
+- changing quests does not reuse stale text or geometry
+- closing and reopening restores a clean baseline
+- switching from native to tooltip-only restores original geometry once
+- tooltip-only mode does not modify native text, flags, or layout
+- native plus original tooltips keeps its existing tooltip pairing
+- stable frame rate while the window remains open and while scrolling
 
-- `dotnet build Echoglossian.sln -c Debug --no-restore`
-- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
+## Completion Rule
 
-In-game checks:
+The front is complete only when:
 
-- `JournalDetail` native mode with long quest body
-- `TooltipTranslation` restores the original native UI and shows translated
-  tooltip only when ready
-- `NativeUiTranslationWithOriginalTooltips` shows translated native UI and the
-  correct original tooltip
-- opening, closing, and mode switching do not leave mutated layout behind
+- the issue branch is merged with current `v4-series` and pushed
+- the PR contains only the narrow native `JournalDetail` reflow plus required
+  regression guards
+- repository build and tests pass
+- all in-game acceptance checks above pass
+- the draft PR description is updated with current architecture and evidence
+- the PR can be marked ready without carrying unrelated handler or generated
+  file regressions
 
-## Merge rule
-
-Do not merge `#193` into `v4-series` until:
-
-- layout is stable in-game
-- tooltip behavior is stable in-game
-- no native text is touched outside the modes that truly mutate it
+If a different native addon later needs reflow, open a focused issue and branch
+from current `v4-series`; do not broaden PR #193.


### PR DESCRIPTION
## Summary
- narrow the remaining #181 front to native translated-text reflow in JournalDetail
- record the stale branch divergence, local-only commits, and predicted merge conflicts
- preserve current v4-series lifecycle/source-scoping behavior as the merge baseline
- remove #181 from the release-only closure batch until PR #193 passes in-game acceptance

## Validation
- git diff --check
- complete open-issue inventory compared with all 27 live open issues
- merge-tree simulation documented for the reflow branch

Documentation-only change; no plugin build required.