### PR TITLE
fix(docs): relax locale compatibility check

### DIFF
--- a/Echoglossian.Docs/scripts/check-locales.mjs
+++ b/Echoglossian.Docs/scripts/check-locales.mjs
@@ -23,14 +23,14 @@ export function validateLocales(resourceCultures, configuredLocales) {
   const resourceCultureSet = new Set(resourceCultures);
   const configuredLocaleSet = new Set(configuredLocales);
 
-  const missingInConfig = resourceCultures.filter(
+  const unpublishedResourceLocales = resourceCultures.filter(
     (culture) => !configuredLocaleSet.has(culture));
-  const unexpectedInConfig = configuredLocales.filter(
+  const configuredWithoutResourceLocales = configuredLocales.filter(
     (culture) => !resourceCultureSet.has(culture));
 
   return {
-    missingInConfig,
-    unexpectedInConfig,
+    unpublishedResourceLocales,
+    configuredWithoutResourceLocales,
   };
 }
 
@@ -40,20 +40,21 @@ async function main() {
   const configuredLocales = buildConfiguredLocales();
   const result = validateLocales(resourceCultures, configuredLocales);
 
-  if (result.missingInConfig.length > 0 || result.unexpectedInConfig.length > 0) {
-    if (result.missingInConfig.length > 0) {
-      console.error(`Missing locale config entries: ${result.missingInConfig.join(', ')}`);
-    }
+  if (result.unpublishedResourceLocales.length > 0) {
+    console.warn(
+      `Plugin resources include locales not yet published by docs: ${result.unpublishedResourceLocales.join(', ')}`,
+    );
+  }
 
-    if (result.unexpectedInConfig.length > 0) {
-      console.error(`Unexpected locale config entries: ${result.unexpectedInConfig.join(', ')}`);
-    }
-
+  if (result.configuredWithoutResourceLocales.length > 0) {
+    console.error(
+      `Unexpected locale config entries: ${result.configuredWithoutResourceLocales.join(', ')}`,
+    );
     process.exitCode = 1;
     return;
   }
 
-  console.log(`Locale config matches plugin resources: ${configuredLocales.join(', ')}`);
+  console.log(`Locale config is compatible with plugin resources: ${configuredLocales.join(', ')}`);
 }
 
 async function getResourceFileNames(directoryPath) {
@@ -81,6 +82,10 @@ function toCultureSegment(fileName) {
 function normalizeResourceLocaleKey(cultureSegment) {
   if (cultureSegment === 'root' || Object.hasOwn(locales, cultureSegment)) {
     return cultureSegment;
+  }
+
+  if (cultureSegment === 'en' || cultureSegment.startsWith('en-')) {
+    return 'root';
   }
 
   return cultureSegment.split('-')[0];

--- a/Echoglossian.Docs/scripts/check-locales.test.mjs
+++ b/Echoglossian.Docs/scripts/check-locales.test.mjs
@@ -18,6 +18,16 @@ test('collectResourceCultures maps neutral and regional resources', () => {
   assert.deepEqual(cultures, ['pt', 'pt-br', 'root', 'ru']);
 });
 
+test('collectResourceCultures folds English regional resources into the root locale', () => {
+  const cultures = collectResourceCultures([
+    'Resources.resx',
+    'Resources.en-US.resx',
+    'Resources.en-GB.resx',
+  ]);
+
+  assert.deepEqual(cultures, ['root']);
+});
+
 test('buildConfiguredLocales reflects the shared site locale list', () => {
   assert.deepEqual(buildConfiguredLocales(), [
     'da',
@@ -34,9 +44,19 @@ test('buildConfiguredLocales reflects the shared site locale list', () => {
   ]);
 });
 
-test('validateLocales reports missing and unexpected locales separately', () => {
+test('validateLocales reports unpublished plugin locales separately from invalid docs locales', () => {
   const result = validateLocales(['pt-br', 'root', 'ru'], ['root', 'ru', 'vi']);
 
-  assert.deepEqual(result.missingInConfig, ['pt-br']);
-  assert.deepEqual(result.unexpectedInConfig, ['vi']);
+  assert.deepEqual(result.unpublishedResourceLocales, ['pt-br']);
+  assert.deepEqual(result.configuredWithoutResourceLocales, ['vi']);
+});
+
+test('validateLocales allows plugin locales that are not published by docs yet', () => {
+  const result = validateLocales(
+    ['ca', 'de', 'nl', 'root'],
+    ['de', 'root'],
+  );
+
+  assert.deepEqual(result.unpublishedResourceLocales, ['ca', 'nl']);
+  assert.deepEqual(result.configuredWithoutResourceLocales, []);
 });


### PR DESCRIPTION
## Summary
- treat docs locale config as compatible when plugin resources include additional unpublished locales
- normalize regional English resource names like `en-US` back to the neutral `root` locale
- add regression tests for unpublished resource locales and English locale folding

## Root cause
The GitHub Pages `check:locales` step required an exact match between published docs locales and every `Properties/Resources*.resx` file. After locale-based resource renames introduced `Resources.ca-ES.resx`, `Resources.en-US.resx`, and `Resources.nl-NL.resx`, the check failed even though those locales were valid plugin resources and only the docs publication set lagged behind.

## Validation
- `npm.cmd run test:locales`
- `npm.cmd run check:locales`
- `npm.cmd run check`
- `npm.cmd run build`