### PR TITLE
chore: prepare v4.2601.0807.1730 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
+## Submitted Release `v4.2601.0807.1730`
+
+This package submits the current `v4-series` head after the follow-up
+MiniTalk native-layout regression fix and keeps the release focused on the
+remaining recycled-bubble height edge case.
+
+Submitted for `DalamudPluginsD17` publication on 2026-08-07.
+
+Highlights:
+
+- isolates the compact detached-container baseline preference to `_MiniTalk_`
+  so recycled oversized bubble slots stop stretching later native dialogue
+  balloons in `Native` and `Swap` mode
+- keeps the shared detached-container layout helper default unchanged for the
+  tooltip and toast-style callers that still need the historical larger
+  baseline behavior
+- adds regression coverage for both stale-primary and stale-secondary recycled
+  `_MiniTalk_` detached-container height paths
+
 ## Published Release `v4.2601.0806.0051`
 
 This package was published to the official Dalamud feed and focuses on

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0806</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">0051</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0807</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">1730</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -29183,7 +29183,7 @@
             </param>
             <returns>The measured size after the text replacement.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResizeFromSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,Echoglossian.NativeUI.Helpers.NativeTextNodeResizeResult,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean,System.Boolean,System.Int32,System.Int32)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResizeFromSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,Echoglossian.NativeUI.Helpers.NativeTextNodeResizeResult,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean,System.Boolean,System.Int32,System.Int32,System.Boolean)">
             <summary>
                 Resizes the supplied container nodes using the text delta captured in a
                 pre-replacement layout snapshot.
@@ -29216,6 +29216,11 @@
                 The minimum vertical padding to preserve inside the secondary
                 container when it grows.
             </param>
+            <param name="preferCompactDetachedBaselineForHeight">
+                Whether detached-container height synchronization should explicitly
+                prefer the more compact of the preserved container baselines instead
+                of preserving the largest detached extent.
+            </param>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean,System.Boolean)">
             <summary>
@@ -29245,7 +29250,7 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.Boolean,System.Boolean,System.UInt16,System.Int32,System.Int32,System.Boolean,System.Byte[])">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.Boolean,System.Boolean,System.UInt16,System.Int32,System.Int32,System.Boolean,System.Boolean,System.Byte[])">
             <summary>
                 Applies translated text to a node and grows its wrapper chain plus the
                 nearest nine-grid background using inferred padding from the current
@@ -29272,6 +29277,11 @@
             <param name="minimumSecondaryVerticalPadding">
                 The minimum vertical padding to preserve inside the secondary
                 background when it grows.
+            </param>
+            <param name="preferCompactDetachedBaselineForHeight">
+                Whether detached-container height synchronization should explicitly
+                prefer the more compact of the preserved container baselines instead
+                of preserving the largest detached extent.
             </param>
             <param name="measureReplacementWidthBeforeApply">
                 Whether the candidate replacement text should be measured before
@@ -29386,7 +29396,7 @@
             <param name="minimumPadding">The minimum padding to preserve.</param>
             <returns>The expanded container extent.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveSynchronizedContainerExtent(System.UInt16,System.UInt16,System.UInt16,System.UInt16,System.Int32)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveSynchronizedContainerExtent(System.UInt16,System.UInt16,System.UInt16,System.UInt16,System.Int32,System.Boolean)">
             <summary>
                 Resolves one shared extent for detached tooltip-style containers that
                 must stay visually aligned even when the text node does not live under
@@ -29399,6 +29409,11 @@
             <param name="minimumSecondaryPadding">
                 The explicit padding that should remain inside the synchronized
                 tooltip-style background.
+            </param>
+            <param name="preferCompactDetachedBaseline">
+                Whether the synchronized extent should explicitly prefer the more
+                compact of the preserved detached-container baselines instead of
+                preserving the largest detached extent.
             </param>
             <returns>The synchronized extent shared by both containers.</returns>
         </member>
@@ -40997,289 +41012,6 @@
             Attribute to indicate the target class should be register for dependency injection as a transient service
             </summary>
             <typeparam name="TService">The type of the service to add.</typeparam>
-            <example>Register the class as an implementation for IService
-              <code>
-              [RegisterTransient&lt;IService&gt;]
-              public class TransientService : IService { }
-              </code>
-            </example>
-        </member>
-        <member name="T:Injectio.Attributes.RegisterTransientAttribute`2">
-            <summary>
-            Attribute to indicate the target class should be register for dependency injection as a transient service
-            </summary>
-            <typeparam name="TService">The type of the service to add.</typeparam>
-            <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
-            <example>Register the TransientService class as an implementation for IService
-              <code>
-              [RegisterTransient&lt;IService, TransientService&gt;]
-              public class TransientService: IService { }
-              </code>
-            </example>
-        </member>
-        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute`1">
-            <summary>
-            Attribute to indicate the target class should be registered as a decorator for <typeparamref name="TService"/>.
-            </summary>
-            <typeparam name="TService">The type of the service to decorate.</typeparam>
-            <example>
-              <code>
-              [RegisterDecorator&lt;IService&gt;]
-              public class LoggingDecorator : IService
-              {
-                  public LoggingDecorator(IService inner) { }
-              }
-              </code>
-            </example>
-        </member>
-        <member name="T:Injectio.Attributes.RegisterDecoratorAttribute`2">
-            <summary>
-            Attribute to indicate the target class should be registered as a decorator for <typeparamref name="TService"/>
-            using <typeparamref name="TImplementation"/> as the decorator implementation.
-            </summary>
-            <typeparam name="TService">The type of the service to decorate.</typeparam>
-            <typeparam name="TImplementation">The type of the decorator implementation.</typeparam>
-        </member>
-        <member name="T:Injectio.Extensions.DecorationExtensions">
-             <summary>
-             Provides extension methods for decorating registered services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
-             </summary>
-             <remarks>
-             <para>
-             The <b>Decorator pattern</b> wraps an existing service with additional behavior without modifying the
-             original implementation. Each decorator implements the same interface as the service it wraps, creating
-             a chain of responsibility:
-             </para>
-             <para>
-             These methods work by replacing the <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/>
-             in-place within the service collection. The original factory, instance, or implementation type is captured
-             so the inner service can still be resolved. The replacement descriptor preserves the original lifetime.
-             Calling a decoration method multiple times stacks decorators, with the last call becoming the outermost layer.
-             </para>
-             <para><b>Usage example — decorating with a factory:</b></para>
-             <code>
-             // Register the original service
-             services.AddScoped&lt;INotificationService, EmailNotificationService&gt;();
-            
-             // Decorate with logging
-             services.Decorate&lt;INotificationService&gt;(
-                 (sp, inner) =&gt; new LoggingNotificationService(inner, sp.GetRequiredService&lt;ILogger&gt;()));
-            
-             // Decorate with retry (stacks on top of logging)
-             services.Decorate&lt;INotificationService&gt;(
-                 (sp, inner) =&gt; new RetryNotificationService(inner));
-            
-             // Resolution chain: Retry → Logging → Email
-             </code>
-             <para><b>Usage example — decorating open generics:</b></para>
-             <code>
-             // Register closed-generic implementations
-             services.AddScoped&lt;IRepository&lt;Order&gt;, OrderRepository&gt;();
-             services.AddScoped&lt;IRepository&lt;Customer&gt;, CustomerRepository&gt;();
-            
-             // Decorate all IRepository&lt;T&gt; with caching
-             services.DecorateOpenGeneric(
-                 typeof(IRepository&lt;&gt;), typeof(CachingRepository&lt;&gt;));
-             </code>
-             </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Func{System.IServiceProvider,System.Object,System.Object})">
-            <summary>
-            Decorates all non-keyed registrations matching <paramref name="serviceType"/> by wrapping each resolved instance
-            with <paramref name="decoratorFactory"/>.
-            </summary>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <param name="serviceType">The service type to decorate.</param>
-            <param name="decoratorFactory">A factory that receives the service provider and the original instance, and returns the decorated instance.</param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            This method replaces matching <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/> entries in-place,
-            preserving each registration lifetime. Keyed registrations are skipped.
-            </para>
-            <para>
-            Multiple calls stack decorators, with the most recent decoration becoming the outermost layer.
-            </para>
-            </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Func{System.IServiceProvider,``0,``0})">
-            <summary>
-            Decorates all registrations of <typeparamref name="TService"/> by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
-            Keyed service registrations are skipped.
-            </summary>
-            <typeparam name="TService">The service type to decorate.</typeparam>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <param name="decoratorFactory">A factory that receives the service provider and the original instance, and returns the decorated instance.</param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            Decoration replaces each existing <see cref="T:Microsoft.Extensions.DependencyInjection.ServiceDescriptor"/> for
-            <typeparamref name="TService"/> in-place. The original descriptor's factory, instance, or implementation type is
-            captured and used to resolve the inner service, which is then passed to <paramref name="decoratorFactory"/>.
-            The replacement descriptor preserves the original registration's lifetime.
-            </para>
-            <para>
-            Multiple calls stack: each call wraps whatever factory is currently registered, enabling layered decoration.
-            Only non-keyed registrations are affected; use <c>DecorateKeyed</c> for keyed services.
-            </para>
-            </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.Decorate``2(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
-            <summary>
-            Decorates all registrations of <typeparamref name="TService"/> by wrapping each resolved instance
-            with an automatically constructed instance of <typeparamref name="TDecorator"/>.
-            Keyed service registrations are skipped.
-            </summary>
-            <typeparam name="TService">The service type to decorate.</typeparam>
-            <typeparam name="TDecorator">The decorator type. Its constructor must accept a <typeparamref name="TService"/> parameter for the inner service; additional parameters are resolved from the service provider.</typeparam>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            This overload uses <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>
-            to construct the decorator, passing the inner service instance as an explicit argument. Any remaining
-            constructor parameters are resolved from the <see cref="T:System.IServiceProvider"/>.
-            </para>
-            </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Object,System.Func{System.IServiceProvider,System.Object,System.Object,System.Object})">
-            <summary>
-            Decorates keyed registrations matching <paramref name="serviceType"/> and <paramref name="serviceKey"/>
-            by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
-            </summary>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <param name="serviceType">The service type to decorate.</param>
-            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
-            <param name="decoratorFactory">A factory that receives the service provider, the key, and the original instance, and returns the decorated instance.</param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            This method only processes keyed registrations and preserves both the original key and lifetime for each replacement descriptor.
-            </para>
-            <para>
-            Non-keyed registrations are skipped. Multiple calls stack decorators for matching keyed registrations.
-            </para>
-            </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Object,System.Func{System.IServiceProvider,System.Object,``0,``0})">
-            <summary>
-            Decorates all keyed registrations of <typeparamref name="TService"/> matching <paramref name="serviceKey"/>
-            by wrapping each resolved instance with <paramref name="decoratorFactory"/>.
-            Pass <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to match all keys.
-            </summary>
-            <typeparam name="TService">The service type to decorate.</typeparam>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
-            <param name="decoratorFactory">A factory that receives the service provider, the key, and the original instance, and returns the decorated instance.</param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            This method iterates through all service descriptors for <typeparamref name="TService"/> and replaces each
-            keyed registration whose key matches <paramref name="serviceKey"/>. The original keyed factory, instance,
-            or implementation type is captured and used to resolve the inner service, which is then passed to
-            <paramref name="decoratorFactory"/> along with the service provider and key. The replacement descriptor
-            preserves the original registration's lifetime and key.
-            </para>
-            <para>
-            Non-keyed registrations are skipped; use <c>Decorate</c> for those. Multiple calls stack, enabling
-            layered decoration of keyed services.
-            </para>
-            </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateKeyed``2(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Object)">
-            <summary>
-            Decorates all keyed registrations of <typeparamref name="TService"/> matching <paramref name="serviceKey"/>
-            by wrapping each resolved instance with an automatically constructed instance of <typeparamref name="TDecorator"/>.
-            Pass <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to match all keys.
-            </summary>
-            <typeparam name="TService">The service type to decorate.</typeparam>
-            <typeparam name="TDecorator">The decorator type. Its constructor must accept a <typeparamref name="TService"/> parameter for the inner service; additional parameters are resolved from the service provider.</typeparam>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <param name="serviceKey">The key to match, or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> for all keys.</param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            This overload uses <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>
-            to construct the decorator, passing the inner service instance as an explicit argument. Any remaining
-            constructor parameters are resolved from the <see cref="T:System.IServiceProvider"/>.
-            </para>
-            </remarks>
-        </member>
-        <member name="M:Injectio.Extensions.DecorationExtensions.DecorateOpenGeneric(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Type,System.Type,System.Object)">
-            <summary>
-            Decorates all closed-generic registrations whose generic type definition matches <paramref name="openServiceType"/>
-            by wrapping each resolved instance with an instance of <paramref name="openDecoratorType"/>.
-            </summary>
-            <param name="services">The service collection containing the registrations to decorate.</param>
-            <param name="openServiceType">The open generic service type (e.g., <c>typeof(IRepository&lt;&gt;)</c>).</param>
-            <param name="openDecoratorType">The open generic decorator type that wraps the original service.</param>
-            <param name="serviceKey">
-            The key of the keyed registrations to decorate. Pass <see langword="null"/> to decorate non-keyed registrations,
-            or <see cref="P:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey"/> to decorate all keyed registrations.
-            Keyed registration matching is only available on .NET 8 and later.
-            </param>
-            <returns>The same <paramref name="services"/> instance for chaining.</returns>
-            <remarks>
-            <para>
-            This method scans all service descriptors for closed-generic types whose generic type definition matches
-            <paramref name="openServiceType"/>. For each match, it closes <paramref name="openDecoratorType"/> over the
-            same type arguments and replaces the descriptor with a factory that resolves the original service and passes
-            it to <see cref="M:Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(System.IServiceProvider,System.Type,System.Object[])"/>.
-            The replacement descriptor preserves the original registration's lifetime.
-            </para>
-            <para>
-            Open-generic descriptors (those registered with an open <c>typeof(T&lt;&gt;)</c> service type) are skipped
-            because the DI container resolves them lazily and replacing the implementation type would cause recursive
-            resolution. When <paramref name="serviceKey"/> is <see langword="null"/>, keyed registrations are skipped.
-            When <paramref name="serviceKey"/> is non-null on .NET 8 and later, non-keyed registrations are skipped and
-            only keyed registrations with the matching key are decorated.
-            </para>
-            </remarks>
-        </member>
-        <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0">
-            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the TimerTextPattern method.</summary>
-        </member>
-        <member name="F:System.Text.RegularExpressions.Generated.TimerTextPattern_0.Instance">
-            <summary>Cached, thread-safe singleton instance.</summary>
-        </member>
-        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.#ctor">
-            <summary>Initializes the instance.</summary>
-        </member>
-        <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory">
-            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
-        </member>
-        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.CreateInstance">
-            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
-        </member>
-        <member name="T:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner">
-            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
-        </member>
-        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
-            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
-            <param name="inputSpan">The text being scanned by the regular expression.</param>
-        </member>
-        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
-            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
-            <param name="inputSpan">The text being scanned by the regular expression.</param>
-            <returns>true if a possible match was found; false if no more matches are possible.</returns>
-        </member>
-        <member name="M:System.Text.RegularExpressions.Generated.TimerTextPattern_0.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
-            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
-            <param name="inputSpan">The text being scanned by the regular expression.</param>
-            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
-        </member>
-        <member name="T:System.Text.RegularExpressions.Generated.Utilities">
-            <summary>Helper methods used by generated <see cref="T:System.Text.RegularExpressions.Regex"/>-derived implementations.</summary>
-        </member>
-        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout">
-            <summary>Default timeout value set in <see cref="T:System.AppContext"/>, or <see cref="F:System.Text.RegularExpressions.Regex.InfiniteMatchTimeout"/> if none was set.</summary>
-        </member>
-        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_hasTimeout">
-            <summary>Whether <see cref="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout"/> is non-infinite.</summary>
-        </member>
-    </members>
-</doc>
-he service to add.</typeparam>
             <example>Register the class as an implementation for IService
               <code>
               [RegisterTransient&lt;IService&gt;]


### PR DESCRIPTION
## Summary
- bump Echoglossian to v4.2601.0807.1730
- add the submitted changelog entry for the MiniTalk recycled-bubble follow-up release
- commit the validated Echoglossian.xml update produced by the real release build

## Root Cause
The MiniTalk compact-baseline follow-up was merged after the previous published release v4.2601.0806.0051, so we need a new release preparation commit on top of the current v4-series head before tagging and updating DalamudPluginsD17.

## Validation
- `dotnet build .\\Echoglossian.sln -c Debug --no-restore`
- `dotnet test .\\Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build .\\Echoglossian.csproj -c Release --no-restore`