### PR TITLE
fix: stabilize MiniTalk regression for v4.2601.0717.0008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,33 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
-## Submitted Release `v4.2601.0715.1114`
+## Submitted Release `v4.2601.0717.0008`
+
+This package is prepared for submission and focuses on the urgent MiniTalk
+native-layout regression that resurfaced after the last release.
+
+Highlights:
+
+- restored MiniTalk plugin-owned bubble layout safely even when the game had
+  already repainted a new source line into the same live field, preventing
+  stale restoration from deforming later bubbles
+- normalized raw SeString line-break payload bytes and residual control-format
+  characters in both overlay rendering and MiniTalk native-text comparisons so
+  source overlays stop showing invalid glyph boxes and native reconciliation
+  stops treating wrapped text as a new untranslated line
+- aligned MiniTalk overlay bounds and native extra-wrap-width handling with the
+  resolved bubble container/background so original-text overlays wrap against
+  the visible balloon and recycled bubble instances keep stable native sizing
+
+## Published Release `v4.2601.0715.1114`
 
 This package delivers the first production-ready RTL presentation path and a
 broader stabilization of translated game-window, reference-text, and tooltip
 workflows.
+
+Published in `DalamudPluginsD17` via
+[PR #9026](https://github.com/goatcorp/DalamudPluginsD17/pull/9026) on
+2026-07-16.
 
 Highlights:
 

--- a/Echoglossian.Tests/MiniTalkWrapWidthHelperTests.cs
+++ b/Echoglossian.Tests/MiniTalkWrapWidthHelperTests.cs
@@ -1,0 +1,49 @@
+// <copyright file="MiniTalkWrapWidthHelperTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+/// Covers the MiniTalk-specific wrap-width policy used before native bubble
+/// reflow is applied.
+/// </summary>
+public sealed class MiniTalkWrapWidthHelperTests
+{
+    /// <summary>
+    /// Ensures no extra width is added when the shared helper already resolved a
+    /// wider visual container.
+    /// </summary>
+    [Fact]
+    public void ResolveAdditionalWrapWidth_WiderPreferredWrap_ReturnsZero()
+    {
+        var result = MiniTalkWrapWidthHelper.ResolveAdditionalWrapWidth(
+            currentTextWidth: 160,
+            preferredWrapWidth: 240,
+            leftPadding: 12,
+            rightPadding: 24);
+
+        Assert.Equal((ushort)0, result);
+    }
+
+    /// <summary>
+    /// Ensures the helper still contributes the larger side padding when the
+    /// shared wrap-width resolution did not already widen the node.
+    /// </summary>
+    [Fact]
+    public void ResolveAdditionalWrapWidth_UsesLargestPaddingWhenNoWiderContainerExists()
+    {
+        var result = MiniTalkWrapWidthHelper.ResolveAdditionalWrapWidth(
+            currentTextWidth: 180,
+            preferredWrapWidth: 180,
+            leftPadding: 12,
+            rightPadding: 28);
+
+        Assert.Equal((ushort)28, result);
+    }
+}

--- a/Echoglossian.Tests/NativeRuntimeSourceScopeTests.cs
+++ b/Echoglossian.Tests/NativeRuntimeSourceScopeTests.cs
@@ -258,6 +258,62 @@ public class NativeRuntimeSourceScopeTests
     }
 
     /// <summary>
+    ///     Ensures layout-only restoration can still reset plugin-owned geometry
+    ///     after the game repaints the original text into the same field.
+    /// </summary>
+    [Fact]
+    public void NativeMutation_LayoutOnlyRestore_IgnoresGameRepaint()
+    {
+        var restoredText = string.Empty;
+        var writeCount = 0;
+
+        var restored = NativeMutationOwnership.TryRestore(
+            "New game-owned source",
+            "Plugin replacement",
+            "Old game source",
+            restoreText: false,
+            restoredValue =>
+            {
+                writeCount++;
+                restoredText = restoredValue;
+            });
+
+        Assert.True(restored);
+        Assert.Equal(1, writeCount);
+        Assert.Equal("Old game source", restoredText);
+    }
+
+    /// <summary>
+    ///     Ensures geometry cleanup can still run after the game repaints a new
+    ///     source into a field that used to contain plugin-owned replacement
+    ///     text.
+    /// </summary>
+    [Fact]
+    public void NativeMutation_TextRestore_FallsBackToLayoutCleanupAfterGameRepaint()
+    {
+        var restoredText = string.Empty;
+        var textRestoreCount = 0;
+        var layoutRestoreCount = 0;
+
+        var restored = NativeMutationOwnership.TryRestoreWithLayoutFallback(
+            "New game-owned source",
+            "Plugin replacement",
+            "Old game source",
+            restoreText: true,
+            restoredValue =>
+            {
+                textRestoreCount++;
+                restoredText = restoredValue;
+            },
+            () => layoutRestoreCount++);
+
+        Assert.True(restored);
+        Assert.Equal(0, textRestoreCount);
+        Assert.Equal(1, layoutRestoreCount);
+        Assert.Equal(string.Empty, restoredText);
+    }
+
+    /// <summary>
     ///     Ensures DB-first restoration uses the replacement recorded for the
     ///     same stable node key rather than another node's equal translation.
     /// </summary>

--- a/Echoglossian.Tests/NativeTextComparisonNormalizationHelperTests.cs
+++ b/Echoglossian.Tests/NativeTextComparisonNormalizationHelperTests.cs
@@ -1,0 +1,64 @@
+// <copyright file="NativeTextComparisonNormalizationHelperTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers native text-comparison normalization for wrapped SeString payloads
+///     that leak raw line-break bytes into visible node text.
+/// </summary>
+public class NativeTextComparisonNormalizationHelperTests
+{
+    /// <summary>
+    ///     Ensures raw MiniTalk line-break payload bytes compare equal to the
+    ///     same translated line after native wrapping inserts control markers.
+    /// </summary>
+    [Fact]
+    public void NormalizeForComparison_RawSeStringLineBreakPayloadsCollapseForMatching()
+    {
+        const string wrappedVisibleText =
+            "N\u00e3o consigo ganhar \u0002\u0010\u0001\u0003nada... Estou " +
+            "\u0002\u0010\u0001\u0003come\u00e7ando a achar que " +
+            "\u0002\u0010\u0001\u0003os sorteios s\u00e3o " +
+            "\u0002\u0010\u0001\u0003fraudados.";
+        const string replacementText =
+            "N\u00e3o consigo ganhar nada... Estou come\u00e7ando a achar que os sorteios s\u00e3o fraudados.";
+
+        var normalizedVisible =
+            NativeTextComparisonNormalizationHelper.NormalizeForComparison(
+                wrappedVisibleText);
+        var normalizedReplacement =
+            NativeTextComparisonNormalizationHelper.NormalizeForComparison(
+                replacementText);
+
+        Assert.Equal(normalizedReplacement, normalizedVisible);
+    }
+
+    /// <summary>
+    ///     Ensures legacy carriage-return wraps and residual control bytes do
+    ///     not create a false source change during native reconciliation.
+    /// </summary>
+    [Fact]
+    public void NormalizeForComparison_CarriageReturnsAndControlBytesDoNotChangeMeaning()
+    {
+        const string wrappedVisibleText =
+            "Rig away! I've won\rthree drawings \u0002\u0010\u0001\u0003straight!\u0002";
+        const string replacementText =
+            "Rig away! I've won three drawings straight!";
+
+        var normalizedVisible =
+            NativeTextComparisonNormalizationHelper.NormalizeForComparison(
+                wrappedVisibleText);
+        var normalizedReplacement =
+            NativeTextComparisonNormalizationHelper.NormalizeForComparison(
+                replacementText);
+
+        Assert.Equal(normalizedReplacement, normalizedVisible);
+    }
+}

--- a/Echoglossian.Tests/TranslationOverlayBoundsCalculatorTests.cs
+++ b/Echoglossian.Tests/TranslationOverlayBoundsCalculatorTests.cs
@@ -1,0 +1,79 @@
+// <copyright file="TranslationOverlayBoundsCalculatorTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.UIOverlays.TranslationOverlay;
+
+using System.Numerics;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+/// Covers pure overlay-bounds calculations used before the ImGui layout pass.
+/// </summary>
+public sealed class TranslationOverlayBoundsCalculatorTests
+{
+    /// <summary>
+    /// Ensures MiniTalk anchors to the visual bubble bounds when they are wider
+    /// than the raw text node.
+    /// </summary>
+    [Fact]
+    public void CalculateMiniTalkBounds_UsesVisualBubbleWhenAvailable()
+    {
+        var result = TranslationOverlayBoundsCalculator.CalculateMiniTalkBounds(
+            new Vector2(640f, 480f),
+            new Vector2(72f, 28f),
+            1f,
+            1.05f,
+            new Vector2(612f, 468f),
+            new Vector2(188f, 70f));
+
+        Assert.Equal(612f, result.Position.X, 3);
+        Assert.Equal(468f, result.Position.Y, 3);
+        Assert.Equal(188f, result.Dimensions.X, 3);
+        Assert.Equal(70f, result.Dimensions.Y, 3);
+    }
+
+    /// <summary>
+    /// Ensures MiniTalk falls back to padded text bounds when no larger visual
+    /// bubble node is available.
+    /// </summary>
+    [Fact]
+    public void CalculateMiniTalkBounds_FallsBackToTextBoundsWhenVisualNodeIsTooSmall()
+    {
+        var result = TranslationOverlayBoundsCalculator.CalculateMiniTalkBounds(
+            new Vector2(640f, 480f),
+            new Vector2(100f, 24f),
+            1f,
+            1.05f,
+            new Vector2(642f, 481f),
+            new Vector2(80f, 20f));
+
+        Assert.Equal(640f, result.Position.X, 3);
+        Assert.Equal(480f, result.Position.Y, 3);
+        Assert.Equal(105f, result.Dimensions.X, 3);
+        Assert.Equal(25.2f, result.Dimensions.Y, 3);
+    }
+
+    /// <summary>
+    /// Ensures generic text-bounded overlays preserve the existing padding-based
+    /// sizing behavior used by toast surfaces.
+    /// </summary>
+    [Fact]
+    public void CalculateTextBounds_AppliesScaleAndPadding()
+    {
+        var result = TranslationOverlayBoundsCalculator.CalculateTextBounds(
+            new Vector2(300f, 140f),
+            new Vector2(200f, 30f),
+            1.5f,
+            1.05f);
+
+        Assert.Equal(300f, result.Position.X, 3);
+        Assert.Equal(140f, result.Position.Y, 3);
+        Assert.Equal(315f, result.Dimensions.X, 3);
+        Assert.Equal(47.25f, result.Dimensions.Y, 3);
+    }
+}

--- a/Echoglossian.Tests/TranslationOverlayRendererTests.cs
+++ b/Echoglossian.Tests/TranslationOverlayRendererTests.cs
@@ -111,4 +111,36 @@ public sealed class TranslationOverlayRendererTests
 
         Assert.Equal("Krile##overlay-42", actual);
     }
+
+    /// <summary>
+    /// Ensures raw SeString line-break payload markers become real overlay line
+    /// breaks instead of invalid glyph boxes.
+    /// </summary>
+    [Fact]
+    public void NormalizeOverlayText_RawSeStringLineBreaksBecomeNewLines()
+    {
+        const string rawText =
+            "N\u00e3o consigo \u0002\u0010\u0001\u0003ganhar nada... " +
+            "\u0002\u0010\u0001\u0003Estou \u0002\u0010\u0001\u0003come\u00e7ando.";
+
+        var actual = TranslationOverlayTextNormalizationHelper.NormalizeForDisplay(rawText);
+
+        Assert.Equal(
+            "N\u00e3o consigo \nganhar nada... \nEstou \ncome\u00e7ando.",
+            actual);
+    }
+
+    /// <summary>
+    /// Ensures carriage-return line endings and residual control bytes are
+    /// normalized before the overlay renderer measures or draws the text.
+    /// </summary>
+    [Fact]
+    public void NormalizeOverlayText_NormalizesCarriageReturnsAndDropsResidualControls()
+    {
+        const string rawText = "But... But... You said this\rwas your first time playing!\u0002";
+
+        var actual = TranslationOverlayTextNormalizationHelper.NormalizeForDisplay(rawText);
+
+        Assert.Equal("But... But... You said this\nwas your first time playing!", actual);
+    }
 }

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0715</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">1114</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0717</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">0008</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2494,17 +2494,8 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
-                Hosts debug-only automatic addon-probe watches that start on login for
-                selected addons with early hidden-state value.
-            </summary>
-            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
-            </summary>
-            <summary>
-                Handles the quest probe command used to inspect the complete quest data
-                shape from Lumina, the live quest progress resolver, and the current
-                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -3142,11 +3133,6 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
-        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
-            <summary>
-            Holds the currently active addon structure probe watch, if any.
-            </summary>
-        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -3313,11 +3299,6 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
-            <summary>
-                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -4880,109 +4861,6 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
-        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
-            <summary>
-                Ticks manual and automatic addon-probe watches, including the
-                debug-only login bootstrap for the default watch set.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
-            <summary>
-                Gets how many addon-probe watches are currently active across manual
-                and managed watch sets.
-            </summary>
-            <returns>The active probe-watch count.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
-            <summary>
-                Stops every active addon-probe watch known to the plugin.
-            </summary>
-            <param name="suppressAutoUntilLogout">
-                Whether the current login session should suppress the default
-                automatic watch set after the stop completes.
-            </param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
-            <summary>
-                Ticks the currently active manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
-            <summary>
-                Ticks every managed addon-probe watch and prunes the disposed ones.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic addon-probe watch set when the player
-                logs in, then resets the gate on logout.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic watch set used to capture early
-                structural state for pooled dialogue addons.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
-            <summary>
-                Starts one managed addon-probe watch and tracks it for later stop or
-                pruning.
-            </summary>
-            <param name="addonName">The addon name to watch.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="duration">How long the watch should stay alive.</param>
-            <param name="reason">The debug log reason attached to the startup.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
-            <summary>
-                Stops the current manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
-            <summary>
-                Stops every managed automatic addon-probe watch.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log so we can
-            inspect its live node tree, component roots, and likely overlay anchors.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
-            <summary>
-            Parses the addon probe command arguments into an addon name, optional index,
-            and optional watch duration.
-            </summary>
-            <param name="args">The raw command arguments.</param>
-            <returns>The addon name, index, and duration to probe.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
-            <summary>
-            Parses one addon-probe duration token such as "90s" or "15m".
-            </summary>
-            <param name="token">The raw duration token.</param>
-            <param name="duration">Receives the parsed duration.</param>
-            <returns><see langword="true"/> when the token parsed successfully.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
-            <summary>
-            Determines whether a token looks like an addon-probe duration even when the
-            value is outside the accepted range.
-            </summary>
-            <param name="token">The token to inspect.</param>
-            <returns><see langword="true"/> when the token resembles a duration.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
-            <summary>
-            Formats one addon-probe watch duration for chat feedback.
-            </summary>
-            <param name="duration">The duration to format.</param>
-            <returns>The human-readable duration string.</returns>
-        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -5254,102 +5132,6 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
-            <summary>
-                Handles the quest probe command.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
-            <summary>
-                Tries to resolve the quest probe target from either a quest id or a
-                quest name.
-            </summary>
-            <param name="input">The command argument.</param>
-            <param name="questIdText">The resolved quest id as text.</param>
-            <param name="questName">The resolved quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>True when the quest could be resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the quest data structure for inspection.
-            </summary>
-            <param name="questIdText">The quest id as text.</param>
-            <param name="questName">The quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the raw Lumina quest row properties.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs all rows from the quest text sheet, not just the live todo
-                entries, so we can inspect the full structure of the quest sheet.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
-            <summary>
-                Logs the QuestPlate rows currently stored for the quest.
-            </summary>
-            <param name="questIdText">The quest id text.</param>
-            <param name="questName">The quest name.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
-            <summary>
-                Logs the resolved live quest progression snapshot.
-            </summary>
-            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves a human-readable quest name from a quest row.
-            </summary>
-            <param name="questRow">The quest row.</param>
-            <returns>The resolved quest name, if available.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
-            <summary>
-                Converts quest text to a readable string for probe output.
-            </summary>
-            <param name="text">The quest text.</param>
-            <returns>The evaluated text string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
-            <summary>
-                Formats a probe value for log output.
-            </summary>
-            <param name="value">The value to format.</param>
-            <returns>A human-readable value string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Builds the raw quest sheet name used by the game files.
-            </summary>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>The quest text sheet name, if it can be derived.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest row id as text through reflection so the probe
-                stays compatible with generated sheet shapes.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest row id as text, or an empty string if unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest sheet identifier used to mount the quest text
-                sheet path.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -14674,6 +14456,43 @@
             <param name="restore">The native restore mutation.</param>
             <returns>True when the plugin still owned the field and restored it.</returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Common.NativeMutationOwnership.TryRestore(System.String,System.String,System.String,System.Boolean,System.Action{System.String})">
+            <summary>
+                Performs one guarded restore mutation, or restores layout-only state
+                immediately when the caller is not writing text back into the game.
+            </summary>
+            <param name="liveText">The current live field text.</param>
+            <param name="replacementText">The exact plugin-applied replacement.</param>
+            <param name="originalText">The original game-owned text.</param>
+            <param name="restoreText">
+                Whether the restore path will write text back into the live field.
+            </param>
+            <param name="restore">The native restore mutation.</param>
+            <returns>True when the restore mutation ran.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Common.NativeMutationOwnership.TryRestoreWithLayoutFallback(System.String,System.String,System.String,System.Boolean,System.Action{System.String},System.Action)">
+            <summary>
+                Performs one guarded text restore and falls back to layout-only
+                cleanup when the live field has already been repainted by the game.
+            </summary>
+            <param name="liveText">The current live field text.</param>
+            <param name="replacementText">The exact plugin-applied replacement.</param>
+            <param name="originalText">The original game-owned text.</param>
+            <param name="restoreText">
+                Whether the restore path is expected to write text back into the
+                live field.
+            </param>
+            <param name="restore">
+                The restore mutation to run when the plugin still owns the live
+                text, or when the caller is intentionally restoring without
+                touching live text ownership.
+            </param>
+            <param name="restoreLayoutOnly">
+                The layout-only cleanup to run when the live field no longer
+                contains the plugin-applied replacement.
+            </param>
+            <returns>True when one restore or layout cleanup mutation ran.</returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Common.DbFirstGameWindowRuntimeState">
             <summary>
                 Tracks the currently applied DB-first payload for one addon instance.
@@ -17604,7 +17423,7 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ResolveMiniTalkAdditionalWrapWidth(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ResolveMiniTalkAdditionalWrapWidth(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*)">
             <summary>
                 Resolves a small amount of extra wrap width from the live MiniTalk node
                 padding so translated lines can gain a bit of horizontal room without
@@ -21015,46 +20834,6 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
-            <summary>
-                Encapsulates the login-session gating rules for debug-only automatic
-                addon-probe watches.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
-            <summary>
-                Determines whether the current login session should start the default
-                automatic addon-probe watch set.
-            </summary>
-            <param name="isLoggedIn">Whether the client is currently logged in.</param>
-            <param name="hasStartedForCurrentLogin">
-                Whether the current login session already started its automatic probe
-                set.
-            </param>
-            <param name="isSuppressedUntilLogout">
-                Whether the user explicitly suppressed the automatic probe set until
-                the next logout.
-            </param>
-            <param name="activeManagedWatchCount">
-                How many managed automatic probe watches are currently alive.
-            </param>
-            <returns>
-                <see langword="true" /> when the automatic probe set should start.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
-            <summary>
-                Determines whether the automatic login-session gate should reset
-                because the player logged out.
-            </summary>
-            <param name="wasLoggedIn">
-                Whether the client was logged in on the previous tick.
-            </param>
-            <param name="isLoggedIn">Whether the client is logged in now.</param>
-            <returns>
-                <see langword="true" /> when the automatic probe gate should reset.
-            </returns>
-        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -22294,6 +22073,25 @@
             <param name="gameVersion">The current game version.</param>
             <returns>The canonical original text, or the visible text.</returns>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.MiniTalkWrapWidthHelper">
+            <summary>
+            Resolves MiniTalk-specific wrap-width adjustments without coupling tests to
+            live native nodes.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.MiniTalkWrapWidthHelper.ResolveAdditionalWrapWidth(System.UInt16,System.UInt16,System.Int32,System.Int32)">
+            <summary>
+            Determines whether MiniTalk should add any extra wrap width beyond the
+            shared container-derived preference.
+            </summary>
+            <param name="currentTextWidth">The current width assigned to the text node.</param>
+            <param name="preferredWrapWidth">
+            The width already resolved by the shared reflow helper.
+            </param>
+            <param name="leftPadding">The current left padding around the text node.</param>
+            <param name="rightPadding">The current right padding around the text node.</param>
+            <returns>The additional width that should be added to the wrap width.</returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.NativeReplacementTextNormalizationHelper">
             <summary>
                 Normalizes translated payload text for native replacement-only flows.
@@ -22334,6 +22132,21 @@
                 Tracks whether any normalized value differed from the source value.
             </param>
             <returns>The normalized payload map.</returns>
+        </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.NativeTextComparisonNormalizationHelper">
+            <summary>
+                Normalizes live native text for equality checks when wrapped SeString
+                payloads inject raw control bytes into visible node text.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextComparisonNormalizationHelper.NormalizeForComparison(System.String)">
+            <summary>
+                Collapses control-format noise and line-break payload bytes so two
+                native text values can be compared by meaning instead of raw wrapped
+                representation.
+            </summary>
+            <param name="text">The live or replacement text to normalize.</param>
+            <returns>The normalized comparison text.</returns>
         </member>
         <member name="T:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper">
             <summary>
@@ -25034,7 +24847,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -31414,6 +31227,65 @@
             <param name="request">The presentation request.</param>
             <returns>The resolved backend kind.</returns>
         </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBoundsCalculator">
+            <summary>
+            Calculates overlay anchor bounds from native node geometry without relying on
+            a live ImGui context.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBoundsCalculator.CalculateTextBounds(System.Numerics.Vector2,System.Numerics.Vector2,System.Single,System.Single)">
+            <summary>
+            Calculates padded bounds from a text node.
+            </summary>
+            <param name="textPosition">The screen position of the text node.</param>
+            <param name="textSize">The native width and height of the text node.</param>
+            <param name="scale">The owning addon's current scale.</param>
+            <param name="paddingScale">
+            The multiplier applied to the text-node size so overlays keep a small
+            amount of breathing room.
+            </param>
+            <returns>The resolved overlay bounds.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBoundsCalculator.CalculateMiniTalkBounds(System.Numerics.Vector2,System.Numerics.Vector2,System.Single,System.Single,System.Nullable{System.Numerics.Vector2},System.Nullable{System.Numerics.Vector2})">
+            <summary>
+            Calculates MiniTalk overlay bounds, preferring the surrounding bubble
+            geometry whenever it is large enough to represent the visible balloon.
+            </summary>
+            <param name="textPosition">The screen position of the text node.</param>
+            <param name="textSize">The native width and height of the text node.</param>
+            <param name="scale">The owning addon's current scale.</param>
+            <param name="paddingScale">
+            The multiplier applied to fallback text-node bounds.
+            </param>
+            <param name="visualNodePosition">
+            The screen position of the resolved bubble container or background.
+            </param>
+            <param name="visualNodeSize">
+            The native width and height of the resolved bubble container or
+            background.
+            </param>
+            <returns>The resolved overlay bounds.</returns>
+        </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBounds">
+            <summary>
+            Represents the screen bounds used to anchor one overlay.
+            </summary>
+            <param name="Position">The upper-left screen position.</param>
+            <param name="Dimensions">The width and height of the overlay anchor.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBounds.#ctor(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Represents the screen bounds used to anchor one overlay.
+            </summary>
+            <param name="Position">The upper-left screen position.</param>
+            <param name="Dimensions">The width and height of the overlay anchor.</param>
+        </member>
+        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBounds.Position">
+            <summary>The upper-left screen position.</summary>
+        </member>
+        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayBounds.Dimensions">
+            <summary>The width and height of the overlay anchor.</summary>
+        </member>
         <member name="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayLayoutRequest">
             <summary>
             Describes the ImGui-independent inputs required to place one overlay.
@@ -31707,6 +31579,21 @@
         </member>
         <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderResult.PresentationMode">
             <summary>The text backend used for the render.</summary>
+        </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayTextNormalizationHelper">
+            <summary>
+            Normalizes overlay text for display when raw native payload separators leak
+            into the source-facing overlay path.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayTextNormalizationHelper.NormalizeForDisplay(System.String)">
+            <summary>
+            Converts raw SeString line-break payloads and legacy carriage-return
+            separators into regular new lines while stripping residual non-printing
+            control bytes.
+            </summary>
+            <param name="text">The raw overlay text.</param>
+            <returns>The normalized display text.</returns>
         </member>
         <member name="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId">
             <summary>

--- a/NativeUI/AddonHandlers/Common/DbFirstGameWindowAddonHandler.cs
+++ b/NativeUI/AddonHandlers/Common/DbFirstGameWindowAddonHandler.cs
@@ -4265,6 +4265,91 @@ internal static class NativeMutationOwnership
         restore(originalText);
         return true;
     }
+
+    /// <summary>
+    ///     Performs one guarded restore mutation, or restores layout-only state
+    ///     immediately when the caller is not writing text back into the game.
+    /// </summary>
+    /// <param name="liveText">The current live field text.</param>
+    /// <param name="replacementText">The exact plugin-applied replacement.</param>
+    /// <param name="originalText">The original game-owned text.</param>
+    /// <param name="restoreText">
+    ///     Whether the restore path will write text back into the live field.
+    /// </param>
+    /// <param name="restore">The native restore mutation.</param>
+    /// <returns>True when the restore mutation ran.</returns>
+    public static bool TryRestore(
+        string? liveText,
+        string? replacementText,
+        string originalText,
+        bool restoreText,
+        Action<string> restore)
+    {
+        ArgumentNullException.ThrowIfNull(restore);
+
+        if (!restoreText)
+        {
+            restore(originalText);
+            return true;
+        }
+
+        return TryRestore(
+            liveText,
+            replacementText,
+            originalText,
+            restore);
+    }
+
+    /// <summary>
+    ///     Performs one guarded text restore and falls back to layout-only
+    ///     cleanup when the live field has already been repainted by the game.
+    /// </summary>
+    /// <param name="liveText">The current live field text.</param>
+    /// <param name="replacementText">The exact plugin-applied replacement.</param>
+    /// <param name="originalText">The original game-owned text.</param>
+    /// <param name="restoreText">
+    ///     Whether the restore path is expected to write text back into the
+    ///     live field.
+    /// </param>
+    /// <param name="restore">
+    ///     The restore mutation to run when the plugin still owns the live
+    ///     text, or when the caller is intentionally restoring without
+    ///     touching live text ownership.
+    /// </param>
+    /// <param name="restoreLayoutOnly">
+    ///     The layout-only cleanup to run when the live field no longer
+    ///     contains the plugin-applied replacement.
+    /// </param>
+    /// <returns>True when one restore or layout cleanup mutation ran.</returns>
+    public static bool TryRestoreWithLayoutFallback(
+        string? liveText,
+        string? replacementText,
+        string originalText,
+        bool restoreText,
+        Action<string> restore,
+        Action restoreLayoutOnly)
+    {
+        ArgumentNullException.ThrowIfNull(restore);
+        ArgumentNullException.ThrowIfNull(restoreLayoutOnly);
+
+        if (!restoreText)
+        {
+            restore(originalText);
+            return true;
+        }
+
+        if (TryRestore(
+                liveText,
+                replacementText,
+                originalText,
+                restore))
+        {
+            return true;
+        }
+
+        restoreLayoutOnly();
+        return true;
+    }
 }
 
 /// <summary>

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -398,14 +398,20 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       return;
     }
 
-    NativeMutationOwnership.TryRestore(
+    NativeMutationOwnership.TryRestoreWithLayoutFallback(
         this.ReadTextNode(textNode),
         replacementText,
         originalText,
+        restoreText,
         restoredText => NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
             snapshot,
             restoredText,
             restoreText,
+            restorePositions: false),
+        () => NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
+            snapshot,
+            originalText,
+            restoreText: false,
             restorePositions: false));
   }
 
@@ -600,7 +606,9 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
           textNode,
           replacementText,
           allowWidthGrowth: true,
-          additionalWrapWidth: this.ResolveMiniTalkAdditionalWrapWidth(textNode));
+          additionalWrapWidth: this.ResolveMiniTalkAdditionalWrapWidth(
+              addon,
+              textNode));
       if (layoutSnapshot != null)
       {
         lock (this.stateGate)
@@ -880,7 +888,9 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
   /// </summary>
   /// <param name="textNode">The live MiniTalk text node.</param>
   /// <returns>The additional wrap width suggested by the current bubble layout.</returns>
-  private unsafe ushort ResolveMiniTalkAdditionalWrapWidth(AtkTextNode* textNode)
+  private unsafe ushort ResolveMiniTalkAdditionalWrapWidth(
+      AtkUnitBase* addon,
+      AtkTextNode* textNode)
   {
     if (textNode == null)
     {
@@ -888,19 +898,40 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
     }
 
     var parentNode = textNode->AtkResNode.ParentNode;
+    var currentWidth = textNode->GetWidth();
+    var preferredWrapWidth = currentWidth;
+    if (NativeTextNodeLayoutHelper.TryResolveContainerNodes(
+            addon,
+            textNode,
+            out var containerNode,
+            out var backgroundNode))
+    {
+      preferredWrapWidth = NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(
+          textNode,
+          containerNode,
+          backgroundNode != null
+              ? &backgroundNode->AtkResNode
+              : null);
+    }
+
     var leftPadding = Math.Max(0, (int)textNode->AtkResNode.GetXShort());
     if (parentNode == null)
     {
-      return (ushort)Math.Min(ushort.MaxValue, leftPadding);
+      return MiniTalkWrapWidthHelper.ResolveAdditionalWrapWidth(
+          currentWidth,
+          preferredWrapWidth,
+          leftPadding,
+          0);
     }
 
-    var currentWidth = textNode->GetWidth();
     var rightPadding = Math.Max(
         0,
         parentNode->GetWidth() - leftPadding - currentWidth);
-    return (ushort)Math.Min(
-        ushort.MaxValue,
-        Math.Max(leftPadding, rightPadding));
+    return MiniTalkWrapWidthHelper.ResolveAdditionalWrapWidth(
+        currentWidth,
+        preferredWrapWidth,
+        leftPadding,
+        rightPadding);
   }
 
   /// <summary>
@@ -1233,12 +1264,8 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       return string.Empty;
     }
 
-    var replacementText = this.NormalizeForReplacement(text);
-    return string.Join(
-        " ",
-        replacementText.Split(
-            ['\r', '\n', '\t', ' '],
-            StringSplitOptions.RemoveEmptyEntries));
+    return NativeTextComparisonNormalizationHelper.NormalizeForComparison(
+        this.NormalizeForReplacement(text));
   }
 
   /// <summary>

--- a/NativeUI/Helpers/MiniTalkWrapWidthHelper.cs
+++ b/NativeUI/Helpers/MiniTalkWrapWidthHelper.cs
@@ -1,0 +1,42 @@
+// <copyright file="MiniTalkWrapWidthHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+/// Resolves MiniTalk-specific wrap-width adjustments without coupling tests to
+/// live native nodes.
+/// </summary>
+internal static class MiniTalkWrapWidthHelper
+{
+    /// <summary>
+    /// Determines whether MiniTalk should add any extra wrap width beyond the
+    /// shared container-derived preference.
+    /// </summary>
+    /// <param name="currentTextWidth">The current width assigned to the text node.</param>
+    /// <param name="preferredWrapWidth">
+    /// The width already resolved by the shared reflow helper.
+    /// </param>
+    /// <param name="leftPadding">The current left padding around the text node.</param>
+    /// <param name="rightPadding">The current right padding around the text node.</param>
+    /// <returns>The additional width that should be added to the wrap width.</returns>
+    public static ushort ResolveAdditionalWrapWidth(
+        ushort currentTextWidth,
+        ushort preferredWrapWidth,
+        int leftPadding,
+        int rightPadding)
+    {
+        if (preferredWrapWidth > currentTextWidth)
+        {
+            return 0;
+        }
+
+        return (ushort)Math.Min(
+            ushort.MaxValue,
+            Math.Max(
+                Math.Max(0, leftPadding),
+                Math.Max(0, rightPadding)));
+    }
+}

--- a/NativeUI/Helpers/NativeTextComparisonNormalizationHelper.cs
+++ b/NativeUI/Helpers/NativeTextComparisonNormalizationHelper.cs
@@ -1,0 +1,62 @@
+// <copyright file="NativeTextComparisonNormalizationHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Globalization;
+using System.Text;
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Normalizes live native text for equality checks when wrapped SeString
+///     payloads inject raw control bytes into visible node text.
+/// </summary>
+internal static class NativeTextComparisonNormalizationHelper
+{
+    /// <summary>
+    ///     Collapses control-format noise and line-break payload bytes so two
+    ///     native text values can be compared by meaning instead of raw wrapped
+    ///     representation.
+    /// </summary>
+    /// <param name="text">The live or replacement text to normalize.</param>
+    /// <returns>The normalized comparison text.</returns>
+    public static string NormalizeForComparison(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var normalizedText = text
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var builder = new StringBuilder(normalizedText.Length);
+
+        foreach (var character in normalizedText)
+        {
+            if (character == '\n' || character == '\t' || character == ' ')
+            {
+                builder.Append(' ');
+                continue;
+            }
+
+            var category = char.GetUnicodeCategory(character);
+            if (char.IsControl(character) ||
+                category == UnicodeCategory.Format ||
+                category == UnicodeCategory.PrivateUse)
+            {
+                builder.Append(' ');
+                continue;
+            }
+
+            builder.Append(character);
+        }
+
+        return string.Join(
+            " ",
+            builder.ToString().Split(
+                [' ', '\r', '\n', '\t'],
+                StringSplitOptions.RemoveEmptyEntries));
+    }
+}

--- a/UIOverlays/TranslationOverlay/TranslationOverlayBoundsCalculator.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayBoundsCalculator.cs
@@ -1,0 +1,100 @@
+// <copyright file="TranslationOverlayBoundsCalculator.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.UIOverlays.TranslationOverlay;
+
+/// <summary>
+/// Calculates overlay anchor bounds from native node geometry without relying on
+/// a live ImGui context.
+/// </summary>
+internal static class TranslationOverlayBoundsCalculator
+{
+    /// <summary>
+    /// Calculates padded bounds from a text node.
+    /// </summary>
+    /// <param name="textPosition">The screen position of the text node.</param>
+    /// <param name="textSize">The native width and height of the text node.</param>
+    /// <param name="scale">The owning addon's current scale.</param>
+    /// <param name="paddingScale">
+    /// The multiplier applied to the text-node size so overlays keep a small
+    /// amount of breathing room.
+    /// </param>
+    /// <returns>The resolved overlay bounds.</returns>
+    public static TranslationOverlayBounds CalculateTextBounds(
+        Vector2 textPosition,
+        Vector2 textSize,
+        float scale,
+        float paddingScale)
+    {
+        return new TranslationOverlayBounds(
+            textPosition,
+            new Vector2(
+                Math.Max(1f, textSize.X * scale * paddingScale),
+                Math.Max(1f, textSize.Y * scale * paddingScale)));
+    }
+
+    /// <summary>
+    /// Calculates MiniTalk overlay bounds, preferring the surrounding bubble
+    /// geometry whenever it is large enough to represent the visible balloon.
+    /// </summary>
+    /// <param name="textPosition">The screen position of the text node.</param>
+    /// <param name="textSize">The native width and height of the text node.</param>
+    /// <param name="scale">The owning addon's current scale.</param>
+    /// <param name="paddingScale">
+    /// The multiplier applied to fallback text-node bounds.
+    /// </param>
+    /// <param name="visualNodePosition">
+    /// The screen position of the resolved bubble container or background.
+    /// </param>
+    /// <param name="visualNodeSize">
+    /// The native width and height of the resolved bubble container or
+    /// background.
+    /// </param>
+    /// <returns>The resolved overlay bounds.</returns>
+    public static TranslationOverlayBounds CalculateMiniTalkBounds(
+        Vector2 textPosition,
+        Vector2 textSize,
+        float scale,
+        float paddingScale,
+        Vector2? visualNodePosition,
+        Vector2? visualNodeSize)
+    {
+        var fallbackBounds = CalculateTextBounds(
+            textPosition,
+            textSize,
+            scale,
+            paddingScale);
+
+        if (!visualNodePosition.HasValue ||
+            !visualNodeSize.HasValue ||
+            visualNodeSize.Value.X <= 0f ||
+            visualNodeSize.Value.Y <= 0f)
+        {
+            return fallbackBounds;
+        }
+
+        var visualDimensions = new Vector2(
+            Math.Max(1f, visualNodeSize.Value.X * scale),
+            Math.Max(1f, visualNodeSize.Value.Y * scale));
+        if (visualDimensions.X + 0.5f < fallbackBounds.Dimensions.X &&
+            visualDimensions.Y + 0.5f < fallbackBounds.Dimensions.Y)
+        {
+            return fallbackBounds;
+        }
+
+        return new TranslationOverlayBounds(
+            visualNodePosition.Value,
+            visualDimensions);
+    }
+}
+
+/// <summary>
+/// Represents the screen bounds used to anchor one overlay.
+/// </summary>
+/// <param name="Position">The upper-left screen position.</param>
+/// <param name="Dimensions">The width and height of the overlay anchor.</param>
+internal sealed record TranslationOverlayBounds(
+    Vector2 Position,
+    Vector2 Dimensions);

--- a/UIOverlays/TranslationOverlay/TranslationOverlayDrawer.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayDrawer.cs
@@ -3,6 +3,8 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using Echoglossian.UIOverlays.TranslationOverlay;
+
 namespace Echoglossian
 {
   public partial class Echoglossian
@@ -31,6 +33,10 @@ namespace Echoglossian
       }
 
       bool hasValidText = !string.IsNullOrWhiteSpace(translatedText);
+      var normalizedText = hasValidText
+          ? TranslationOverlayTextNormalizationHelper.NormalizeForDisplay(
+              translatedText)
+          : Resources.WaitingForTranslation;
 
       if (!this.TryEnterOverlaySemaphore(overlay.NameSemaphore))
       {
@@ -66,7 +72,7 @@ namespace Echoglossian
         }
 
         overlay.CurrentText =
-            hasValidText ? translatedText : Resources.WaitingForTranslation;
+            normalizedText;
         overlay.Display = hasValidText;
         overlay.CurrentTextId++;
       }
@@ -270,10 +276,13 @@ namespace Echoglossian
       }
 
       var paddingScale = 1.05f;
-      overlay.Position = new Vector2(textNode->ScreenX, textNode->ScreenY);
-      overlay.Dimensions = new Vector2(
-          Math.Max(1f, textNode->GetWidth() * addon->Scale * paddingScale),
-          Math.Max(1f, textNode->GetHeight() * addon->Scale * paddingScale));
+      var bounds = TranslationOverlayBoundsCalculator.CalculateTextBounds(
+          new Vector2(textNode->ScreenX, textNode->ScreenY),
+          new Vector2(textNode->GetWidth(), textNode->GetHeight()),
+          addon->Scale,
+          paddingScale);
+      overlay.Position = bounds.Position;
+      overlay.Dimensions = bounds.Dimensions;
     }
 
     /// <summary>
@@ -289,7 +298,9 @@ namespace Echoglossian
         return [];
       }
 
-      return text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+      return TranslationOverlayTextNormalizationHelper
+          .NormalizeForDisplay(text)
+          .Split('\n');
     }
 
     /// <summary>
@@ -309,7 +320,35 @@ namespace Echoglossian
       }
 
       var overlay = this.GetOrCreateMiniTalkBubbleOverlay(bubbleKey);
-      this.UpdateToastOverlayBounds(overlay, addon, textNode);
+      var paddingScale = 1.05f;
+      Vector2? visualNodePosition = null;
+      Vector2? visualNodeSize = null;
+
+      if (NativeTextNodeLayoutHelper.TryResolveContainerNodes(
+              addon,
+              textNode,
+              out var containerNode,
+              out var backgroundNode))
+      {
+        var visualNode = backgroundNode != null
+            ? &backgroundNode->AtkResNode
+            : containerNode;
+        if (visualNode != null)
+        {
+          visualNodePosition = new Vector2(visualNode->ScreenX, visualNode->ScreenY);
+          visualNodeSize = new Vector2(visualNode->GetWidth(), visualNode->GetHeight());
+        }
+      }
+
+      var bounds = TranslationOverlayBoundsCalculator.CalculateMiniTalkBounds(
+          new Vector2(textNode->ScreenX, textNode->ScreenY),
+          new Vector2(textNode->GetWidth(), textNode->GetHeight()),
+          addon->Scale,
+          paddingScale,
+          visualNodePosition,
+          visualNodeSize);
+      overlay.Position = bounds.Position;
+      overlay.Dimensions = bounds.Dimensions;
     }
 
     /// <summary>

--- a/UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs
@@ -67,7 +67,8 @@ internal sealed class TranslationOverlayRenderer : IDisposable
         overlay.Semaphore.Wait();
         try
         {
-            overlayText = overlay.CurrentText;
+            overlayText = TranslationOverlayTextNormalizationHelper.NormalizeForDisplay(
+                overlay.CurrentText);
             shouldDraw = !string.IsNullOrEmpty(overlayText) &&
                          overlayText != Resources.WaitingForTranslation;
         }
@@ -476,7 +477,9 @@ internal sealed class TranslationOverlayRenderer : IDisposable
     {
         return string.IsNullOrEmpty(text)
             ? []
-            : text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+            : TranslationOverlayTextNormalizationHelper
+                .NormalizeForDisplay(text)
+                .Split('\n');
     }
 
     /// <summary>

--- a/UIOverlays/TranslationOverlay/TranslationOverlayTextNormalizationHelper.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayTextNormalizationHelper.cs
@@ -1,0 +1,58 @@
+// <copyright file="TranslationOverlayTextNormalizationHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Globalization;
+using System.Text;
+
+namespace Echoglossian.UIOverlays.TranslationOverlay;
+
+/// <summary>
+/// Normalizes overlay text for display when raw native payload separators leak
+/// into the source-facing overlay path.
+/// </summary>
+internal static class TranslationOverlayTextNormalizationHelper
+{
+    private const string RawSeStringLineBreakPayload = "\u0002\u0010\u0001\u0003";
+
+    /// <summary>
+    /// Converts raw SeString line-break payloads and legacy carriage-return
+    /// separators into regular new lines while stripping residual non-printing
+    /// control bytes.
+    /// </summary>
+    /// <param name="text">The raw overlay text.</param>
+    /// <returns>The normalized display text.</returns>
+    public static string NormalizeForDisplay(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var normalizedText = text
+            .Replace(RawSeStringLineBreakPayload, "\n", StringComparison.Ordinal)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var builder = new StringBuilder(normalizedText.Length);
+
+        foreach (var character in normalizedText)
+        {
+            if (character == '\n' || character == '\t')
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            var category = char.GetUnicodeCategory(character);
+            if (char.IsControl(character) || category == UnicodeCategory.Format)
+            {
+                continue;
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

- fix the MiniTalk native bubble-regression path that was deforming recycled chat bubbles after replacement-mode use
- normalize raw SeString line-break payload bytes and residual control characters for source overlays and MiniTalk native-text reconciliation
- align MiniTalk overlay bounds and native extra-wrap-width handling with the resolved balloon container/background so wrapping follows the visible bubble instead of a narrow internal text node
- bump the submitted release metadata to `v4.2601.0717.0008` and correct `v4.2601.0715.1114` in `CHANGELOG.md` to the published state after `DalamudPluginsD17#9026`

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] `dotnet build Echoglossian.csproj -c Release --no-restore`
- [x] in-game verification was performed when runtime UI behavior changed

## AI Usage Disclosure

- [ ] `Assist`
- [ ] `Pair`
- [x] `Copilot`
- [ ] `Auto`

AI scope:
- tooling used: Codex
- files or areas most affected: MiniTalk native reflow/restore paths, overlay normalization/bounds, release metadata/tests
- how the result was reviewed/tested: manual diff review, local Debug/Test/Release validation, and in-game verification of the regression fix

## AI-Generated Assets Disclosure

AI-generated assets:
- none
