### PR TITLE
fix: correct OpenRouter live model endpoint

### DIFF
--- a/Translators/OpenRouter/OpenRouterModelManager.cs
+++ b/Translators/OpenRouter/OpenRouterModelManager.cs
@@ -35,7 +35,7 @@ public static class OpenRouterModelManager
         {
             var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"{baseUrl.TrimEnd('/')}/v1/models");
+                $"{baseUrl.Trim().TrimEnd('/')}/models");
             request.Headers.Authorization =
                 new AuthenticationHeaderValue("Bearer", apiKey);
 


### PR DESCRIPTION
## Summary

- The base URL already includes `/v1`, so adding it again caused an invalid models endpoint. This fixes Fetch Live Models.

<img width="1075" height="380" alt="image" src="https://github.com/user-attachments/assets/b754e3d8-0fbe-4417-9242-6bd1677e0907" />


## Validation

- [X] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [X] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [X] in-game verification was performed when runtime UI behavior changed

## AI Usage Disclosure

Required for submissions to the official Dalamud plugin repository when AI use
went beyond basic autocomplete or inline suggestions.

Select one when applicable:

- [ ] `Assist` — human-led work with AI used for specific tasks
- [X] `Pair` — active human/AI collaboration throughout
- [ ] `Copilot` — AI did most of the writing while the human planned and reviewed
- [ ] `Auto` — AI acted mostly autonomously with minimal human direction

If you selected one of the levels above, describe the scope briefly:

```text
AI scope:
- tooling used: Claude
- files or areas most affected: `OpenRouterModelManager`
- how the result was reviewed/tested: Ingame
```

If no AI was used, or only basic autocomplete / inline suggestions were used,
you do not need to disclose anything here.

## AI-Generated Assets Disclosure

If this PR adds or changes AI-generated icons, images, music, sounds, textures,
or other user-facing assets, disclose them here so the plugin description can be
updated if needed.

```text
AI-generated assets:
- none
```
