### PR TITLE
chore: prepare v4.2601.0806.0051 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
+## Submitted Release `v4.2601.0806.0051`
+
+This package submits the current `v4-series` head after the official
+publication of `v4.2601.0802.2355` on August 5, 2026 and focuses on
+MiniTalk native-layout stability, ActionDetail and ItemDetail overlay control
+activation, and safer localized plugin-label sync.
+
+Highlights:
+
+- preserved the visible `_MiniTalk` native bubble baseline in `Native` and
+  `Swap` mode when detached-container synchronization encounters recycled
+  container heights larger than the visible balloon
+- made `ActionDetail` and `ItemDetail` overlays honor dedicated persisted
+  width, line-height, padding, and color controls, and separated those
+  settings visually in the tooltip configuration tab
+- restored friendly localized plugin labels during the latest Crowdin resource
+  sync while keeping the new action/item detail overlay strings required by the
+  expanded tooltip configuration surface
+
 ## Published Release `v4.2601.0802.2355`
 
 This package ships the large native UI translation runtime expansion merged

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0802</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">2355</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0806</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">0051</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2952,10 +2952,6 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
-                Hosts debug-only automatic addon-probe watches that start on login for
-                selected addons with early hidden-state value.
-            </summary>
-            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
             </summary>
@@ -2965,11 +2961,6 @@
             </summary>
             <summary>
                 Handles bootstrap and teardown for the NamePlateGui translation runtime.
-            </summary>
-            <summary>
-                Handles the quest probe command used to inspect the complete quest data
-                shape from Lumina, the live quest progress resolver, and the current
-                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -2987,9 +2978,6 @@
             <summary>
                 Handles bootstrap and teardown for the alternate callback-owned
                 ToastGui route that owns supported normal and error toasts.
-            </summary>
-            <summary>
-            Handles the temporary tooltip-registration diagnostic command.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -3857,11 +3845,6 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
-        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
-            <summary>
-            Holds the currently active addon structure probe watch, if any.
-            </summary>
-        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -4050,11 +4033,6 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
-            <summary>
-                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -5995,109 +5973,6 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
-        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
-            <summary>
-                Ticks manual and automatic addon-probe watches, including the
-                debug-only login bootstrap for the default watch set.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
-            <summary>
-                Gets how many addon-probe watches are currently active across manual
-                and managed watch sets.
-            </summary>
-            <returns>The active probe-watch count.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
-            <summary>
-                Stops every active addon-probe watch known to the plugin.
-            </summary>
-            <param name="suppressAutoUntilLogout">
-                Whether the current login session should suppress the default
-                automatic watch set after the stop completes.
-            </param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
-            <summary>
-                Ticks the currently active manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
-            <summary>
-                Ticks every managed addon-probe watch and prunes the disposed ones.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic addon-probe watch set when the player
-                logs in, then resets the gate on logout.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic watch set used to capture early
-                structural state for pooled dialogue addons.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
-            <summary>
-                Starts one managed addon-probe watch and tracks it for later stop or
-                pruning.
-            </summary>
-            <param name="addonName">The addon name to watch.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="duration">How long the watch should stay alive.</param>
-            <param name="reason">The debug log reason attached to the startup.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
-            <summary>
-                Stops the current manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
-            <summary>
-                Stops every managed automatic addon-probe watch.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log so we can
-            inspect its live node tree, component roots, and likely overlay anchors.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
-            <summary>
-            Parses the addon probe command arguments into an addon name, optional index,
-            and optional watch duration.
-            </summary>
-            <param name="args">The raw command arguments.</param>
-            <returns>The addon name, index, and duration to probe.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
-            <summary>
-            Parses one addon-probe duration token such as "90s" or "15m".
-            </summary>
-            <param name="token">The raw duration token.</param>
-            <param name="duration">Receives the parsed duration.</param>
-            <returns><see langword="true"/> when the token parsed successfully.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
-            <summary>
-            Determines whether a token looks like an addon-probe duration even when the
-            value is outside the accepted range.
-            </summary>
-            <param name="token">The token to inspect.</param>
-            <returns><see langword="true"/> when the token resembles a duration.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
-            <summary>
-            Formats one addon-probe watch duration for chat feedback.
-            </summary>
-            <param name="duration">The duration to format.</param>
-            <returns>The human-readable duration string.</returns>
-        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -6545,102 +6420,6 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
-            <summary>
-                Handles the quest probe command.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
-            <summary>
-                Tries to resolve the quest probe target from either a quest id or a
-                quest name.
-            </summary>
-            <param name="input">The command argument.</param>
-            <param name="questIdText">The resolved quest id as text.</param>
-            <param name="questName">The resolved quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>True when the quest could be resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the quest data structure for inspection.
-            </summary>
-            <param name="questIdText">The quest id as text.</param>
-            <param name="questName">The quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the raw Lumina quest row properties.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs all rows from the quest text sheet, not just the live todo
-                entries, so we can inspect the full structure of the quest sheet.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
-            <summary>
-                Logs the QuestPlate rows currently stored for the quest.
-            </summary>
-            <param name="questIdText">The quest id text.</param>
-            <param name="questName">The quest name.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
-            <summary>
-                Logs the resolved live quest progression snapshot.
-            </summary>
-            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves a human-readable quest name from a quest row.
-            </summary>
-            <param name="questRow">The quest row.</param>
-            <returns>The resolved quest name, if available.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
-            <summary>
-                Converts quest text to a readable string for probe output.
-            </summary>
-            <param name="text">The quest text.</param>
-            <returns>The evaluated text string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
-            <summary>
-                Formats a probe value for log output.
-            </summary>
-            <param name="value">The value to format.</param>
-            <returns>A human-readable value string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Builds the raw quest sheet name used by the game files.
-            </summary>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>The quest text sheet name, if it can be derived.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest row id as text through reflection so the probe
-                stays compatible with generated sheet shapes.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest row id as text, or an empty string if unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest sheet identifier used to mount the quest text
-                sheet path.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -7481,14 +7260,6 @@
                 Unregisters the alternate supported-toast runtime from Dalamud's
                 normal and error-toast callbacks.
             </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloTooltipRegisterLoggingCommand(System.String,System.String)">
-            <summary>
-            Starts or stops temporary logging for hover-tooltip registrations and
-            hover-hit transitions.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
             <summary>
@@ -27523,46 +27294,6 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
-            <summary>
-                Encapsulates the login-session gating rules for debug-only automatic
-                addon-probe watches.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
-            <summary>
-                Determines whether the current login session should start the default
-                automatic addon-probe watch set.
-            </summary>
-            <param name="isLoggedIn">Whether the client is currently logged in.</param>
-            <param name="hasStartedForCurrentLogin">
-                Whether the current login session already started its automatic probe
-                set.
-            </param>
-            <param name="isSuppressedUntilLogout">
-                Whether the user explicitly suppressed the automatic probe set until
-                the next logout.
-            </param>
-            <param name="activeManagedWatchCount">
-                How many managed automatic probe watches are currently alive.
-            </param>
-            <returns>
-                <see langword="true" /> when the automatic probe set should start.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
-            <summary>
-                Determines whether the automatic login-session gate should reset
-                because the player logged out.
-            </summary>
-            <param name="wasLoggedIn">
-                Whether the client was logged in on the previous tick.
-            </param>
-            <param name="isLoggedIn">Whether the client is logged in now.</param>
-            <returns>
-                <see langword="true" /> when the automatic probe gate should reset.
-            </returns>
-        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -33440,7 +33171,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -40247,109 +39978,6 @@
             <param name="minScale">The minimum scale reached at the maximum distance.</param>
             <returns>The resolved distance-aware presentation state.</returns>
         </member>
-        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics">
-            <summary>
-            Emits temporary, deduplicated diagnostics for texture-backed overlay render
-            passes while complex-script overlay regressions are under investigation.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureUnavailable(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,Echoglossian.UIOverlays.TextPresentation.TextureRenderAttemptOutcome,System.ValueTuple{System.Int32,System.Int64,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32})">
-            <summary>
-            Logs one texture-backed overlay render pass that did not reach a drawn
-            state because the backing texture was unavailable.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <param name="surfaceId">The overlay surface identifier.</param>
-            <param name="request">The active overlay render request.</param>
-            <param name="textRequest">The resolved text-layout request.</param>
-            <param name="outcome">The texture-render decision.</param>
-            <param name="stats">The current RTL texture backend stats.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureDrawn(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
-            <summary>
-            Logs one successful texture-backed overlay draw.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <param name="surfaceId">The overlay surface identifier.</param>
-            <param name="request">The active overlay render request.</param>
-            <param name="textRequest">The resolved text-layout request.</param>
-            <param name="renderedPosition">The actual rendered window position.</param>
-            <param name="renderedSize">The actual rendered window size.</param>
-            <param name="bodySize">The measured body-text size.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldLog(Echoglossian.Config)">
-            <summary>
-            Determines whether texture-overlay diagnostics should run for the current
-            language mode.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <returns><see langword="true" /> when diagnostics should log.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldEmit(System.String,System.String)">
-            <summary>
-            Determines whether a deduplicated diagnostic line should be emitted.
-            </summary>
-            <param name="key">The stable diagnostic event key.</param>
-            <param name="signature">The event-state signature.</param>
-            <returns><see langword="true" /> when the line should be emitted.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreviewKey(System.String)">
-            <summary>
-            Builds the preview key used for deduplication.
-            </summary>
-            <param name="text">The source text.</param>
-            <returns>The stable preview key.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreview(System.String)">
-            <summary>
-            Builds a short preview for diagnostic log lines.
-            </summary>
-            <param name="text">The source text.</param>
-            <returns>The shortened preview text.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundVector(System.Numerics.Vector2,System.Single)">
-            <summary>
-            Rounds a vector to a coarse step size for deduplication.
-            </summary>
-            <param name="value">The source vector.</param>
-            <param name="step">The coarse rounding step.</param>
-            <returns>The rounded vector.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundToStep(System.Single,System.Single)">
-            <summary>
-            Rounds a scalar to the requested step size.
-            </summary>
-            <param name="value">The source value.</param>
-            <param name="step">The rounding step.</param>
-            <returns>The rounded scalar.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.FormatVector(System.Numerics.Vector2)">
-            <summary>
-            Formats a vector for diagnostic log output.
-            </summary>
-            <param name="value">The vector value.</param>
-            <returns>The formatted vector.</returns>
-        </member>
-        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState">
-            <summary>
-            Captures the last emitted signature and time for one diagnostic key.
-            </summary>
-            <param name="Signature">The emitted diagnostic-state signature.</param>
-            <param name="EmittedAtUtc">The time the signature was emitted.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.#ctor(System.String,System.DateTime)">
-            <summary>
-            Captures the last emitted signature and time for one diagnostic key.
-            </summary>
-            <param name="Signature">The emitted diagnostic-state signature.</param>
-            <param name="EmittedAtUtc">The time the signature was emitted.</param>
-        </member>
-        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.Signature">
-            <summary>The emitted diagnostic-state signature.</summary>
-        </member>
-        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.EmittedAtUtc">
-            <summary>The time the signature was emitted.</summary>
-        </member>
         <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay.RenderScale">
             <summary>
             Gets or sets the runtime scale multiplier used when rendering the overlay.
@@ -41369,6 +40997,289 @@
             Attribute to indicate the target class should be register for dependency injection as a transient service
             </summary>
             <typeparam name="TService">The type of the service to add.</typeparam>
+            <example>Register the class as an implementation for IService
+              <code>
+              [RegisterTransient&lt;IService&gt;]
+              public class TransientService : IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterTransientAttribute`2">
+            <summary>
+            Attribute to indicate the target class should be register for dependency injection as a transient service
+            </summary>
+            <typeparam name="TService">The type of the service to add.</typeparam>
+            <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
+            <example>Register the TransientService class as an implementation for IService
+              <code>
+              [RegisterTransient&lt;IService, TransientService&gt;]
+              public class TransientService: IService { }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute`1">
+            <summary>
+            Attribute to indicate the target class should be registered as a decorator for <typeparamref name="TService"/>.
+            </summary>
+            <typeparam name="TService">The type of the service to decorate.</typeparam>
+            <example>
+              <code>
+              [RegisterDecorator&lt;IService&gt;]
+              public class LoggingDecorator : IService
+              {
+                  public LoggingDecorator(IService inner) { }
+              }
+              </code>
+            </example>
+        </member>
+        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute`2">
+            <summary>
+            Attribute to indicate the target class should be registered as a decorator for <typeparamref name="TService"/>
+            using <typeparamref name="TImplementation"/> as the decorator implementation.
+            </summary>
+            <typeparam name="TService">The type of the service to decorate.</typeparam>
+            <typeparam name="TImplementation">The type of the decorator implementation.</typeparam>
+        </member>
+        <member name="T:Injectio.Extensions.DecorationExtensions">
+             <summary>
+             Provides extension methods for decorating registered services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+             </summary>
+             <remarks>
+             <para>
+             The <b>Decorator pattern</b> wraps an existing service with additional behavior without modifying the
+             original implementation. Each decorator implements the same interface as the service it wraps, creating
+             a chain of responsibility:
+             </para>
+             <para>
+             These methods work by replacing the <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/>
+             in-place within the service collection. The original factory, instance, or implementation type is captured
+             so the inner service can still be resolved. The replacement descriptor preserves the original lifetime.
+             Calling a decoration method multiple times stacks decorators, with the last call becoming the outermost layer.
+             </para>
+             <para><b>Usage example — decorating with a factory:</b></para>
+             <code>
+             // Register the original service
+             services.AddScoped&lt;INotificationService, EmailNotificationService&gt;();
+            
+             // Decorate with logging
+             services.Decorate&lt;INotificationService&gt;(
+                 (sp, inner) =&gt; new LoggingNotificationService(inner, sp.GetRequiredService&lt;ILogger&gt;()));
+            
+             // Decorate with retry (stacks on top of logging)
+             services.Decorate&lt;INotificationService&gt;(
+                 (sp, inner) =&gt; new RetryNotificationService(inner));
+            
+             // Resolution chain: Retry → Logging → Email
+             </code>
+             <para><b>Usage example — decorating open generics:</b></para>
+             <code>
+             // Register closed-generic implementations
+             services.AddScoped&lt;IRepository&lt;Order&gt;, OrderRepository&gt;();
+             services.AddScoped&lt;IRepository&lt;Customer&gt;, CustomerRepository&gt;();
+            
+             // Decorate all IRepository&lt;T&gt; with caching
+             services.DecorateOpenGeneric(
+                 typeof(IRepository&lt;&gt;), typeof(CachingRepository&lt;&gt;));
+             </code>
+             </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Func{System.IServiceProvider,System.Object,System.Object})">
+            <summary>
+            Decorates all non-keyed registrations matching <paramref name="serviceType"/> by wrapping each resolved instance
+            with <paramref name="decoratorFactory"/>.
+            </summary>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceType">The service type to decorate.</param>
+            <param name="decoratorFactory">A factory that receives the service provider and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method replaces matching <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/> entries in-place,
+            preserving each registration lifetime. Keyed registrations are skipped.
+            </para>
+            <para>
+            Multiple calls stack decorators, with the most recent decoration becoming the outermost layer.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Func{System.IServiceProvider,``0,``0})">
+            <summary>
+            Decorates all registrations of <typeparamref name="TService"/> by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
+            Keyed service registrations are skipped.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="decoratorFactory">A factory that receives the service provider and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            Decoration replaces each existing <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/> for
+            <typeparamref name="TService"/> in-place. The original descriptor's factory, instance, or implementation type is
+            captured and used to resolve the inner service, which is then passed to <paramref name="decoratorFactory"/>.
+            The replacement descriptor preserves the original registration's lifetime.
+            </para>
+            <para>
+            Multiple calls stack: each call wraps whatever factory is currently registered, enabling layered decoration.
+            Only non-keyed registrations are affected; use <c>DecorateKeyed</c> for keyed services.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate``2(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Decorates all registrations of <typeparamref name="TService"/> by wrapping each resolved instance
+            with an automatically constructed instance of <typeparamref name="TDecorator"/>.
+            Keyed service registrations are skipped.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <typeparam name="TDecorator">The decorator type. Its constructor must accept a <typeparamref name="TService"/> parameter for the inner service; additional parameters are resolved from the service provider.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This overload uses <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>
+            to construct the decorator, passing the inner service instance as an explicit argument. Any remaining
+            constructor parameters are resolved from the <see cref="T:System.IServiceProvider"/>.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Object,System.Func{System.IServiceProvider,System.Object,System.Object,System.Object})">
+            <summary>
+            Decorates keyed registrations matching <paramref name="serviceType"/> and <paramref name="serviceKey"/>
+            by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
+            </summary>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceType">The service type to decorate.</param>
+            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
+            <param name="decoratorFactory">A factory that receives the service provider, the key, and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method only processes keyed registrations and preserves both the original key and lifetime for each replacement descriptor.
+            </para>
+            <para>
+            Non-keyed registrations are skipped. Multiple calls stack decorators for matching keyed registrations.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Object,System.Func{System.IServiceProvider,System.Object,``0,``0})">
+            <summary>
+            Decorates all keyed registrations of <typeparamref name="TService"/> matching <paramref name="serviceKey"/>
+            by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
+            Pass <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to match all keys.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
+            <param name="decoratorFactory">A factory that receives the service provider, the key, and the original instance, and returns the decorated instance.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method iterates through all service descriptors for <typeparamref name="TService"/> and replaces each
+            keyed registration whose key matches <paramref name="serviceKey"/>. The original keyed factory, instance,
+            or implementation type is captured and used to resolve the inner service, which is then passed to
+            <paramref name="decoratorFactory"/> along with the service provider and key. The replacement descriptor
+            preserves the original registration's lifetime and key.
+            </para>
+            <para>
+            Non-keyed registrations are skipped; use <c>Decorate</c> for those. Multiple calls stack, enabling
+            layered decoration of keyed services.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed``2(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Object)">
+            <summary>
+            Decorates all keyed registrations of <typeparamref name="TService"/> matching <paramref name="serviceKey"/>
+            by wrapping each resolved instance with an automatically constructed instance of <typeparamref name="TDecorator"/>.
+            Pass <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to match all keys.
+            </summary>
+            <typeparam name="TService">The service type to decorate.</typeparam>
+            <typeparam name="TDecorator">The decorator type. Its constructor must accept a <typeparamref name="TService"/> parameter for the inner service; additional parameters are resolved from the service provider.</typeparam>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This overload uses <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>
+            to construct the decorator, passing the inner service instance as an explicit argument. Any remaining
+            constructor parameters are resolved from the <see cref="T:System.IServiceProvider"/>.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateOpenGeneric(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Type,System.Object)">
+            <summary>
+            Decorates all closed-generic registrations whose generic type definition matches <paramref name="openServiceType"/>
+            by wrapping each resolved instance with an instance of <paramref name="openDecoratorType"/>.
+            </summary>
+            <param name="services">The service collection containing the registrations to decorate.</param>
+            <param name="openServiceType">The open generic service type (e.g., <c>typeof(IRepository&lt;&gt;)</c>).</param>
+            <param name="openDecoratorType">The open generic decorator type that wraps the original service.</param>
+            <param name="serviceKey">
+            The key of the keyed registrations to decorate. Pass <see langword="null"/> to decorate non-keyed registrations,
+            or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to decorate all keyed registrations.
+            Keyed registration matching is only available on .NET 8 and later.
+            </param>
+            <returns>The same <paramref name="services"/> instance for chaining.</returns>
+            <remarks>
+            <para>
+            This method scans all service descriptors for closed-generic types whose generic type definition matches
+            <paramref name="openServiceType"/>. For each match, it closes <paramref name="openDecoratorType"/> over the
+            same type arguments and replaces the descriptor with a factory that resolves the original service and passes
+            it to <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>.
+            The replacement descriptor preserves the original registration's lifetime.
+            </para>
+            <para>
+            Open-generic descriptors (those registered with an open <c>typeof(T&lt;&gt;)</c> service type) are skipped
+            because the DI container resolves them lazily and replacing the implementation type would cause recursive
+            resolution. When <paramref name="serviceKey"/> is <see langword="null"/>, keyed registrations are skipped.
+            When <paramref name="serviceKey"/> is non-null on .NET 8 and later, non-keyed registrations are skipped and
+            only keyed registrations with the matching key are decorated.
+            </para>
+            </remarks>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the TimerTextPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.TimerTextPattern_0.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.Utilities">
+            <summary>Helper methods used by generated <see cref="T:System.Text.RegularExpressions.Regex"/>-derived implementations.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout">
+            <summary>Default timeout value set in <see cref="T:System.AppContext"/>, or <see cref="F:System.Text.RegularExpressions.Regex.InfiniteMatchTimeout"/> if none was set.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_hasTimeout">
+            <summary>Whether <see cref="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout"/> is non-infinite.</summary>
+        </member>
+    </members>
+</doc>
+he service to add.</typeparam>
             <example>Register the class as an implementation for IService
               <code>
               [RegisterTransient&lt;IService&gt;]


### PR DESCRIPTION
## Summary

- bump `Echoglossian.csproj` to `v4.2601.0806.0051` for the next `v4-series` submission
- add the submitted changelog entry covering the MiniTalk baseline fix, ActionDetail and ItemDetail overlay-control activation, and the safe Crowdin terminology sync follow-up
- refresh the validated generated `Echoglossian.xml` output for the exact release-preparation commit

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] `dotnet build Echoglossian.csproj -c Release --no-restore`

## AI Usage Disclosure

- [ ] `Assist`
- [x] `Pair`
- [ ] `Copilot`
- [ ] `Auto`

If you selected one of the levels above, describe the scope briefly:

```text
AI scope:
- tooling used: Codex
- files or areas most affected: release version metadata, changelog entry, and validated generated XML docs
- how the result was reviewed/tested: manual diff review plus local Debug build, test execution, and Release build validation
```

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```