### PR TITLE
docs: record v4.2601.0802.2355 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
-## Submitted Release `v4.2601.0802.2355`
+## Published Release `v4.2601.0802.2355`
 
-This package submits the large native UI translation runtime expansion merged
+This package ships the large native UI translation runtime expansion merged
 through [PR #240](https://github.com/lokinmodar/Echoglossian/pull/240), with a
 focus on broader surface coverage, persistence-backed reuse, and safer native
 and overlay presentation behavior.
+
+Published in `DalamudPluginsD17` via
+[PR #9125](https://github.com/goatcorp/DalamudPluginsD17/pull/9125) on
+2026-08-05.
 
 Highlights:
 
@@ -217,6 +221,10 @@ repository workflow.
 | 2026-06-01 | [PR #8789](https://github.com/goatcorp/DalamudPluginsD17/pull/8789) `v4.2601.0531.0115` | native dialogue/toast reflow stabilization, ToastGui route, and cross-surface isolation fixes |
 | 2026-07-11 | [PR #9006](https://github.com/goatcorp/DalamudPluginsD17/pull/9006) `v4.2601.0710.1250` | LLM structured dialogue/runtime release: custom OpenAI-compatible providers, live model refresh, debugger diagnostics, and prompt/history hardening |
 | 2026-07-12 | [PR #9009](https://github.com/goatcorp/DalamudPluginsD17/pull/9009) `v4.2601.0712.1140` | story-surface retranslation, debugger provenance, and reusable DB inspection tooling |
+| 2026-07-16 | [PR #9026](https://github.com/goatcorp/DalamudPluginsD17/pull/9026) `v4.2601.0715.1114` | RTL overlay presentation plus game-window, reference-text, and tooltip stabilization |
+| 2026-07-17 | [PR #9027](https://github.com/goatcorp/DalamudPluginsD17/pull/9027) `v4.2601.0717.0008` | urgent MiniTalk native-layout stabilization |
+| 2026-07-19 | [PR #9031](https://github.com/goatcorp/DalamudPluginsD17/pull/9031) `v4.2601.0718.2006` | OpenRouter live-model refresh and hosted preview infrastructure follow-up |
+| 2026-08-05 | [PR #9125](https://github.com/goatcorp/DalamudPluginsD17/pull/9125) `v4.2601.0802.2355` | broad native UI runtime expansion across selection dialogs, tooltips, quest surfaces, nameplates, toasts, persistence, and diagnostics |
 
 ## Pre-Official History
 

--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -1,6 +1,6 @@
 # GitHub Issue Backlog
 
-Snapshot date: 2026-07-29
+Snapshot date: 2026-08-05
 
 This document is the operational snapshot for open issues in
 [`lokinmodar/Echoglossian`](https://github.com/lokinmodar/Echoglossian/issues).
@@ -9,23 +9,24 @@ release history belongs in [`CHANGELOG.md`](../CHANGELOG.md), not in this file.
 
 ## Published Release Baseline
 
-- Release: [`v4.2601.0718.2006`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0718.2006)
-- Product commit: `f0b4dec9265b5cf350464974329d4dae4fbc1dd8`
-- Official submission: [`goatcorp/DalamudPluginsD17#9031`](https://github.com/goatcorp/DalamudPluginsD17/pull/9031)
-- D17 status: approved and merged on 2026-07-19
-- D17 merge commit: `a265f794041887c9848b81dcd30a310d5863f8bc`
-- Open issues at the published-release baseline: 25
-- Open issues at the current audit head: 25
-- Focused open issues besides the living tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12): 24
+- Release: [`v4.2601.0802.2355`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0802.2355)
+- Product commit: `0aa0b9658f63acfece1e41b7b544fe38cd93c12b`
+- Official submission: [`goatcorp/DalamudPluginsD17#9125`](https://github.com/goatcorp/DalamudPluginsD17/pull/9125)
+- D17 status: approved and merged on 2026-08-05
+- D17 merge commit: `19025aac1a8db180b78ead8a3ba0b0ddebaf557e`
+- Open issues after post-publication triage: 18
+- Open issues at the current audit head: 18
+- Focused open issues besides the living tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12): 17
 
 ## Current `v4-series` Delta
 
-- Audit head: `origin/v4-series` at `647d86fd6f5140880a9edc3e69791e525152ee2b`
-- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0718.2006` at `f0b4dec9265b5cf350464974329d4dae4fbc1dd8`
-- The only newer commit on `v4-series` is `647d86f` (`chore: ignore local worktrees`), which is repository hygiene and does not change the shipped runtime baseline.
+- Audit head: `origin/v4-series` at `328d0d2b1239b48a36a69e64af42823887ed472a`
+- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0802.2355` at `0aa0b9658f63acfece1e41b7b544fe38cd93c12b`
+- Newer `v4-series` commits are documentation dependency, localization-resource, and locale-check maintenance; they do not supersede the published runtime baseline.
 - Issue [#12](https://github.com/lokinmodar/Echoglossian/issues/12) remains the living known-issues tracker and should stay aligned with this document whenever focused issue state changes materially.
-- The 2026-07-18 focused triage pass remains the latest material issue-state change: it narrowed [#15](https://github.com/lokinmodar/Echoglossian/issues/15), [#68](https://github.com/lokinmodar/Echoglossian/issues/68), [#171](https://github.com/lokinmodar/Echoglossian/issues/171), and [#172](https://github.com/lokinmodar/Echoglossian/issues/172), created [#230](https://github.com/lokinmodar/Echoglossian/issues/230) through [#234](https://github.com/lokinmodar/Echoglossian/issues/234), and closed [#181](https://github.com/lokinmodar/Echoglossian/issues/181).
-- As of 2026-07-29, no additional issues have opened or closed since that pass; the grouped inventory below remains the current countable backlog.
+- Publication of `v4.2601.0802.2355` completed [#15](https://github.com/lokinmodar/Echoglossian/issues/15), [#68](https://github.com/lokinmodar/Echoglossian/issues/68), [#103](https://github.com/lokinmodar/Echoglossian/issues/103), [#206](https://github.com/lokinmodar/Echoglossian/issues/206), [#217](https://github.com/lokinmodar/Echoglossian/issues/217), and [#230](https://github.com/lokinmodar/Echoglossian/issues/230) through [#234](https://github.com/lokinmodar/Echoglossian/issues/234).
+- [#68](https://github.com/lokinmodar/Echoglossian/issues/68) is complete because `CutSceneSelectString` is shipped and the historical `ChatBubble` surface corresponds to the production `_MiniTalk` / `MiniTalk` runtime.
+- New focused work opened as [#237](https://github.com/lokinmodar/Echoglossian/issues/237) through [#239](https://github.com/lokinmodar/Echoglossian/issues/239).
 - Draft PR [#193](https://github.com/lokinmodar/Echoglossian/pull/193) remains open only as a separate follow-up if the narrower native `JournalDetail` translated-text reflow work is still wanted.
 - The open-issue inventory remains grouped by problem type instead of by workflow state so the remaining work is easier to prioritize by subsystem.
 
@@ -36,6 +37,16 @@ most relevant resolved fronts to reference during follow-up triage.
 
 | Issue | Published resolution |
 | --- | --- |
+| [#15 ActionDetail / ItemDetail tooltip translation](https://github.com/lokinmodar/Echoglossian/issues/15) | The DB-first structured tooltip flow is active in production with cache-gap prefetch, source-id binding, atomic detail updates, and native/overlay ownership safeguards. |
+| [#68 Selection dialogs and other specific surfaces](https://github.com/lokinmodar/Echoglossian/issues/68) | `SelectYesNo`, `SelectOk`, `SelectString`, `SelectIconString`, and `CutSceneSelectString` are shipped; the historical `ChatBubble` entry is covered by the production `_MiniTalk` / `MiniTalk` runtime. |
+| [#103 Interactible WorldObjects](https://github.com/lokinmodar/Echoglossian/issues/103) | Eligible nameplate/world-object presentation now supports native translation plus distance-aware overlay fallback with configurable scaling, fading, and cutoff behavior. |
+| [#206 `{targetLanguage}` preview](https://github.com/lokinmodar/Echoglossian/issues/206) | Prompt preview and runtime target-language state now use the configured target language instead of falling back to Japanese. |
+| [#217 Diacritics fallback metadata](https://github.com/lokinmodar/Echoglossian/issues/217) | Native replacement eligibility is represented by explicit language metadata while remaining opt-in and excluded from overlay and texture-backed presentation. |
+| [#230 Position-aware toast controls](https://github.com/lokinmodar/Echoglossian/issues/230) | Toast behavior can be configured by toast type and runtime placement without breaking native, overlay, or swap semantics. |
+| [#231 Quest retriggering, cache invalidation, and UI reapplication](https://github.com/lokinmodar/Echoglossian/issues/231) | Quest-family state refreshes across acceptance, progression, language changes, recycled addons, and partial translation availability. |
+| [#232 Remaining `Journal*` and recommendation-family surfaces](https://github.com/lokinmodar/Echoglossian/issues/232) | Translation application was restored across the remaining Journal, recommendation, scenario, and related quest consumers. |
+| [#233 Surface-aware translation logging](https://github.com/lokinmodar/Echoglossian/issues/233) | Translation diagnostics identify the requesting surface/runtime for requests, reuse, skips, failures, and application decisions. |
+| [#234 Google AI Studio compatibility](https://github.com/lokinmodar/Echoglossian/issues/234) | The Google provider audit, configuration-label clarification, and compatible model-selection follow-up are published. |
 | [#139 Arabic Translation Support](https://github.com/lokinmodar/Echoglossian/issues/139) | Plugin-owned overlays and hover tooltips support Arabic and other RTL or complex-script languages through texture-backed shaping, bidi ordering, right alignment, adaptive sizing, and bounded caches. Native FFXIV UI RTL remains separate Phase B research. |
 | [#174 Retranslate saved texts](https://github.com/lokinmodar/Echoglossian/issues/174) | Translation reuse and persistence are scoped by client source language, target language, and engine policy. Language changes invalidate incompatible runtime state and permit explicit retranslation. |
 | [#189 MSQ bar and mission windows untranslated](https://github.com/lokinmodar/Echoglossian/issues/189) | Quest-family handlers use source-scoped state and incremental application across `ScenarioTree`, `RecommendList`, `JournalAccept`, `JournalDetail`, and `ToDoList`. |
@@ -64,16 +75,13 @@ most relevant resolved fronts to reference during follow-up triage.
 | [#104 Unending Journey](https://github.com/lokinmodar/Echoglossian/issues/104) | Planned quest-surface coverage remains undelivered. |
 | [#171 DeepSeek, mission text, layout, and tracker progression](https://github.com/lokinmodar/Echoglossian/issues/171) | After the 2026-07-18 split, keep this mixed issue focused on the DeepSeek authentication/runtime side and any remaining mission-text symptom that still lacks its own isolated repro. |
 | [#172 Google layout and untranslated quest/FATE text](https://github.com/lokinmodar/Echoglossian/issues/172) | After the 2026-07-18 split, keep this mixed issue only for still-unsplit quest/FATE or selection-dialog repros. The tracker-progression and Journal/recommendation follow-up work moved out to focused issues. |
-| [#231 Quest retriggering, cache invalidation, and UI reapplication](https://github.com/lokinmodar/Echoglossian/issues/231) | New focused bug for quest acceptance, progression, cache refresh, and consumer reapply behavior that currently stalls after the first partial translation pass. |
-| [#232 Remaining `Journal*` and recommendation-family quest surfaces](https://github.com/lokinmodar/Echoglossian/issues/232) | New focused bug for the remaining `Journal*` and `RecommendList`-style surfaces that still do not reliably apply translated quest text. |
+| [#237 Guildleves](https://github.com/lokinmodar/Echoglossian/issues/237) | Add translation coverage for the `GuildLeve` addon with current persistence, cache, and native/overlay/swap semantics. |
 
-### Surface Coverage And Interaction UIs
+### Reference-Text And Sheet Coverage
 
 | Issue | Current reason |
 | --- | --- |
-| [#15 ActionDetail / ItemDetail tooltip translation](https://github.com/lokinmodar/Echoglossian/issues/15) | Structured tooltip runtime exists, but `ActionDetail` and `ItemDetail` still need real validation, stabilization, and activation for release use. |
-| [#68 Selection dialogs and other specific surfaces](https://github.com/lokinmodar/Echoglossian/issues/68) | Generic coverage tracker is now intentionally narrowed to `SelectYesNo`, `SelectOk`, `SelectString`, `CutSceneSelectString`, and `ChatBubble`. |
-| [#103 Interactible WorldObjects](https://github.com/lokinmodar/Echoglossian/issues/103) | No delivered implementation. |
+| [#238 Triple Triad card text](https://github.com/lokinmodar/Echoglossian/issues/238) | Add sheet-backed translation and version-aware reuse for names and descriptions from `TripleTriadCard`. |
 
 ### Overlay, Toast, And Presentation Behavior
 
@@ -81,8 +89,6 @@ most relevant resolved fronts to reference during follow-up triage.
 | --- | --- |
 | [#167 Overlay-only dialogue glitches](https://github.com/lokinmodar/Echoglossian/issues/167) | Still awaiting a fresh retest with display mode, screenshot, and log if native text continues to change or glitch. |
 | [#175 Overlay problem](https://github.com/lokinmodar/Echoglossian/issues/175) | Still awaiting a fresh retest with saved display mode, affected addon, and startup/runtime log if the overlay remains absent. |
-| [#217 Diacritics fallback metadata](https://github.com/lokinmodar/Echoglossian/issues/217) | Canonical future task for opt-in native replacement fallback metadata. Overlay and tooltip paths must remain unaffected. |
-| [#230 Position-aware toast controls](https://github.com/lokinmodar/Echoglossian/issues/230) | New focused enhancement for independent toast treatment by toast type and runtime placement, including separate overlay/native/swap behavior and per-placement styling/offset controls. |
 
 ### Translation Engines, Prompts, And Provider Support
 
@@ -91,11 +97,9 @@ most relevant resolved fronts to reference during follow-up triage.
 | [#148 Structured LLM input/output](https://github.com/lokinmodar/Echoglossian/issues/148) | Foundation work exists, but the requested cross-provider glossary and metadata contract is incomplete. |
 | [#176 Local LLM latency](https://github.com/lokinmodar/Echoglossian/issues/176) | The reported approximately one-second overhead still needs focused profiling and acceptance evidence. |
 | [#203 Echoglossian not translating](https://github.com/lokinmodar/Echoglossian/issues/203) | Still awaiting a fresh engine-by-engine retest with client language, target language, surface, and log evidence. |
-| [#206 `{targetLanguage}` preview](https://github.com/lokinmodar/Echoglossian/issues/206) | Confirmed current defect: the prompt editor preview state initializes the target language as `Japanese`. This was not fixed by #204. |
 | [#209 Dialogue context controls](https://github.com/lokinmodar/Echoglossian/issues/209) | User-facing disable or limit controls for local LLM context are not implemented. |
 | [#212 DeepL `TooManyRequests`](https://github.com/lokinmodar/Echoglossian/issues/212) | The supplied log indicates provider rate limiting. Backoff, classification, and user-facing behavior need focused triage. |
 | [#214 First dialogue speaker context](https://github.com/lokinmodar/Echoglossian/issues/214) | First-line speaker context correctness remains unresolved. |
-| [#234 Google AI Studio compatibility](https://github.com/lokinmodar/Echoglossian/issues/234) | New enhancement to verify whether the current Gemini path truly covers Google AI Studio and to add a separate engine if it does not. |
 
 ### Compatibility, Diagnostics, And UX Polish
 
@@ -104,26 +108,27 @@ most relevant resolved fronts to reference during follow-up triage.
 | [#173 CharacterPanelRefined incompatibility](https://github.com/lokinmodar/Echoglossian/issues/173) | Originating user report remains unverified against the compatibility work requested by #179. |
 | [#179 CharacterPanelRefined analysis](https://github.com/lokinmodar/Echoglossian/issues/179) | Explicit compatibility engineering task remains incomplete. |
 | [#192 Configuration screenshots](https://github.com/lokinmodar/Echoglossian/issues/192) | Documentation and UI enhancement has not been implemented. |
-| [#233 Surface-aware translation logging](https://github.com/lokinmodar/Echoglossian/issues/233) | New diagnostics enhancement so logs can identify which surface/runtime triggered translation requests, cache reuse, skips, failures, and applies. |
+| [#239 Generic batched translation fallback hardening](https://github.com/lokinmodar/Echoglossian/issues/239) | The published narrow fix rejects unchanged batch echoes, but structured transport, provider-echo classification, and negative-result cooldown remain open. |
 
 ## Complete Open-Issue Inventory
 
-This table is the countable audit of all 25 open issues at the snapshot date, including the living meta-tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12).
+This table is the countable audit of all 18 open issues at the snapshot date, including the living meta-tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12).
 
 | Problem type | Issues | Count |
 | --- | --- | ---: |
 | Meta tracking and living documentation | #12 | 1 |
-| Quest-family runtime and surfaces | #104, #171, #172, #231, #232 | 5 |
-| Surface coverage and interaction UIs | #15, #68, #103 | 3 |
-| Overlay, toast, and presentation behavior | #167, #175, #217, #230 | 4 |
-| Translation engines, prompts, and provider support | #148, #176, #203, #206, #209, #212, #214, #234 | 8 |
-| Compatibility, diagnostics, and UX polish | #173, #179, #192, #233 | 4 |
-| **Total open at snapshot** |  | **25** |
+| Quest-family runtime and surfaces | #104, #171, #172, #237 | 4 |
+| Reference-text and sheet coverage | #238 | 1 |
+| Overlay and presentation behavior | #167, #175 | 2 |
+| Translation engines, prompts, and provider support | #148, #176, #203, #209, #212, #214 | 6 |
+| Compatibility, diagnostics, and UX polish | #173, #179, #192, #239 | 4 |
+| **Total open at snapshot** |  | **18** |
 
 ## Next Actions
 
-1. Prioritize the new focused quest issues [#231](https://github.com/lokinmodar/Echoglossian/issues/231) and [#232](https://github.com/lokinmodar/Echoglossian/issues/232) so the remaining mixed work in [#171](https://github.com/lokinmodar/Echoglossian/issues/171) and [#172](https://github.com/lokinmodar/Echoglossian/issues/172) can continue shrinking.
-2. Keep [#68](https://github.com/lokinmodar/Echoglossian/issues/68) narrowed to selection dialogs and similar surfaces, while tooltip activation remains isolated in [#15](https://github.com/lokinmodar/Echoglossian/issues/15).
-3. Decide whether draft PR [#193](https://github.com/lokinmodar/Echoglossian/pull/193) should be reconciled, retargeted, or closed now that [#181](https://github.com/lokinmodar/Echoglossian/issues/181) itself is resolved.
-4. Monitor reporter retests on [#167](https://github.com/lokinmodar/Echoglossian/issues/167), [#175](https://github.com/lokinmodar/Echoglossian/issues/175), and [#203](https://github.com/lokinmodar/Echoglossian/issues/203) and close only after the exact symptom is validated or replaced by a more focused issue.
-5. Re-run the open-issue audit and refresh [#12](https://github.com/lokinmodar/Echoglossian/issues/12) whenever issue state changes again or when the next quest-surface or provider-support tranche lands.
+1. Keep the remaining mixed symptoms in [#171](https://github.com/lokinmodar/Echoglossian/issues/171) and [#172](https://github.com/lokinmodar/Echoglossian/issues/172) narrowed now that the focused quest-runtime issues shipped.
+2. Prioritize the new concrete coverage work in [#237](https://github.com/lokinmodar/Echoglossian/issues/237) and [#238](https://github.com/lokinmodar/Echoglossian/issues/238).
+3. Continue the structural remediation in [#239](https://github.com/lokinmodar/Echoglossian/issues/239) beyond the already published unchanged-batch fallback fix.
+4. Decide whether draft PR [#193](https://github.com/lokinmodar/Echoglossian/pull/193) should be reconciled, retargeted, or closed now that [#181](https://github.com/lokinmodar/Echoglossian/issues/181) itself is resolved.
+5. Monitor reporter retests on [#167](https://github.com/lokinmodar/Echoglossian/issues/167), [#175](https://github.com/lokinmodar/Echoglossian/issues/175), and [#203](https://github.com/lokinmodar/Echoglossian/issues/203) and close only after the exact symptom is validated or replaced by a more focused issue.
+6. Re-run the open-issue audit and refresh [#12](https://github.com/lokinmodar/Echoglossian/issues/12) whenever issue state changes again or when the next runtime or provider-support tranche lands.


### PR DESCRIPTION
## Summary

- mark `v4.2601.0802.2355` as published through [DalamudPluginsD17 #9125](https://github.com/goatcorp/DalamudPluginsD17/pull/9125) on 2026-08-05
- refresh the issue backlog to the current published baseline and exact 18-issue open inventory
- document the published resolution of issues #15, #68, #103, #206, #217, and #230 through #234
- record that the historical `ChatBubble` item in #68 is implemented by the production `_MiniTalk` / `MiniTalk` runtime and that `CutSceneSelectString` is already shipped

## GitHub issue follow-up

- added publication comments to all release-resolved issue fronts
- closed #206 and #68 as completed
- updated the living tracker #12 to 17 focused open issues plus the tracker itself

## Validation

- `dotnet build Echoglossian.sln -c Debug --no-restore` — passed
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build` — 1096 passed, 0 failed
- `git diff --check` — passed
- compared the backlog inventory with the current GitHub open-issue list: 18 total, 17 excluding #12

## AI Usage Disclosure

AI Usage Disclosure: Pair

Used AI for post-release audit, issue-comment drafting, tracker reconciliation, and documentation updates. The plugin author corrected the `ChatBubble`/`_MiniTalk` mapping and confirmed that `CutSceneSelectString` is already in production; the final repository and GitHub states were re-audited after that correction.

AI-generated assets: none.