### PR TITLE
fix: isolate compact detached baseline to MiniTalk

### DIFF
--- a/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
+++ b/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
@@ -349,12 +349,12 @@ public class NativeTextNodeLayoutHelperTests
     }
 
     /// <summary>
-    ///     Ensures detached MiniTalk-style component roots do not become the
-    ///     permanent minimum bubble height when the visible nine-grid background
-    ///     is much smaller and no explicit tooltip padding policy is requested.
+    ///     Ensures detached-container synchronization keeps the historical
+    ///     largest container extent by default so tooltip and toast surfaces do
+    ///     not shrink their root containers unexpectedly.
     /// </summary>
     [Fact]
-    public void ResolveSynchronizedContainerExtent_PrefersVisibleBackgroundBaseline_WhenDetachedPrimaryIsLargerAndNoPaddingIsRequested()
+    public void ResolveSynchronizedContainerExtent_PreservesLargestDetachedBaseline_ByDefault()
     {
         var resolvedExtent = NativeTextNodeLayoutHelper.ResolveSynchronizedContainerExtent(
             primaryContainerExtent: 192,
@@ -362,6 +362,45 @@ public class NativeTextNodeLayoutHelperTests
             currentTextExtent: 37,
             measuredTextExtent: 38,
             minimumSecondaryPadding: 0);
+
+        Assert.Equal((ushort)192, resolvedExtent);
+    }
+
+    /// <summary>
+    ///     Ensures detached MiniTalk-style component roots can explicitly prefer
+    ///     the compact bubble baseline when the detached primary container is
+    ///     the stale oversize surface from a recycled slot.
+    /// </summary>
+    [Fact]
+    public void ResolveSynchronizedContainerExtent_PrefersCompactDetachedBaseline_WhenRequestedAndPrimaryIsStale()
+    {
+        var resolvedExtent = NativeTextNodeLayoutHelper.ResolveSynchronizedContainerExtent(
+            primaryContainerExtent: 192,
+            secondaryContainerExtent: 42,
+            currentTextExtent: 37,
+            measuredTextExtent: 38,
+            minimumSecondaryPadding: 0,
+            preferCompactDetachedBaseline: true);
+
+        Assert.Equal((ushort)43, resolvedExtent);
+    }
+
+    /// <summary>
+    ///     Ensures detached MiniTalk-style component roots can also recover
+    ///     when the visible nine-grid background is the stale oversize surface
+    ///     from a recycled slot and the detached primary height is the compact
+    ///     baseline that should win.
+    /// </summary>
+    [Fact]
+    public void ResolveSynchronizedContainerExtent_PrefersCompactDetachedBaseline_WhenRequestedAndSecondaryIsStale()
+    {
+        var resolvedExtent = NativeTextNodeLayoutHelper.ResolveSynchronizedContainerExtent(
+            primaryContainerExtent: 42,
+            secondaryContainerExtent: 192,
+            currentTextExtent: 37,
+            measuredTextExtent: 38,
+            minimumSecondaryPadding: 0,
+            preferCompactDetachedBaseline: true);
 
         Assert.Equal((ushort)43, resolvedExtent);
     }

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -606,6 +606,7 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
           textNode,
           replacementText,
           allowWidthGrowth: true,
+          preferCompactDetachedBaselineForHeight: true,
           additionalWrapWidth: this.ResolveMiniTalkAdditionalWrapWidth(
               addon,
               textNode));

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -252,6 +252,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     The minimum vertical padding to preserve inside the secondary
   ///     container when it grows.
   /// </param>
+  /// <param name="preferCompactDetachedBaselineForHeight">
+  ///     Whether detached-container height synchronization should explicitly
+  ///     prefer the more compact of the preserved container baselines instead
+  ///     of preserving the largest detached extent.
+  /// </param>
   public static void ResizeFromSnapshot(
       NativeTextNodeLayoutSnapshot snapshot,
       NativeTextNodeResizeResult resizeResult,
@@ -261,7 +266,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
       bool allowWidthGrowth = false,
       bool restoreHorizontalCentering = true,
       int minimumSecondaryHorizontalPadding = 0,
-      int minimumSecondaryVerticalPadding = 0)
+      int minimumSecondaryVerticalPadding = 0,
+      bool preferCompactDetachedBaselineForHeight = false)
   {
     var childWidth = resizeResult.Width;
     var childHeight = resizeResult.Height;
@@ -324,7 +330,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
             snapshot.SecondaryContainerHeight,
             snapshot.TextHeight,
             resizeResult.Height,
-            minimumSecondaryVerticalPadding);
+            minimumSecondaryVerticalPadding,
+            preferCompactDetachedBaseline: preferCompactDetachedBaselineForHeight);
         if (synchronizedHeight > 0)
         {
           primaryContainerNode->SetHeight(synchronizedHeight);
@@ -360,7 +367,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
                 snapshot.SecondaryContainerHeight,
                 snapshot.TextHeight,
                 resizeResult.Height,
-                minimumSecondaryVerticalPadding)
+                minimumSecondaryVerticalPadding,
+                preferCompactDetachedBaseline: preferCompactDetachedBaselineForHeight)
             : ResolveExpandedContainerExtent(
                 snapshot.SecondaryContainerHeight,
                 snapshot.TextHeight,
@@ -610,6 +618,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     The minimum vertical padding to preserve inside the secondary
   ///     background when it grows.
   /// </param>
+  /// <param name="preferCompactDetachedBaselineForHeight">
+  ///     Whether detached-container height synchronization should explicitly
+  ///     prefer the more compact of the preserved container baselines instead
+  ///     of preserving the largest detached extent.
+  /// </param>
   /// <param name="measureReplacementWidthBeforeApply">
   ///     Whether the candidate replacement text should be measured before
   ///     native apply so width growth can use its draw width.
@@ -627,6 +640,7 @@ internal static unsafe class NativeTextNodeLayoutHelper
       ushort additionalWrapWidth = 0,
       int minimumSecondaryHorizontalPadding = 0,
       int minimumSecondaryVerticalPadding = 0,
+      bool preferCompactDetachedBaselineForHeight = false,
       bool measureReplacementWidthBeforeApply = false,
       byte[]? replacementPayload = null)
   {
@@ -674,7 +688,9 @@ internal static unsafe class NativeTextNodeLayoutHelper
         allowWidthGrowth: allowWidthGrowth,
         restoreHorizontalCentering: restoreHorizontalCentering,
         minimumSecondaryHorizontalPadding: minimumSecondaryHorizontalPadding,
-        minimumSecondaryVerticalPadding: minimumSecondaryVerticalPadding);
+        minimumSecondaryVerticalPadding: minimumSecondaryVerticalPadding,
+        preferCompactDetachedBaselineForHeight:
+        preferCompactDetachedBaselineForHeight);
     return snapshot;
   }
 
@@ -964,22 +980,40 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     The explicit padding that should remain inside the synchronized
   ///     tooltip-style background.
   /// </param>
+  /// <param name="preferCompactDetachedBaseline">
+  ///     Whether the synchronized extent should explicitly prefer the more
+  ///     compact of the preserved detached-container baselines instead of
+  ///     preserving the largest detached extent.
+  /// </param>
   /// <returns>The synchronized extent shared by both containers.</returns>
   public static ushort ResolveSynchronizedContainerExtent(
       ushort primaryContainerExtent,
       ushort secondaryContainerExtent,
       ushort currentTextExtent,
       ushort measuredTextExtent,
-      int minimumSecondaryPadding)
+      int minimumSecondaryPadding,
+      bool preferCompactDetachedBaseline = false)
   {
-    if (minimumSecondaryPadding <= 0 &&
-        secondaryContainerExtent > 0)
+    if (preferCompactDetachedBaseline)
     {
+      var compactBaseline = primaryContainerExtent > 0 &&
+                            secondaryContainerExtent > 0
+          ? Math.Min(
+              primaryContainerExtent,
+              secondaryContainerExtent)
+          : Math.Max(
+              primaryContainerExtent,
+              secondaryContainerExtent);
+      if (compactBaseline <= 0)
+      {
+        return 0;
+      }
+
       return ResolveExpandedContainerExtent(
-          secondaryContainerExtent,
+          compactBaseline,
           currentTextExtent,
           measuredTextExtent,
-          minimumPadding: 0);
+          minimumSecondaryPadding);
     }
 
     var baseExtent = Math.Max(


### PR DESCRIPTION
Summary:
- isolate the compact detached-container height baseline preference to _MiniTalk_
- keep the shared layout helper default behavior unchanged for tooltip and toast style callers
- add regression coverage for stale-primary and stale-secondary recycled MiniTalk bubble paths

Root cause:
The shared detached-container synchronization default preserves the largest historical container extent, which is still correct for general tooltip and toast callers. _MiniTalk_ can instead recycle a stale oversized detached container from an earlier bubble slot, so it needs a MiniTalk-specific opt-in that prefers the compact preserved baseline without changing the shared helper default.

Validation:
- dotnet build .\\Echoglossian.sln -c Debug --no-restore
- dotnet test .\\Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build
- dotnet test .\\Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --filter NativeTextNodeLayoutHelperTests --no-build