### PR TITLE
docs: finalize v4.2601.0807.1730 publication bookkeeping

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,11 @@ Select one when applicable:
 - [ ] `Copilot` — AI did most of the writing while the human planned and reviewed
 - [ ] `Auto` — AI acted mostly autonomously with minimal human direction
 
+For Echoglossian release and submission work, do not choose `Auto` when the
+human reported or scoped the issue, approved the plan or release steps,
+reviewed the diff, or performed local or in-game QA before submission. That
+workflow is still `Assist`.
+
 If you selected one of the levels above, describe the scope briefly:
 
 ```text

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,10 +22,10 @@ Select one when applicable:
 - [ ] `Copilot` — AI did most of the writing while the human planned and reviewed
 - [ ] `Auto` — AI acted mostly autonomously with minimal human direction
 
-For Echoglossian release and submission work, do not choose `Auto` when the
-human reported or scoped the issue, approved the plan or release steps,
-reviewed the diff, or performed local or in-game QA before submission. That
-workflow is still `Assist`.
+For Echoglossian release and submission work, this note does not mean every PR
+requires disclosure. When disclosure is required, do not choose `Auto` solely
+because an agent executed many intermediate steps under human direction,
+approval, review, or QA.
 
 If you selected one of the levels above, describe the scope briefly:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
-## Submitted Release `v4.2601.0807.1730`
+## Published Release `v4.2601.0807.1730`
 
-This package submits the current `v4-series` head after the follow-up
+This package was published to the official Dalamud feed after the follow-up
 MiniTalk native-layout regression fix and keeps the release focused on the
 remaining recycled-bubble height edge case.
 
-Submitted for `DalamudPluginsD17` publication on 2026-08-07.
+Published in `DalamudPluginsD17` via
+[PR #9163](https://github.com/goatcorp/DalamudPluginsD17/pull/9163) on
+2026-08-08.
 
 Highlights:
 

--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -1,6 +1,6 @@
 # GitHub Issue Backlog
 
-Snapshot date: 2026-08-06
+Snapshot date: 2026-08-08
 
 This document is the operational snapshot for open issues in
 [`lokinmodar/Echoglossian`](https://github.com/lokinmodar/Echoglossian/issues).
@@ -9,23 +9,24 @@ release history belongs in [`CHANGELOG.md`](../CHANGELOG.md), not in this file.
 
 ## Published Release Baseline
 
-- Release: [`v4.2601.0806.0051`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0806.0051)
-- Product commit: `8d776af8223aaff8df1cb250cf983fac70a47536`
-- Official submission: [`goatcorp/DalamudPluginsD17#9151`](https://github.com/goatcorp/DalamudPluginsD17/pull/9151)
-- D17 status: approved and merged on 2026-08-06
-- D17 merge commit: `831baf32566e3cd0650840582a93f593da06f075`
-- Open issues after post-publication triage: 19
-- Open issues at the current audit head: 19
-- Focused open issues besides the living tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12): 18
+- Release: [`v4.2601.0807.1730`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0807.1730)
+- Product commit: `9a39a2be87c3a376448f2967ccc5225c63b1e69c`
+- Official submission: [`goatcorp/DalamudPluginsD17#9163`](https://github.com/goatcorp/DalamudPluginsD17/pull/9163)
+- D17 status: approved and merged on 2026-08-08
+- D17 merge commit: `12ca53c2095b4be958d61e065565131723c0e75e`
+- Open issues after post-publication triage: 20
+- Open issues at the current audit head: 20
+- Focused open issues besides the living tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12): 19
 
 ## Current `v4-series` Delta
 
-- Audit head: `origin/v4-series` at `8d776af8223aaff8df1cb250cf983fac70a47536`
-- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0806.0051` at `8d776af8223aaff8df1cb250cf983fac70a47536`
+- Audit head: `origin/v4-series` at `9a39a2be87c3a376448f2967ccc5225c63b1e69c`
+- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0807.1730` at `9a39a2be87c3a376448f2967ccc5225c63b1e69c`
 - The audit head currently matches the latest published runtime baseline; there are no newer `v4-series` commits beyond this published release.
 - Issue [#12](https://github.com/lokinmodar/Echoglossian/issues/12) remains the living known-issues tracker and should stay aligned with this document whenever focused issue state changes materially.
-- Publication of `v4.2601.0806.0051` completed [#246](https://github.com/lokinmodar/Echoglossian/issues/246).
+- Publication of `v4.2601.0807.1730` completed the recycled `_MiniTalk` follow-up for [#246](https://github.com/lokinmodar/Echoglossian/issues/246).
 - New focused prompt and glossary behavior work is currently tracked in [#252](https://github.com/lokinmodar/Echoglossian/issues/252).
+- New performance and persistence architecture work is now tracked in [#258](https://github.com/lokinmodar/Echoglossian/issues/258).
 - Draft PR [#193](https://github.com/lokinmodar/Echoglossian/pull/193) remains open only as a separate follow-up if the narrower native `JournalDetail` translated-text reflow work is still wanted.
 - The open-issue inventory remains grouped by problem type instead of by workflow state so the remaining work is easier to prioritize by subsystem.
 
@@ -36,7 +37,7 @@ most relevant resolved fronts to reference during follow-up triage.
 
 | Issue | Published resolution |
 | --- | --- |
-| [#246 `_MiniTalk` native bubble dimensions regress in `Native` and `Swap` modes`](https://github.com/lokinmodar/Echoglossian/issues/246) | The `_MiniTalk` native reflow path now preserves the visible bubble baseline in `Native` and `Swap` mode instead of carrying detached container heights forward into later translated balloons. |
+| [#246 `_MiniTalk` native bubble dimensions regress in `Native` and `Swap` modes`](https://github.com/lokinmodar/Echoglossian/issues/246) | The published follow-up release now isolates the compact detached-container baseline preference to `_MiniTalk_`, preventing recycled oversized bubble slots from stretching later translated balloons while keeping the shared tooltip and toast behavior unchanged. |
 | [#15 ActionDetail / ItemDetail tooltip translation](https://github.com/lokinmodar/Echoglossian/issues/15) | The DB-first structured tooltip flow is active in production with cache-gap prefetch, source-id binding, atomic detail updates, and native/overlay ownership safeguards. |
 | [#68 Selection dialogs and other specific surfaces](https://github.com/lokinmodar/Echoglossian/issues/68) | `SelectYesNo`, `SelectOk`, `SelectString`, `SelectIconString`, and `CutSceneSelectString` are shipped; the historical `ChatBubble` entry is covered by the production `_MiniTalk` / `MiniTalk` runtime. |
 | [#103 Interactible WorldObjects](https://github.com/lokinmodar/Echoglossian/issues/103) | Eligible nameplate/world-object presentation now supports native translation plus distance-aware overlay fallback with configurable scaling, fading, and cutoff behavior. |
@@ -111,9 +112,15 @@ most relevant resolved fronts to reference during follow-up triage.
 | [#192 Configuration screenshots](https://github.com/lokinmodar/Echoglossian/issues/192) | Documentation and UI enhancement has not been implemented. |
 | [#239 Generic batched translation fallback hardening](https://github.com/lokinmodar/Echoglossian/issues/239) | The published narrow fix rejects unchanged batch echoes, but structured transport, provider-echo classification, and negative-result cooldown remain open. |
 
+### Performance, Scheduling, And Persistence Architecture
+
+| Issue | Current reason |
+| --- | --- |
+| [#258 Runtime DB access and prefetch architecture](https://github.com/lokinmodar/Echoglossian/issues/258) | New RCA and remediation track for synchronous EF/SQLite work in runtime callbacks, unbounded prefetch, queue pressure, and plugin-correlated frametime pulses. |
+
 ## Complete Open-Issue Inventory
 
-This table is the countable audit of all 19 open issues at the snapshot date, including the living meta-tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12).
+This table is the countable audit of all 20 open issues at the snapshot date, including the living meta-tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12).
 
 | Problem type | Issues | Count |
 | --- | --- | ---: |
@@ -123,7 +130,8 @@ This table is the countable audit of all 19 open issues at the snapshot date, in
 | Overlay and presentation behavior | #167, #175 | 2 |
 | Translation engines, prompts, and provider support | #148, #176, #203, #209, #212, #214, #252 | 7 |
 | Compatibility, diagnostics, and UX polish | #173, #179, #192, #239 | 4 |
-| **Total open at snapshot** |  | **19** |
+| Performance, scheduling, and persistence architecture | #258 | 1 |
+| **Total open at snapshot** |  | **20** |
 
 ## Next Actions
 
@@ -131,6 +139,7 @@ This table is the countable audit of all 19 open issues at the snapshot date, in
 2. Prioritize the new concrete coverage work in [#237](https://github.com/lokinmodar/Echoglossian/issues/237) and [#238](https://github.com/lokinmodar/Echoglossian/issues/238).
 3. Triage the new prompt and glossary report in [#252](https://github.com/lokinmodar/Echoglossian/issues/252) to determine whether the defect is Gemini-specific, glossary-pipeline-specific, or a prompt-routing mismatch against the current LLM flow.
 4. Continue the structural remediation in [#239](https://github.com/lokinmodar/Echoglossian/issues/239) beyond the already published unchanged-batch fallback fix.
-5. Decide whether draft PR [#193](https://github.com/lokinmodar/Echoglossian/pull/193) should be reconciled, retargeted, or closed now that [#181](https://github.com/lokinmodar/Echoglossian/issues/181) itself is resolved.
-6. Monitor reporter retests on [#167](https://github.com/lokinmodar/Echoglossian/issues/167), [#175](https://github.com/lokinmodar/Echoglossian/issues/175), and [#203](https://github.com/lokinmodar/Echoglossian/issues/203) and close only after the exact symptom is validated or replaced by a more focused issue.
-7. Re-run the open-issue audit and refresh [#12](https://github.com/lokinmodar/Echoglossian/issues/12) whenever issue state changes again or when the next runtime or provider-support tranche lands.
+5. Decide whether [#258](https://github.com/lokinmodar/Echoglossian/issues/258) should stay as one bounded performance architecture front or be split further once the first remediation tranche lands.
+6. Decide whether draft PR [#193](https://github.com/lokinmodar/Echoglossian/pull/193) should be reconciled, retargeted, or closed now that [#181](https://github.com/lokinmodar/Echoglossian/issues/181) itself is resolved.
+7. Monitor reporter retests on [#167](https://github.com/lokinmodar/Echoglossian/issues/167), [#175](https://github.com/lokinmodar/Echoglossian/issues/175), and [#203](https://github.com/lokinmodar/Echoglossian/issues/203) and close only after the exact symptom is validated or replaced by a more focused issue.
+8. Re-run the open-issue audit and refresh [#12](https://github.com/lokinmodar/Echoglossian/issues/12) whenever issue state changes again or when the next runtime or provider-support tranche lands.

--- a/docs/official-plugin-repo-ai-usage-disclosure.md
+++ b/docs/official-plugin-repo-ai-usage-disclosure.md
@@ -40,6 +40,22 @@ For this repo, the expected workflow is:
 4. keep the disclosure concise but specific enough that a reviewer can tell how
    the work was produced and validated
 
+## Repo Default For Supervised Release Work
+
+For Echoglossian, treat the workflow as `Assist`, not `Auto`, when the human:
+
+- reported or scoped the issue being fixed
+- reviewed or approved the implementation or release plan
+- retained the ability to stop or redirect the work at each step
+- reviewed the resulting diff
+- performed local, in-game, or release-gate validation before submission
+
+That is still human-led work even when the agent executed many intermediate
+steps.
+
+Use `Auto` only when the agent truly operated with minimal human direction and
+minimal human review before the official submission.
+
 ## Important Clarification For Echoglossian
 
 Echoglossian can call machine-translation and LLM providers at runtime as part
@@ -70,6 +86,9 @@ Human verification:
 - ran local build and tests
 - performed in-game verification where applicable
 ```
+
+If the human also controlled issue triage, plan approval, or release approval,
+say so explicitly instead of escalating the disclosure level to `Auto`.
 
 ## Asset Disclosure Reminder
 

--- a/docs/official-plugin-repo-ai-usage-disclosure.md
+++ b/docs/official-plugin-repo-ai-usage-disclosure.md
@@ -40,21 +40,22 @@ For this repo, the expected workflow is:
 4. keep the disclosure concise but specific enough that a reviewer can tell how
    the work was produced and validated
 
-## Repo Default For Supervised Release Work
+## Avoid Overstating Autonomy
 
-For Echoglossian, treat the workflow as `Assist`, not `Auto`, when the human:
+These notes do not mean every official `DalamudPluginsD17` submission requires
+AI disclosure, and they do not mean every disclosed submission should say
+`Assist`.
 
-- reported or scoped the issue being fixed
-- reviewed or approved the implementation or release plan
-- retained the ability to stop or redirect the work at each step
-- reviewed the resulting diff
-- performed local, in-game, or release-gate validation before submission
+The first step is still to determine whether disclosure is required at all
+under the Goatcorp policy.
 
-That is still human-led work even when the agent executed many intermediate
-steps.
+When disclosure is required, do not escalate the level to `Auto` solely because
+an agent executed many intermediate implementation or release steps.
 
-Use `Auto` only when the agent truly operated with minimal human direction and
-minimal human review before the official submission.
+Human-scoped, human-reviewed, human-approved, and human-QA'd work is not
+autonomous by itself. Use `Auto` only when the agent truly operated with
+minimal human direction and minimal human review before the official
+submission.
 
 ## Important Clarification For Echoglossian
 
@@ -87,8 +88,8 @@ Human verification:
 - performed in-game verification where applicable
 ```
 
-If the human also controlled issue triage, plan approval, or release approval,
-say so explicitly instead of escalating the disclosure level to `Auto`.
+If the human also controlled issue triage, plan approval, release approval, or
+QA, say so explicitly instead of overstating autonomy.
 
 ## Asset Disclosure Reminder
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -38,6 +38,10 @@ has merged.
 4. Commit and push the release preparation on the issue branch.
 5. Open a ready pull request against `v4-series` with a high-level change
    summary, validation results, related issues, and the required AI disclosure.
+   For this repo, do not default to `Auto` when the user reported the issue,
+   reviewed or approved the plan, reviewed the resulting changes, or retained
+   QA control through local and in-game validation. That workflow remains
+   human-led and should normally be disclosed as `Assist`.
 6. Wait for required checks and merge the pull request. GitHub does not permit
    authors to approve their own pull requests; use the repository's permitted
    merge path after checks pass rather than representing self-review as an
@@ -87,6 +91,13 @@ In `C:\Dante\_dalamud\DalamudPluginsD17`:
 The official pull request must include the disclosure defined in
 `docs/official-plugin-repo-ai-usage-disclosure.md`. Runtime-generated text
 textures are not AI-generated repository assets.
+
+When choosing the official disclosure level:
+
+- default to `Assist` when the user is still directing scope, approving
+  implementation or release steps, reviewing diffs, and performing QA
+- do not use `Auto` unless the agent truly acted with minimal human direction
+  and minimal human review before submission
 
 ## 5. Finish Publication
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -38,10 +38,9 @@ has merged.
 4. Commit and push the release preparation on the issue branch.
 5. Open a ready pull request against `v4-series` with a high-level change
    summary, validation results, related issues, and the required AI disclosure.
-   For this repo, do not default to `Auto` when the user reported the issue,
-   reviewed or approved the plan, reviewed the resulting changes, or retained
-   QA control through local and in-game validation. That workflow remains
-   human-led and should normally be disclosed as `Assist`.
+   This does not mean every release PR requires disclosure. When disclosure is
+   required by policy, do not overstate autonomy solely because an agent
+   executed many intermediate steps under human direction and review.
 6. Wait for required checks and merge the pull request. GitHub does not permit
    authors to approve their own pull requests; use the repository's permitted
    merge path after checks pass rather than representing self-review as an
@@ -94,8 +93,10 @@ textures are not AI-generated repository assets.
 
 When choosing the official disclosure level:
 
-- default to `Assist` when the user is still directing scope, approving
-  implementation or release steps, reviewing diffs, and performing QA
+- first determine whether disclosure is required at all under the official
+  policy
+- if disclosure is required, choose the lowest accurate level instead of
+  overstating autonomy
 - do not use `Auto` unless the agent truly acted with minimal human direction
   and minimal human review before submission
 


### PR DESCRIPTION
## Summary
- mark `v4.2601.0807.1730` as published in the changelog and release backlog
- refresh the backlog snapshot after the official `DalamudPluginsD17` merge on August 8, 2026
- document that supervised Echoglossian release submissions should default to `Assist`, not `Auto`

## Why
The official `DalamudPluginsD17` PR for `v4.2601.0807.1730` has merged, so the repo needs its normal post-publication bookkeeping. This also locks in the clarified AI disclosure rule so future official submissions do not overstate autonomy when the user is still directing scope, approving plans, reviewing diffs, and controlling QA.

## Additional GitHub updates
- updated issue `#12` to the new published baseline and open-issue inventory
- added a published-release comment to issue `#246`

## Validation
- not run; documentation-only and issue-tracker updates