### PR TITLE
fix(#248): honor detail overlay formatting controls

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -1286,6 +1286,34 @@ public class Config : IPluginConfiguration
   /// <summary>Manual maximum width used by the Tooltip addon anchored overlay.</summary>
   [DefaultValue(720f)] public float TooltipAddonOverlayManualMaxWidth = 720f;
 
+  /// <summary>Text color used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(typeof(Vector3), "1, 1, 1")]
+  public Vector3 ActionItemDetailOverlayTextColor = new(1f, 1f, 1f);
+
+  /// <summary>Background color used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(typeof(Vector3), "0.08, 0.08, 0.08")]
+  public Vector3 ActionItemDetailOverlayBackgroundColor = new(0.08f, 0.08f, 0.08f);
+
+  /// <summary>Background opacity used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(0.95f)] public float ActionItemDetailOverlayBackgroundOpacity = 0.95f;
+
+  /// <summary>Font scale adjustment used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(0.65f)] public float ActionItemDetailOverlayFontScaleAdjustment = 0.65f;
+
+  /// <summary>Line-height scale used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(0.9f)] public float ActionItemDetailOverlayLineHeightScale = 0.9f;
+
+  /// <summary>Padding applied by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(8f)] public float ActionItemDetailOverlayPadding = 8f;
+
+  /// <summary>Width mode used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(TooltipAddonOverlayMaxWidthMode.MatchNative)]
+  public TooltipAddonOverlayMaxWidthMode ActionItemDetailOverlayMaxWidthMode =
+      TooltipAddonOverlayMaxWidthMode.MatchNative;
+
+  /// <summary>Manual maximum width used by ActionDetail and ItemDetail overlays.</summary>
+  [DefaultValue(720f)] public float ActionItemDetailOverlayManualMaxWidth = 720f;
+
   /// <summary>Text color used by Echoglossian hover tooltips.</summary>
   [DefaultValue(typeof(Vector3), "1, 1, 1")]
   public Vector3 HoverTooltipTextColor = new(1f, 1f, 1f);

--- a/Echoglossian.Tests/ConfigDefaultsTests.cs
+++ b/Echoglossian.Tests/ConfigDefaultsTests.cs
@@ -82,6 +82,22 @@ public class ConfigDefaultsTests
     }
 
     /// <summary>
+    ///     Ensures ActionDetail and ItemDetail overlays default to the same
+    ///     smaller scale as the Tooltip addon overlay bucket so detail text
+    ///     stays visually aligned with the native surfaces they anchor to.
+    /// </summary>
+    [Fact]
+    public void ActionItemDetailOverlayFontScaleAdjustment_DefaultsToSixtyFivePercent()
+    {
+        var config = new Config();
+        var field = typeof(Config).GetField(
+            nameof(Config.ActionItemDetailOverlayFontScaleAdjustment));
+
+        Assert.NotNull(field);
+        Assert.Equal(0.65f, Assert.IsType<float>(field!.GetValue(config)));
+    }
+
+    /// <summary>
     ///     Ensures hover tooltips can use a wider layout cap than the legacy
     ///     hardcoded width so long RTL paragraphs do not collapse into a tall
     ///     column.

--- a/Echoglossian.Tests/TooltipAddonConfigContractTests.cs
+++ b/Echoglossian.Tests/TooltipAddonConfigContractTests.cs
@@ -54,6 +54,36 @@ public sealed class TooltipAddonConfigContractTests
     }
 
     /// <summary>
+    ///     Ensures ActionDetail and ItemDetail overlays keep their own shared
+    ///     persisted appearance settings instead of reusing the Tooltip addon
+    ///     overlay bucket.
+    /// </summary>
+    [Fact]
+    public void Config_DefinesDedicatedActionItemDetailOverlaySettings()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "Config.cs"));
+
+        Assert.Contains(
+            "ActionItemDetailOverlayTextColor",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ActionItemDetailOverlayFontScaleAdjustment",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ActionItemDetailOverlayLineHeightScale",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ActionItemDetailOverlayMaxWidthMode",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     ///     Ensures the tooltip settings UI exposes the dedicated Tooltip addon
     ///     controls separately from ActionDetail and ItemDetail.
     /// </summary>
@@ -70,6 +100,35 @@ public sealed class TooltipAddonConfigContractTests
         Assert.Contains("config.TranslateTooltipAddon", source, StringComparison.Ordinal);
         Assert.Contains("config.TooltipAddonTranslationDisplayMode", source, StringComparison.Ordinal);
         Assert.Contains("Resources.TranslateTooltipAddonLabel", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Ensures the tooltip settings UI exposes a dedicated ActionDetail /
+    ///     ItemDetail overlay appearance bucket instead of relying on the
+    ///     hover-tooltip controls.
+    /// </summary>
+    [Fact]
+    public void TooltipTab_RendersDedicatedActionItemDetailOverlayControls()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "PluginUI",
+            "Tabs",
+            "TooltipTab.cs"));
+
+        Assert.Contains(
+            "Resources.ActionItemDetailOverlayAppearanceSectionLabel",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "config.ActionItemDetailOverlayFontScaleAdjustment",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "config.ActionItemDetailOverlayMaxWidthMode",
+            source,
+            StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/TranslationOverlayRendererContractTests.cs
+++ b/Echoglossian.Tests/TranslationOverlayRendererContractTests.cs
@@ -40,6 +40,38 @@ public sealed class TranslationOverlayRendererContractTests
     }
 
     /// <summary>
+    ///     Ensures ActionDetail and ItemDetail overlays use their dedicated
+    ///     persisted override bucket for texture width and line-height instead
+    ///     of falling through to the hover-tooltip or Tooltip addon paths.
+    /// </summary>
+    [Fact]
+    public void StructuredDetailOverlays_UseDedicatedRendererOverrideBucket()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            this.RepositoryRoot,
+            "UIOverlays",
+            "TranslationOverlay",
+            "TranslationOverlayRenderer.cs"));
+
+        Assert.Contains(
+            "TranslationOverlaySurfaceId.ActionDetail",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "TranslationOverlaySurfaceId.ItemDetail",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ActionItemDetailOverlayPadding",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ActionItemDetailOverlayLineHeightScale",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Gets the repository root discovered from the test output directory.
     /// </summary>
     private string RepositoryRoot => FindRepositoryRoot();

--- a/Echoglossian.Tests/TranslationWindowConfigTests.cs
+++ b/Echoglossian.Tests/TranslationWindowConfigTests.cs
@@ -41,23 +41,6 @@ public class TranslationWindowConfigTests
     }
 
     /// <summary>
-    /// Ensures the tooltip-only surfaces remain explicitly unavailable to the
-    /// overlay renderer until their later preview phases.
-    /// </summary>
-    /// <param name="surfaceId">The unsupported tooltip surface.</param>
-    [Theory]
-    [InlineData((int)TranslationOverlaySurfaceId.ActionDetail)]
-    [InlineData((int)TranslationOverlaySurfaceId.ItemDetail)]
-    public void ForSurface_TooltipOnlySurface_ThrowsNotSupportedException(
-        int surfaceId)
-    {
-        Assert.Throws<NotSupportedException>(
-            () => TranslationWindowConfig.ForSurface(
-                new Config(),
-                (TranslationOverlaySurfaceId)surfaceId));
-    }
-
-    /// <summary>
     /// Ensures callers get an immediate argument error for a missing config.
     /// </summary>
     [Fact]
@@ -216,6 +199,22 @@ public class TranslationWindowConfigTests
         [
             TranslationOverlaySurfaceId.QuestToast,
             (Func<Config, TranslationWindowConfig>)TranslationWindowConfig.FromConfigForQuestToast,
+        ];
+        yield return
+        [
+            TranslationOverlaySurfaceId.ActionDetail,
+            (Func<Config, TranslationWindowConfig>)(config =>
+                TranslationWindowConfig.FromConfigForActionItemDetail(
+                    config,
+                    TranslationOverlaySurfaceId.ActionDetail)),
+        ];
+        yield return
+        [
+            TranslationOverlaySurfaceId.ItemDetail,
+            (Func<Config, TranslationWindowConfig>)(config =>
+                TranslationWindowConfig.FromConfigForActionItemDetail(
+                    config,
+                    TranslationOverlaySurfaceId.ItemDetail)),
         ];
         yield return
         [

--- a/Echoglossian.Tests/UiTerminologyResourcesTests.cs
+++ b/Echoglossian.Tests/UiTerminologyResourcesTests.cs
@@ -77,6 +77,21 @@ public class UiTerminologyResourcesTests
     }
 
     /// <summary>
+    ///     Ensures ActionDetail and ItemDetail overlay settings are labeled as
+    ///     detail overlays so they are not confused with hover tooltips or the
+    ///     Tooltip addon.
+    /// </summary>
+    [Fact]
+    public void ActionItemDetailOverlayAppearanceSectionLabel_UsesDetailOverlayTerminology()
+    {
+        using var cultureScope = new ResourceCultureScope(
+            CultureInfo.InvariantCulture);
+        Assert.Equal(
+            "Action/item detail overlay appearance",
+            Resources.ActionItemDetailOverlayAppearanceSectionLabel);
+    }
+
+    /// <summary>
     ///     Ensures the tab title reflects that this area now combines detail
     ///     windows with hover-tooltip controls.
     /// </summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2748,6 +2748,30 @@
         <member name="F:Echoglossian.Config.TooltipAddonOverlayManualMaxWidth">
             <summary>Manual maximum width used by the Tooltip addon anchored overlay.</summary>
         </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayTextColor">
+            <summary>Text color used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayBackgroundColor">
+            <summary>Background color used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayBackgroundOpacity">
+            <summary>Background opacity used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayFontScaleAdjustment">
+            <summary>Font scale adjustment used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayLineHeightScale">
+            <summary>Line-height scale used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayPadding">
+            <summary>Padding applied by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayMaxWidthMode">
+            <summary>Width mode used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
+        <member name="F:Echoglossian.Config.ActionItemDetailOverlayManualMaxWidth">
+            <summary>Manual maximum width used by ActionDetail and ItemDetail overlays.</summary>
+        </member>
         <member name="F:Echoglossian.Config.HoverTooltipTextColor">
             <summary>Text color used by Echoglossian hover tooltips.</summary>
         </member>
@@ -5719,14 +5743,6 @@
             <param name="surfaceName">The logical surface name.</param>
             <param name="overlay">The overlay instance to draw.</param>
             <param name="config">The overlay configuration.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildTooltipOverlayConfig(Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,System.String)">
-            <summary>
-                Builds the shared overlay configuration used by structured tooltips.
-            </summary>
-            <param name="surfaceId">The stable overlay surface identifier.</param>
-            <param name="defaultTitle">The default overlay title.</param>
-            <returns>The overlay configuration.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.NormalizeHoveredItemId(System.UInt32)">
             <summary>
@@ -33578,6 +33594,36 @@
             <param name="config">The current plugin configuration.</param>
             <returns><c>true</c> when a setting changed.</returns>
         </member>
+        <member name="M:Echoglossian.PluginUI.Tabs.TooltipTab.DrawSectionHeader(System.String,System.String)">
+            <summary>
+                Draws one visually separated section heading for the tooltip tab.
+            </summary>
+            <param name="title">The section title.</param>
+            <param name="description">The optional section description.</param>
+        </member>
+        <member name="M:Echoglossian.PluginUI.Tabs.TooltipTab.DrawSharedOverlayAppearanceControls(System.String,System.Single@,System.String,System.Single@,System.String,System.Single@,System.String,System.Numerics.Vector3@,System.String,System.Numerics.Vector3@,System.String,System.Single@,System.String,System.String,Echoglossian.TooltipAddonOverlayMaxWidthMode@,System.String,System.Single@)">
+            <summary>
+                Draws one shared overlay-appearance control bucket.
+            </summary>
+            <param name="fontScaleLabel">The font-scale slider label.</param>
+            <param name="fontScale">The persisted font-scale value.</param>
+            <param name="lineHeightLabel">The line-height slider label.</param>
+            <param name="lineHeight">The persisted line-height value.</param>
+            <param name="paddingLabel">The padding slider label.</param>
+            <param name="padding">The persisted padding value.</param>
+            <param name="textColorLabel">The text-color label.</param>
+            <param name="textColor">The persisted text color.</param>
+            <param name="backgroundColorLabel">The background-color label.</param>
+            <param name="backgroundColor">The persisted background color.</param>
+            <param name="backgroundOpacityLabel">The opacity slider label.</param>
+            <param name="backgroundOpacity">The persisted background opacity.</param>
+            <param name="maxWidthModeLabel">The width-mode combo label.</param>
+            <param name="matchNativeLabel">The native-width option label.</param>
+            <param name="maxWidthMode">The persisted width mode.</param>
+            <param name="manualMaxWidthLabel">The manual-width slider label.</param>
+            <param name="manualMaxWidth">The persisted manual width.</param>
+            <returns><c>true</c> when one or more controls changed.</returns>
+        </member>
         <member name="T:Echoglossian.PluginUI.Tabs.TranslationDisplayModeUiHelper">
             <summary>
                 Renders the shared translation display-mode dropdown used by DB-first UI
@@ -41022,6 +41068,15 @@
             <param name="config">The active plugin configuration.</param>
             <returns>The Tooltip addon anchored-overlay configuration.</returns>
         </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForActionItemDetail(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId)">
+            <summary>
+            Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance based on the
+            provided <see cref="T:Echoglossian.Config"/> for ActionDetail and ItemDetail overlays.
+            </summary>
+            <param name="config">The active plugin configuration.</param>
+            <param name="surfaceId">The detail overlay surface identifier.</param>
+            <returns>The shared detail-overlay configuration.</returns>
+        </member>
         <member name="M:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig.FromConfigForQuestToastPlacement(Echoglossian.Config,Dalamud.Game.Gui.Toast.QuestToastPosition)">
             <summary>
             Creates a <see cref="T:Echoglossian.UIOverlays.TranslationOverlay.TranslationWindowConfig"/> instance for one
@@ -41050,6 +41105,508 @@
             <param name="serviceCollection">The service collection.</param>
             <param name="tags">The service registration tags to include.</param>
             <returns>The service collection</returns>
+        </member>
+        <member name="T:Injectio.Attributes.DuplicateStrategy">
+            <summary>
+            Service registration duplicate strategies
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.DuplicateStrategy.Skip">
+            <summary>
+            Skips registrations for services that already exists.
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.DuplicateStrategy.Replace">
+            <summary>
+            Replaces existing service registrations.
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.DuplicateStrategy.Append">
+            <summary>
+            Appends a new registration for existing services.
+            </summary>
+        </member>
+        <member name="T:Injectio.Attributes.RegistrationStrategy">
+            <summary>
+            Register service type strategies
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.RegistrationStrategy.Self">
+            <summary>
+            Registers each matching concrete type as itself
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.RegistrationStrategy.ImplementedInterfaces">
+            <summary>
+            Registers each matching concrete type as all of its implemented interfaces.
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.RegistrationStrategy.SelfWithInterfaces">
+            <summary>
+            Registers each matching concrete type as all of its implemented interfaces and itself
+            </summary>
+        </member>
+        <member name="F:Injectio.Attributes.RegistrationStrategy.SelfWithProxyFactory">
+            <summary>
+            Registers each matching concrete type as all of its implemented interfaces and itself.
+            For the interfaces a proxy-factory resolves the service from its type-name, so only one instance is created per lifetime
+            </summary>
+            <remarks>For open-generic registrations, this behaves like <see cref="F:Injectio.Attributes.RegistrationStrategy.SelfWithInterfaces"/></remarks>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterAttribute">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection
+            </summary>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.ServiceType">
+            <summary>
+            The <see cref="T:System.Type"/> of the service
+            </summary>
+            <seealso cref="P:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ServiceType"/>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.ImplementationType">
+            <summary>
+            The <see cref="T:System.Type"/> that implements the service.  If not set, the class the interface is on will be used.
+            </summary>
+            <seealso cref="P:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ServiceType"/>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.ServiceKey">
+            <summary>
+            Gets or sets the key of the service.
+            </summary>
+            <value>The service key.</value>
+            <seealso cref="P:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ServiceKey "/>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.Factory">
+            <summary>
+            Name of a factory method to create new instances of the service implementation
+            </summary>
+            <remarks>
+            The method signature must be Func{IServiceProvider, object} and must be static
+            </remarks>
+            <seealso cref="P:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ImplementationFactory"/>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.Duplicate">
+            <summary>
+            Gets or sets the duplicate.
+            </summary>
+            <value>
+            The duplicate.
+            </value>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.Registration">
+            <summary>
+            Gets or sets the registration.
+            </summary>
+            <value>
+            The registration.
+            </value>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterAttribute.Tags">
+            <summary>
+            Gets or sets the comma delimited list of service registration tags.
+            </summary>
+            <value>
+            The comma delimited list of service registration tags.
+            </value>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterScopedAttribute">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a scoped service
+            </summary>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterScoped]
+              public class ScopedService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterSingletonAttribute">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a singleton service
+            </summary>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterSingleton]
+              public class SingletonService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterTransientAttribute">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a transient service
+            </summary>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterTransient]
+              public class TransientService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterServicesAttribute">
+            <summary>Attribute to indicate the method should be called to register services</summary>
+            <example>use the RegisterServices attribute
+              <code>
+              public class RegistrationModule
+              {
+                  [RegisterServices]
+                  public static void Register(IServiceCollection services)
+                  {
+                      services.TryAddTransient&lt;IModuleService, ModuleService&gt;();
+                  }
+              }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute">
+            <summary>
+            Attribute to indicate the target class should be registered as a decorator for an existing service.
+            The decorator wraps the previously registered service implementation and inherits its <see cref="P:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Lifetime"/>.
+            </summary>
+            <example>Decorate <c>IService</c> with a logging wrapper
+              <code>
+              [RegisterDecorator(ServiceType = typeof(IService))]
+              public class LoggingDecorator : IService
+              {
+                  public LoggingDecorator(IService inner) { }
+              }
+              </code>
+            </example>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.ServiceType">
+            <summary>
+            The <see cref="T:System.Type"/> of the service to decorate.
+            </summary>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.ImplementationType">
+            <summary>
+            The <see cref="T:System.Type"/> that implements the decorator. If not set, the class the attribute is on will be used.
+            </summary>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.ServiceKey">
+            <summary>
+            Gets or sets the key of the keyed service to decorate.
+            Leave unset (and <see cref="P:Injectio.Attributes.RegisterDecoratorAttribute.AnyKey"/> false) to decorate the non-keyed registration.
+            </summary>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.AnyKey">
+            <summary>
+            When <c>true</c>, the decorator is applied to every keyed registration of <see cref="P:Injectio.Attributes.RegisterDecoratorAttribute.ServiceType"/>,
+            regardless of its key. Equivalent to <c>KeyedService.AnyKey</c>.
+            </summary>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.Factory">
+            <summary>
+            Name of a static factory method to construct the decorator.
+            </summary>
+            <remarks>
+            The factory signature must be <c>(IServiceProvider, TService) -&gt; TService</c> for non-keyed services
+            or <c>(IServiceProvider, object?, TService) -&gt; TService</c> for keyed services.
+            </remarks>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.Order">
+            <summary>
+            Gets or sets the order in which the decorator is applied. Lower values are applied first (innermost).
+            </summary>
+        </member>
+        <member name="P:Injectio.Attributes.RegisterDecoratorAttribute.Tags">
+            <summary>
+            Gets or sets the comma delimited list of registration tags.
+            </summary>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterScopedAttribute`1">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a scoped service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterScoped&lt;IService&gt;]
+              public class ScopedService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterScopedAttribute`2">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a scoped service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
+            <example>Register the ScopedService class as an implementation for IService
+              <code>
+              [RegisterScoped&lt;IService, ScopedService&gt;]
+              public class ScopedService: IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterSingletonAttribute`1">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a singleton service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterSingleton&lt;IService&gt;]
+              public class SingletonService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterSingletonAttribute`2">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a singleton service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
+            <example>Register the SingletonService class as an implementation for IService
+              <code>
+              [RegisterSingleton&lt;IService, SingletonService&gt;]
+              public class SingletonService: IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterTransientAttribute`1">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a transient service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterTransient&lt;IService&gt;]
+              public class TransientService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterTransientAttribute`2">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a transient service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
+            <example>Register the TransientService class as an implementation for IService
+              <code>
+              [RegisterTransient&lt;IService, TransientService&gt;]
+              public class TransientService: IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute`1">
+            <summary>
+            Attribute to indicate the target class should be registered as a decorator for <typeparamref name="TService"/>.
+            </summary>
+            <typeparam name="TService">The type of the service to decorate.</typeparam>
+            <example>
+              <code>
+              [RegisterDecorator&lt;IService&gt;]
+              public class LoggingDecorator : IService
+              {
+                  public LoggingDecorator(IService inner) { }
+              }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute`2">
+            <summary>
+            Attribute to indicate the target class should be registered as a decorator for <typeparamref name="TService"/>
+            using <typeparamref name="TImplementation"/> as the decorator implementation.
+            </summary>
+            <typeparam name="TService">The type of the service to decorate.</typeparam>
+            <typeparam name="TImplementation">The type of the decorator implementation.</typeparam>
+        </member>
+        <member name="T:Injectio.Extensions.DecorationExtensions">
+             <summary>
+             Provides extension methods for decorating registered services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+             </summary>
+             <remarks>
+             <para>
+             The <b>Decorator pattern</b> wraps an existing service with additional behavior without modifying the
+             original implementation. Each decorator implements the same interface as the service it wraps, creating
+             a chain of responsibility:
+             </para>
+             <para>
+             These methods work by replacing the <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/>
+             in-place within the service collection. The original factory, instance, or implementation type is captured
+             so the inner service can still be resolved. The replacement descriptor preserves the original lifetime.
+             Calling a decoration method multiple times stacks decorators, with the last call becoming the outermost layer.
+             </para>
+             <para><b>Usage example — decorating with a factory:</b></para>
+             <code>
+             // Register the original service
+             services.AddScoped&lt;INotificationService, EmailNotificationService&gt;();
+            
+             // Decorate with logging
+             services.Decorate&lt;INotificationService&gt;(
+                 (sp, inner) =&gt; new LoggingNotificationService(inner, sp.GetRequiredService&lt;ILogger&gt;()));
+            
+             // Decorate with retry (stacks on top of logging)
+             services.Decorate&lt;INotificationService&gt;(
+                 (sp, inner) =&gt; new RetryNotificationService(inner));
+            
+             // Resolution chain: Retry → Logging → Email
+             </code>
+             <para><b>Usage example — decorating open generics:</b></para>
+             <code>
+             // Register closed-generic implementations
+             services.AddScoped&lt;IRepository&lt;Order&gt;, OrderRepository&gt;();
+             services.AddScoped&lt;IRepository&lt;Customer&gt;, CustomerRepository&gt;();
+            
+             // Decorate all IRepository&lt;T&gt; with caching
+             services.DecorateOpenGeneric(
+                 typeof(IRepository&lt;&gt;), typeof(CachingRepository&lt;&gt;));
+             </code>
+             </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Func{System.IServiceProvider,System.Object,System.Object})">
+            <summary>
+            Decorates all non-keyed registrations matching <paramref name="serviceType"/> by wrapping each resolved instance
+            with <paramref name="decoratorFactory"/>.
+            </summary>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceType">The service type to decorate.</param>
+            <param name="decoratorFactory">A factory that receives the service provider and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method replaces matching <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/> entries in-place,
+            preserving each registration lifetime. Keyed registrations are skipped.
+            </para>
+            <para>
+            Multiple calls stack decorators, with the most recent decoration becoming the outermost layer.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Func{System.IServiceProvider,``0,``0})">
+            <summary>
+            Decorates all registrations of <typeparamref name="TService"/> by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
+            Keyed service registrations are skipped.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="decoratorFactory">A factory that receives the service provider and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            Decoration replaces each existing <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/> for
+            <typeparamref name="TService"/> in-place. The original descriptor's factory, instance, or implementation type is
+            captured and used to resolve the inner service, which is then passed to <paramref name="decoratorFactory"/>.
+            The replacement descriptor preserves the original registration's lifetime.
+            </para>
+            <para>
+            Multiple calls stack: each call wraps whatever factory is currently registered, enabling layered decoration.
+            Only non-keyed registrations are affected; use <c>DecorateKeyed</c> for keyed services.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate``2(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Decorates all registrations of <typeparamref name="TService"/> by wrapping each resolved instance
+            with an automatically constructed instance of <typeparamref name="TDecorator"/>.
+            Keyed service registrations are skipped.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <typeparam name="TDecorator">The decorator type. Its constructor must accept a <typeparamref name="TService"/> parameter for the inner service; additional parameters are resolved from the service provider.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This overload uses <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>
+            to construct the decorator, passing the inner service instance as an explicit argument. Any remaining
+            constructor parameters are resolved from the <see cref="T:System.IServiceProvider"/>.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Object,System.Func{System.IServiceProvider,System.Object,System.Object,System.Object})">
+            <summary>
+            Decorates keyed registrations matching <paramref name="serviceType"/> and <paramref name="serviceKey"/>
+            by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
+            </summary>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceType">The service type to decorate.</param>
+            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
+            <param name="decoratorFactory">A factory that receives the service provider, the key, and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method only processes keyed registrations and preserves both the original key and lifetime for each replacement descriptor.
+            </para>
+            <para>
+            Non-keyed registrations are skipped. Multiple calls stack decorators for matching keyed registrations.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Object,System.Func{System.IServiceProvider,System.Object,``0,``0})">
+            <summary>
+            Decorates all keyed registrations of <typeparamref name="TService"/> matching <paramref name="serviceKey"/>
+            by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
+            Pass <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to match all keys.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
+            <param name="decoratorFactory">A factory that receives the service provider, the key, and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method iterates through all service descriptors for <typeparamref name="TService"/> and replaces each
+            keyed registration whose key matches <paramref name="serviceKey"/>. The original keyed factory, instance,
+            or implementation type is captured and used to resolve the inner service, which is then passed to
+            <paramref name="decoratorFactory"/> along with the service provider and key. The replacement descriptor
+            preserves the original registration's lifetime and key.
+            </para>
+            <para>
+            Non-keyed registrations are skipped; use <c>Decorate</c> for those. Multiple calls stack, enabling
+            layered decoration of keyed services.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed``2(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Object)">
+            <summary>
+            Decorates all keyed registrations of <typeparamref name="TService"/> matching <paramref name="serviceKey"/>
+            by wrapping each resolved instance with an automatically constructed instance of <typeparamref name="TDecorator"/>.
+            Pass <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to match all keys.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <typeparam name="TDecorator">The decorator type. Its constructor must accept a <typeparamref name="TService"/> parameter for the inner service; additional parameters are resolved from the service provider.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This overload uses <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>
+            to construct the decorator, passing the inner service instance as an explicit argument. Any remaining
+            constructor parameters are resolved from the <see cref="T:System.IServiceProvider"/>.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateOpenGeneric(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Type,System.Object)">
+            <summary>
+            Decorates all closed-generic registrations whose generic type definition matches <paramref name="openServiceType"/>
+            by wrapping each resolved instance with an instance of <paramref name="openDecoratorType"/>.
+            </summary>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="openServiceType">The open generic service type (e.g., <c>typeof(IRepository&lt;&gt;)</c>).</param>
+            <param name="openDecoratorType">The open generic decorator type that wraps the original service.</param>
+            <param name="serviceKey">
+            The key of the keyed registrations to decorate. Pass <see langword="null"/> to decorate non-keyed registrations,
+            or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to decorate all keyed registrations.
+            Keyed registration matching is only available on .NET 8 and later.
+            </param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method scans all service descriptors for closed-generic types whose generic type definition matches
+            <paramref name="openServiceType"/>. For each match, it closes <paramref name="openDecoratorType"/> over the
+            same type arguments and replaces the descriptor with a factory that resolves the original service and passes
+            it to <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>.
+            The replacement descriptor preserves the original registration's lifetime.
+            </para>
+            <para>
+            Open-generic descriptors (those registered with an open <c>typeof(T&lt;&gt;)</c> service type) are skipped
+            because the DI container resolves them lazily and replacing the implementation type would cause recursive
+            resolution. When <paramref name="serviceKey"/> is <see langword="null"/>, keyed registrations are skipped.
+            When <paramref name="serviceKey"/> is non-null on .NET 8 and later, non-keyed registrations are skipped and
+            only keyed registrations with the matching key are decorated.
+            </para>
+            </remarks>
         </member>
         <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0">
             <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the TimerTextPattern method.</summary>

--- a/NativeUI/Helpers/ActionItemDetailUiRuntime.cs
+++ b/NativeUI/Helpers/ActionItemDetailUiRuntime.cs
@@ -144,15 +144,15 @@ public unsafe partial class Echoglossian
         this.DrawStructuredTooltipOverlay(
             ActionDetailSurfaceName,
             this.actionDetailOverlay,
-            this.BuildTooltipOverlayConfig(
-                TranslationOverlaySurfaceId.ActionDetail,
-                Resources.OverlayWindowTitleActionTooltipTranslation));
+            TranslationWindowConfig.ForSurface(
+                this.configuration,
+                TranslationOverlaySurfaceId.ActionDetail));
         this.DrawStructuredTooltipOverlay(
             ItemDetailSurfaceName,
             this.itemDetailOverlay,
-            this.BuildTooltipOverlayConfig(
-                TranslationOverlaySurfaceId.ItemDetail,
-                Resources.OverlayWindowTitleItemTooltipTranslation));
+            TranslationWindowConfig.ForSurface(
+                this.configuration,
+                TranslationOverlaySurfaceId.ItemDetail));
     }
 
     /// <summary>
@@ -3552,36 +3552,6 @@ public unsafe partial class Echoglossian
             reason: "overlay-render",
             overlayText: currentText);
         this.DrawTranslationWindow(overlay, config);
-    }
-
-    /// <summary>
-    ///     Builds the shared overlay configuration used by structured tooltips.
-    /// </summary>
-    /// <param name="surfaceId">The stable overlay surface identifier.</param>
-    /// <param name="defaultTitle">The default overlay title.</param>
-    /// <returns>The overlay configuration.</returns>
-    private TranslationWindowConfig BuildTooltipOverlayConfig(
-        TranslationOverlaySurfaceId surfaceId,
-        string defaultTitle)
-    {
-        return new TranslationWindowConfig(
-            SurfaceId: surfaceId,
-            DefaultTitle: defaultTitle,
-            FontScale: 1.0f,
-            WidthMultiplier: 1.0f,
-            HeightMultiplier: 1.0f,
-            TextColor: new Vector4(1f, 1f, 1f, 1f),
-            PosCorrection: Vector2.Zero,
-            ForceShowTitle: false,
-            BackgroundOpacity: 0.95f,
-            NoBackground: false,
-            UseFixedWindowSize: false,
-            CenterOnAddon: false,
-            AutoSizeToTextWithMaxWidth: true,
-            ExpandWidthToFitText: true,
-            MaxAutoExpandedWidthMultiplier: 1.35f,
-            MinWidthViewportFraction: 0.18f,
-            MaxWidthViewportFraction: 0.36f);
     }
 
     /// <summary>

--- a/PluginUI/Tabs/TooltipTab.cs
+++ b/PluginUI/Tabs/TooltipTab.cs
@@ -10,6 +10,9 @@ namespace Echoglossian.PluginUI.Tabs;
 /// </summary>
 public static class TooltipTab
 {
+    private static readonly Vector4 SectionHeaderColor =
+        new(0.78f, 0.86f, 0.97f, 1f);
+
     /// <summary>
     ///     Draws the tooltip settings tab.
     /// </summary>
@@ -26,8 +29,9 @@ public static class TooltipTab
 
         changed |= config.NormalizeStructuredTooltipPresentationSettings();
 
-        ImGui.TextUnformatted(Resources.ActionAndItemTooltipsSectionLabel);
-        ImGui.Separator();
+        DrawSectionHeader(
+            Resources.ActionAndItemTooltipsSectionLabel,
+            null);
 
         changed |= ImGui.Checkbox(
             Resources.ActionAndItemTooltipsToggleLabel,
@@ -38,9 +42,32 @@ public static class TooltipTab
             ImGui.TextWrapped(Resources.ActionAndItemTooltipsOverlayOnlyDescription);
         }
 
-        ImGui.TextUnformatted(Resources.HoverTooltipAppearanceSectionLabel);
-        ImGui.Separator();
-        ImGui.TextWrapped(Resources.HoverTooltipAppearanceDescription);
+        DrawSectionHeader(
+            Resources.ActionItemDetailOverlayAppearanceSectionLabel,
+            Resources.ActionItemDetailOverlayAppearanceDescription);
+
+        changed |= DrawSharedOverlayAppearanceControls(
+            fontScaleLabel: Resources.TooltipAddonOverlayFontScaleAdjustmentLabel,
+            ref config.ActionItemDetailOverlayFontScaleAdjustment,
+            lineHeightLabel: Resources.TooltipAddonOverlayLineHeightScaleLabel,
+            ref config.ActionItemDetailOverlayLineHeightScale,
+            paddingLabel: Resources.TooltipAddonOverlayPaddingLabel,
+            ref config.ActionItemDetailOverlayPadding,
+            textColorLabel: Resources.TooltipAddonOverlayTextColorLabel,
+            ref config.ActionItemDetailOverlayTextColor,
+            backgroundColorLabel: Resources.TooltipAddonOverlayBackgroundColorLabel,
+            ref config.ActionItemDetailOverlayBackgroundColor,
+            backgroundOpacityLabel: Resources.TooltipAddonOverlayBackgroundOpacityLabel,
+            ref config.ActionItemDetailOverlayBackgroundOpacity,
+            maxWidthModeLabel: Resources.TooltipAddonOverlayMaxWidthModeLabel,
+            matchNativeLabel: Resources.ActionItemDetailOverlayMaxWidthMatchNativeLabel,
+            ref config.ActionItemDetailOverlayMaxWidthMode,
+            manualMaxWidthLabel: Resources.TooltipAddonOverlayManualMaxWidthLabel,
+            ref config.ActionItemDetailOverlayManualMaxWidth);
+
+        DrawSectionHeader(
+            Resources.HoverTooltipAppearanceSectionLabel,
+            Resources.HoverTooltipAppearanceDescription);
 
         changed |= ImGui.SliderFloat(
             Resources.HoverTooltipFontScaleLabel,
@@ -87,10 +114,9 @@ public static class TooltipTab
             1f,
             "%.2f");
 
-        ImGui.Spacing();
-        ImGui.Separator();
-        ImGui.TextUnformatted(Resources.TranslateTooltipAddonLabel);
-        ImGui.Separator();
+        DrawSectionHeader(
+            Resources.TranslateTooltipAddonLabel,
+            null);
 
         changed |= ImGui.Checkbox(
             Resources.TranslateTooltipAddonLabel,
@@ -100,89 +126,170 @@ public static class TooltipTab
             ref config.TooltipAddonTranslationDisplayMode,
             config.OverlayOnlyLanguage);
 
-        ImGui.TextUnformatted(Resources.TooltipAddonOverlayAppearanceSectionLabel);
-        ImGui.Separator();
-        ImGui.TextWrapped(Resources.TooltipAddonOverlayAppearanceDescription);
+        DrawSectionHeader(
+            Resources.TooltipAddonOverlayAppearanceSectionLabel,
+            Resources.TooltipAddonOverlayAppearanceDescription);
 
         changed |= ImGui.Checkbox(
             Resources.TooltipAddonHideNativeTooltipWhenOverlayActiveLabel,
             ref config.TooltipAddonHideNativeTooltipWhenOverlayActive);
 
-        changed |= ImGui.SliderFloat(
-            Resources.TooltipAddonOverlayFontScaleAdjustmentLabel,
+        changed |= DrawSharedOverlayAppearanceControls(
+            fontScaleLabel: Resources.TooltipAddonOverlayFontScaleAdjustmentLabel,
             ref config.TooltipAddonOverlayFontScaleAdjustment,
-            0.25f,
-            3f,
-            "%.2f");
-
-        changed |= ImGui.SliderFloat(
-            Resources.TooltipAddonOverlayLineHeightScaleLabel,
+            lineHeightLabel: Resources.TooltipAddonOverlayLineHeightScaleLabel,
             ref config.TooltipAddonOverlayLineHeightScale,
-            0.8f,
-            1.2f,
-            "%.2f");
-
-        changed |= ImGui.SliderFloat(
-            Resources.TooltipAddonOverlayPaddingLabel,
+            paddingLabel: Resources.TooltipAddonOverlayPaddingLabel,
             ref config.TooltipAddonOverlayPadding,
-            0f,
-            32f,
-            "%.0f px");
-
-        var tooltipAddonTextColorLabel = Resources.TooltipAddonOverlayTextColorLabel;
-        ImGui.Text(tooltipAddonTextColorLabel);
-        ImGui.SameLine();
-        changed |= ImGui.ColorEdit3(
-            $"{tooltipAddonTextColorLabel}##Color",
+            textColorLabel: Resources.TooltipAddonOverlayTextColorLabel,
             ref config.TooltipAddonOverlayTextColor,
-            ImGuiColorEditFlags.NoInputs);
-
-        var tooltipAddonBackgroundColorLabel =
-            Resources.TooltipAddonOverlayBackgroundColorLabel;
-        ImGui.Text(tooltipAddonBackgroundColorLabel);
-        ImGui.SameLine();
-        changed |= ImGui.ColorEdit3(
-            $"{tooltipAddonBackgroundColorLabel}##Color",
+            backgroundColorLabel: Resources.TooltipAddonOverlayBackgroundColorLabel,
             ref config.TooltipAddonOverlayBackgroundColor,
-            ImGuiColorEditFlags.NoInputs);
-
-        changed |= ImGui.SliderFloat(
-            Resources.TooltipAddonOverlayBackgroundOpacityLabel,
+            backgroundOpacityLabel: Resources.TooltipAddonOverlayBackgroundOpacityLabel,
             ref config.TooltipAddonOverlayBackgroundOpacity,
-            0f,
-            1f,
-            "%.2f");
-
-        var maxWidthMode = (int)config.TooltipAddonOverlayMaxWidthMode;
-        if (ImGui.Combo(
-                Resources.TooltipAddonOverlayMaxWidthModeLabel,
-                ref maxWidthMode,
-                [
-                    Resources.TooltipAddonOverlayMaxWidthMatchNativeLabel,
-                    Resources.TooltipAddonOverlayMaxWidthManualCapLabel,
-                ],
-                2))
-        {
-            config.TooltipAddonOverlayMaxWidthMode =
-                (TooltipAddonOverlayMaxWidthMode)maxWidthMode;
-            changed = true;
-        }
-
-        if (config.TooltipAddonOverlayMaxWidthMode ==
-            TooltipAddonOverlayMaxWidthMode.ManualCap)
-        {
-            changed |= ImGui.SliderFloat(
-                Resources.TooltipAddonOverlayManualMaxWidthLabel,
-                ref config.TooltipAddonOverlayManualMaxWidth,
-                240f,
-                1920f,
-                "%.0f px");
-        }
+            maxWidthModeLabel: Resources.TooltipAddonOverlayMaxWidthModeLabel,
+            matchNativeLabel: Resources.TooltipAddonOverlayMaxWidthMatchNativeLabel,
+            ref config.TooltipAddonOverlayMaxWidthMode,
+            manualMaxWidthLabel: Resources.TooltipAddonOverlayManualMaxWidthLabel,
+            ref config.TooltipAddonOverlayManualMaxWidth);
 
         if (changed)
         {
             FieldValidationHelper.MarkAllRequiredFieldsTouched(config);
             Echoglossian.SaveConfig(config);
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    ///     Draws one visually separated section heading for the tooltip tab.
+    /// </summary>
+    /// <param name="title">The section title.</param>
+    /// <param name="description">The optional section description.</param>
+    private static void DrawSectionHeader(
+        string title,
+        string? description)
+    {
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.Spacing();
+        ImGui.TextColored(SectionHeaderColor, title);
+
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            ImGui.TextWrapped(description);
+        }
+
+        ImGui.Spacing();
+    }
+
+    /// <summary>
+    ///     Draws one shared overlay-appearance control bucket.
+    /// </summary>
+    /// <param name="fontScaleLabel">The font-scale slider label.</param>
+    /// <param name="fontScale">The persisted font-scale value.</param>
+    /// <param name="lineHeightLabel">The line-height slider label.</param>
+    /// <param name="lineHeight">The persisted line-height value.</param>
+    /// <param name="paddingLabel">The padding slider label.</param>
+    /// <param name="padding">The persisted padding value.</param>
+    /// <param name="textColorLabel">The text-color label.</param>
+    /// <param name="textColor">The persisted text color.</param>
+    /// <param name="backgroundColorLabel">The background-color label.</param>
+    /// <param name="backgroundColor">The persisted background color.</param>
+    /// <param name="backgroundOpacityLabel">The opacity slider label.</param>
+    /// <param name="backgroundOpacity">The persisted background opacity.</param>
+    /// <param name="maxWidthModeLabel">The width-mode combo label.</param>
+    /// <param name="matchNativeLabel">The native-width option label.</param>
+    /// <param name="maxWidthMode">The persisted width mode.</param>
+    /// <param name="manualMaxWidthLabel">The manual-width slider label.</param>
+    /// <param name="manualMaxWidth">The persisted manual width.</param>
+    /// <returns><c>true</c> when one or more controls changed.</returns>
+    private static bool DrawSharedOverlayAppearanceControls(
+        string fontScaleLabel,
+        ref float fontScale,
+        string lineHeightLabel,
+        ref float lineHeight,
+        string paddingLabel,
+        ref float padding,
+        string textColorLabel,
+        ref Vector3 textColor,
+        string backgroundColorLabel,
+        ref Vector3 backgroundColor,
+        string backgroundOpacityLabel,
+        ref float backgroundOpacity,
+        string maxWidthModeLabel,
+        string matchNativeLabel,
+        ref TooltipAddonOverlayMaxWidthMode maxWidthMode,
+        string manualMaxWidthLabel,
+        ref float manualMaxWidth)
+    {
+        var changed = false;
+
+        changed |= ImGui.SliderFloat(
+            fontScaleLabel,
+            ref fontScale,
+            0.25f,
+            3f,
+            "%.2f");
+
+        changed |= ImGui.SliderFloat(
+            lineHeightLabel,
+            ref lineHeight,
+            0.8f,
+            1.2f,
+            "%.2f");
+
+        changed |= ImGui.SliderFloat(
+            paddingLabel,
+            ref padding,
+            0f,
+            32f,
+            "%.0f px");
+
+        ImGui.Text(textColorLabel);
+        ImGui.SameLine();
+        changed |= ImGui.ColorEdit3(
+            $"{textColorLabel}##Color",
+            ref textColor,
+            ImGuiColorEditFlags.NoInputs);
+
+        ImGui.Text(backgroundColorLabel);
+        ImGui.SameLine();
+        changed |= ImGui.ColorEdit3(
+            $"{backgroundColorLabel}##Color",
+            ref backgroundColor,
+            ImGuiColorEditFlags.NoInputs);
+
+        changed |= ImGui.SliderFloat(
+            backgroundOpacityLabel,
+            ref backgroundOpacity,
+            0f,
+            1f,
+            "%.2f");
+
+        var maxWidthModeIndex = (int)maxWidthMode;
+        if (ImGui.Combo(
+                maxWidthModeLabel,
+                ref maxWidthModeIndex,
+                [
+                    matchNativeLabel,
+                    Resources.TooltipAddonOverlayMaxWidthManualCapLabel,
+                ],
+                2))
+        {
+            maxWidthMode = (TooltipAddonOverlayMaxWidthMode)maxWidthModeIndex;
+            changed = true;
+        }
+
+        if (maxWidthMode == TooltipAddonOverlayMaxWidthMode.ManualCap)
+        {
+            changed |= ImGui.SliderFloat(
+                manualMaxWidthLabel,
+                ref manualMaxWidth,
+                240f,
+                1920f,
+                "%.0f px");
         }
 
         return changed;

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -3941,6 +3941,10 @@ namespace Echoglossian.Properties
 
         public static string TooltipAddonOverlayAppearanceDescription => ResourceManager.GetString("TooltipAddonOverlayAppearanceDescription", resourceCulture);
 
+        public static string ActionItemDetailOverlayAppearanceSectionLabel => ResourceManager.GetString("ActionItemDetailOverlayAppearanceSectionLabel", resourceCulture);
+
+        public static string ActionItemDetailOverlayAppearanceDescription => ResourceManager.GetString("ActionItemDetailOverlayAppearanceDescription", resourceCulture);
+
         public static string TooltipAddonHideNativeTooltipWhenOverlayActiveLabel => ResourceManager.GetString("TooltipAddonHideNativeTooltipWhenOverlayActiveLabel", resourceCulture);
 
         public static string TooltipAddonOverlayFontScaleAdjustmentLabel => ResourceManager.GetString("TooltipAddonOverlayFontScaleAdjustmentLabel", resourceCulture);
@@ -3958,6 +3962,8 @@ namespace Echoglossian.Properties
         public static string TooltipAddonOverlayMaxWidthModeLabel => ResourceManager.GetString("TooltipAddonOverlayMaxWidthModeLabel", resourceCulture);
 
         public static string TooltipAddonOverlayMaxWidthMatchNativeLabel => ResourceManager.GetString("TooltipAddonOverlayMaxWidthMatchNativeLabel", resourceCulture);
+
+        public static string ActionItemDetailOverlayMaxWidthMatchNativeLabel => ResourceManager.GetString("ActionItemDetailOverlayMaxWidthMatchNativeLabel", resourceCulture);
 
         public static string TooltipAddonOverlayMaxWidthManualCapLabel => ResourceManager.GetString("TooltipAddonOverlayMaxWidthManualCapLabel", resourceCulture);
 

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -706,6 +706,12 @@
   <data name="TooltipAddonOverlayAppearanceDescription" xml:space="preserve">
     <value>These settings apply only when the Tooltip addon uses its anchored Plugin Overlay.</value>
   </data>
+  <data name="ActionItemDetailOverlayAppearanceSectionLabel" xml:space="preserve">
+    <value>Action/item detail overlay appearance</value>
+  </data>
+  <data name="ActionItemDetailOverlayAppearanceDescription" xml:space="preserve">
+    <value>These settings apply to the Plugin Overlays shown above ActionDetail and ItemDetail.</value>
+  </data>
   <data name="TooltipAddonHideNativeTooltipWhenOverlayActiveLabel" xml:space="preserve">
     <value>Hide native Tooltip while overlay is active</value>
   </data>
@@ -732,6 +738,9 @@
   </data>
   <data name="TooltipAddonOverlayMaxWidthMatchNativeLabel" xml:space="preserve">
     <value>Match native tooltip</value>
+  </data>
+  <data name="ActionItemDetailOverlayMaxWidthMatchNativeLabel" xml:space="preserve">
+    <value>Match native detail window</value>
   </data>
   <data name="TooltipAddonOverlayMaxWidthManualCapLabel" xml:space="preserve">
     <value>Manual cap</value>

--- a/UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs
@@ -551,23 +551,42 @@ internal sealed class TranslationOverlayRenderer : IDisposable
             return request.TextureMaxWidthOverride.Value;
         }
 
-        if (config.SurfaceId != TranslationOverlaySurfaceId.TooltipAddon)
+        if (config.SurfaceId == TranslationOverlaySurfaceId.TooltipAddon)
+        {
+            var padding =
+                Math.Max(0f, this.configuration.TooltipAddonOverlayPadding) * 2f;
+            var nativeWidth = Math.Max(64f, request.AddonSize.X - padding);
+            if (this.configuration.TooltipAddonOverlayMaxWidthMode ==
+                TooltipAddonOverlayMaxWidthMode.ManualCap)
+            {
+                var manualWidth = Math.Max(
+                    64f,
+                    this.configuration.TooltipAddonOverlayManualMaxWidth - padding);
+                return Math.Min(nativeWidth, manualWidth);
+            }
+
+            return nativeWidth;
+        }
+
+        if (config.SurfaceId is not TranslationOverlaySurfaceId.ActionDetail
+            and not TranslationOverlaySurfaceId.ItemDetail)
         {
             return null;
         }
 
-        var padding = Math.Max(0f, this.configuration.TooltipAddonOverlayPadding) * 2f;
-        var nativeWidth = Math.Max(64f, request.AddonSize.X - padding);
-        if (this.configuration.TooltipAddonOverlayMaxWidthMode ==
+        var detailPadding =
+            Math.Max(0f, this.configuration.ActionItemDetailOverlayPadding) * 2f;
+        var detailNativeWidth = Math.Max(64f, request.AddonSize.X - detailPadding);
+        if (this.configuration.ActionItemDetailOverlayMaxWidthMode ==
             TooltipAddonOverlayMaxWidthMode.ManualCap)
         {
             var manualWidth = Math.Max(
                 64f,
-                this.configuration.TooltipAddonOverlayManualMaxWidth - padding);
-            return Math.Min(nativeWidth, manualWidth);
+                this.configuration.ActionItemDetailOverlayManualMaxWidth - detailPadding);
+            return Math.Min(detailNativeWidth, manualWidth);
         }
 
-        return nativeWidth;
+        return detailNativeWidth;
     }
 
     /// <summary>
@@ -586,13 +605,22 @@ internal sealed class TranslationOverlayRenderer : IDisposable
             return request.TextureLineHeightScaleOverride.Value;
         }
 
-        if (config.SurfaceId != TranslationOverlaySurfaceId.TooltipAddon)
+        if (config.SurfaceId == TranslationOverlaySurfaceId.TooltipAddon)
+        {
+            return Math.Clamp(
+                this.configuration.TooltipAddonOverlayLineHeightScale,
+                0.8f,
+                1.2f);
+        }
+
+        if (config.SurfaceId is not TranslationOverlaySurfaceId.ActionDetail
+            and not TranslationOverlaySurfaceId.ItemDetail)
         {
             return null;
         }
 
         return Math.Clamp(
-            this.configuration.TooltipAddonOverlayLineHeightScale,
+            this.configuration.ActionItemDetailOverlayLineHeightScale,
             0.8f,
             1.2f);
     }

--- a/UIOverlays/TranslationOverlay/TranslationWindowConfig.cs
+++ b/UIOverlays/TranslationOverlay/TranslationWindowConfig.cs
@@ -125,8 +125,7 @@ internal record TranslationWindowConfig(
       TranslationOverlaySurfaceId.ChatBubble => FromConfigForChatBubble(config),
       TranslationOverlaySurfaceId.TooltipAddon => FromConfigForTooltipAddon(config),
       TranslationOverlaySurfaceId.ActionDetail or TranslationOverlaySurfaceId.ItemDetail =>
-          throw new NotSupportedException(
-              $"The {surfaceId} surface is rendered through the tooltip path."),
+          FromConfigForActionItemDetail(config, surfaceId),
       _ => throw new ArgumentOutOfRangeException(nameof(surfaceId), surfaceId, null),
     };
   }
@@ -540,6 +539,55 @@ internal record TranslationWindowConfig(
             TooltipAddonOverlayMaxWidthMode.ManualCap
                 ? Math.Clamp(
                     config.TooltipAddonOverlayManualMaxWidth / 1920f,
+                    0.10f,
+                    0.90f)
+                : 0f);
+  }
+
+  /// <summary>
+  /// Creates a <see cref="TranslationWindowConfig"/> instance based on the
+  /// provided <see cref="Config"/> for ActionDetail and ItemDetail overlays.
+  /// </summary>
+  /// <param name="config">The active plugin configuration.</param>
+  /// <param name="surfaceId">The detail overlay surface identifier.</param>
+  /// <returns>The shared detail-overlay configuration.</returns>
+  public static TranslationWindowConfig FromConfigForActionItemDetail(
+      Config config,
+      TranslationOverlaySurfaceId surfaceId)
+  {
+    var defaultTitle = surfaceId switch
+    {
+      TranslationOverlaySurfaceId.ActionDetail =>
+          Resources.OverlayWindowTitleActionTooltipTranslation,
+      TranslationOverlaySurfaceId.ItemDetail =>
+          Resources.OverlayWindowTitleItemTooltipTranslation,
+      _ => throw new ArgumentOutOfRangeException(nameof(surfaceId), surfaceId, null),
+    };
+
+    return new TranslationWindowConfig(
+        SurfaceId: surfaceId,
+        DefaultTitle: defaultTitle,
+        FontScale: config.ActionItemDetailOverlayFontScaleAdjustment,
+        WidthMultiplier: 1.0f,
+        HeightMultiplier: 1.0f,
+        TextColor: new Vector4(
+            config.ActionItemDetailOverlayTextColor.X,
+            config.ActionItemDetailOverlayTextColor.Y,
+            config.ActionItemDetailOverlayTextColor.Z,
+            1.0f),
+        PosCorrection: Vector2.Zero,
+        ForceShowTitle: false,
+        BackgroundOpacity: config.ActionItemDetailOverlayBackgroundOpacity,
+        AutoSizeToTextWithMaxWidth: true,
+        ExpandWidthToFitText:
+            config.ActionItemDetailOverlayMaxWidthMode ==
+            TooltipAddonOverlayMaxWidthMode.MatchNative,
+        MaxAutoExpandedWidthMultiplier: 1.35f,
+        MaxWidthViewportFraction:
+            config.ActionItemDetailOverlayMaxWidthMode ==
+            TooltipAddonOverlayMaxWidthMode.ManualCap
+                ? Math.Clamp(
+                    config.ActionItemDetailOverlayManualMaxWidth / 1920f,
                     0.10f,
                     0.90f)
                 : 0f);


### PR DESCRIPTION
Fixes #248

## Summary

- route `ActionDetail` and `ItemDetail` overlays through dedicated persisted overlay appearance settings instead of the old hard-coded tooltip-style config
- apply the dedicated width and line-height overrides in the shared overlay renderer so the controls actually affect those detail surfaces
- add a distinct configuration section for action/item detail overlays and visually separate the tooltip settings groups in the config tab

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] in-game verification was performed when runtime UI behavior changed

## AI Usage Disclosure

- [ ] `Assist`
- [x] `Pair`
- [ ] `Copilot`
- [ ] `Auto`

If you selected one of the levels above, describe the scope briefly:

```text
AI scope:
- tooling used: Codex
- files or areas most affected: ActionDetail/ItemDetail overlay config plumbing, tooltip config UI, overlay renderer, config/resource/test coverage
- how the result was reviewed/tested: repo diff review, local build/test validation, and in-game UI verification
```

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```