### PR TITLE
fix(i18n): apply plugin resource culture

### DIFF
--- a/Echoglossian.Tests/PluginCultureLocaleNormalizationTests.cs
+++ b/Echoglossian.Tests/PluginCultureLocaleNormalizationTests.cs
@@ -3,7 +3,10 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using System.Globalization;
 using System.Reflection;
+
+using Echoglossian.Properties;
 
 using Xunit;
 
@@ -16,12 +19,50 @@ namespace Echoglossian.Tests;
 public sealed class PluginCultureLocaleNormalizationTests
 {
     /// <summary>
+    ///     Ensures applying a persisted neutral culture also configures the
+    ///     strongly typed resource accessor used throughout the plugin UI.
+    /// </summary>
+    [Fact]
+    public void ApplyPersistedCultureName_SetsStronglyTypedResourceCulture()
+    {
+        var previousCulture = Resources.Culture;
+
+        try
+        {
+            var helperType = typeof(Config).Assembly.GetType("Echoglossian.PluginCultureLocaleHelper");
+            Assert.NotNull(helperType);
+
+            var method = helperType!.GetMethod(
+                "ApplyPersistedCultureName",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var culture = Assert.IsType<CultureInfo>(method!.Invoke(null, ["fr"]));
+
+            Assert.Equal("fr-FR", culture.Name);
+            Assert.Equal("fr-FR", Resources.Culture?.Name);
+
+            var resourceSet = Resources.ResourceManager.GetResourceSet(
+                culture,
+                true,
+                false);
+            Assert.NotNull(resourceSet);
+            Assert.NotNull(resourceSet!.GetString("ConfigWindowTitle"));
+        }
+        finally
+        {
+            Resources.Culture = previousCulture;
+        }
+    }
+
+    /// <summary>
     ///     Ensures legacy neutral culture codes are promoted to the locale-
     ///     specific resource names now used by plugin UI resources.
     /// </summary>
     /// <param name="input">The persisted culture value.</param>
     /// <param name="expected">The normalized culture value.</param>
     [Theory]
+    [InlineData("ca", "ca-ES")]
     [InlineData("da", "da-DK")]
     [InlineData("de", "de-DE")]
     [InlineData("el", "el-GR")]
@@ -29,6 +70,7 @@ public sealed class PluginCultureLocaleNormalizationTests
     [InlineData("eu", "eu-ES")]
     [InlineData("fr", "fr-FR")]
     [InlineData("it", "it-IT")]
+    [InlineData("nl", "nl-NL")]
     [InlineData("pt", "pt-PT")]
     [InlineData("pt-BR", "pt-BR")]
     [InlineData("ru", "ru-RU")]

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -188,7 +188,8 @@ public partial class Echoglossian : IDalamudPlugin
         normalizedPluginCulture,
         StringComparison.Ordinal);
     this.configuration.DefaultPluginCulture = normalizedPluginCulture;
-    this.cultureInfo = new CultureInfo(normalizedPluginCulture);
+    this.cultureInfo = PluginCultureLocaleHelper.ApplyPersistedCultureName(
+        normalizedPluginCulture);
     if (persistedConfig == null)
     {
       PluginInterface.SavePluginConfig(this.configuration);

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -2952,6 +2952,10 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
+                Hosts debug-only automatic addon-probe watches that start on login for
+                selected addons with early hidden-state value.
+            </summary>
+            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
             </summary>
@@ -2961,6 +2965,11 @@
             </summary>
             <summary>
                 Handles bootstrap and teardown for the NamePlateGui translation runtime.
+            </summary>
+            <summary>
+                Handles the quest probe command used to inspect the complete quest data
+                shape from Lumina, the live quest progress resolver, and the current
+                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -2978,6 +2987,9 @@
             <summary>
                 Handles bootstrap and teardown for the alternate callback-owned
                 ToastGui route that owns supported normal and error toasts.
+            </summary>
+            <summary>
+            Handles the temporary tooltip-registration diagnostic command.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -3845,6 +3857,11 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
+        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
+            <summary>
+            Holds the currently active addon structure probe watch, if any.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -4033,6 +4050,11 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
+            <summary>
+                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -5973,6 +5995,109 @@
             Handles the registration of addon handlers.
             </summary>
         </member>
+        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
+            <summary>
+                Ticks manual and automatic addon-probe watches, including the
+                debug-only login bootstrap for the default watch set.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
+            <summary>
+                Gets how many addon-probe watches are currently active across manual
+                and managed watch sets.
+            </summary>
+            <returns>The active probe-watch count.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
+            <summary>
+                Stops every active addon-probe watch known to the plugin.
+            </summary>
+            <param name="suppressAutoUntilLogout">
+                Whether the current login session should suppress the default
+                automatic watch set after the stop completes.
+            </param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
+            <summary>
+                Ticks the currently active manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
+            <summary>
+                Ticks every managed addon-probe watch and prunes the disposed ones.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic addon-probe watch set when the player
+                logs in, then resets the gate on logout.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic watch set used to capture early
+                structural state for pooled dialogue addons.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
+            <summary>
+                Starts one managed addon-probe watch and tracks it for later stop or
+                pruning.
+            </summary>
+            <param name="addonName">The addon name to watch.</param>
+            <param name="index">The addon instance index.</param>
+            <param name="duration">How long the watch should stay alive.</param>
+            <param name="reason">The debug log reason attached to the startup.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
+            <summary>
+                Stops the current manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
+            <summary>
+                Stops every managed automatic addon-probe watch.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
+            <summary>
+            Dumps a recursive probe of the requested addon to the log so we can
+            inspect its live node tree, component roots, and likely overlay anchors.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
+            <summary>
+            Parses the addon probe command arguments into an addon name, optional index,
+            and optional watch duration.
+            </summary>
+            <param name="args">The raw command arguments.</param>
+            <returns>The addon name, index, and duration to probe.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
+            <summary>
+            Parses one addon-probe duration token such as "90s" or "15m".
+            </summary>
+            <param name="token">The raw duration token.</param>
+            <param name="duration">Receives the parsed duration.</param>
+            <returns><see langword="true"/> when the token parsed successfully.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
+            <summary>
+            Determines whether a token looks like an addon-probe duration even when the
+            value is outside the accepted range.
+            </summary>
+            <param name="token">The token to inspect.</param>
+            <returns><see langword="true"/> when the token resembles a duration.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
+            <summary>
+            Formats one addon-probe watch duration for chat feedback.
+            </summary>
+            <param name="duration">The duration to format.</param>
+            <returns>The human-readable duration string.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -6420,6 +6545,102 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
+            <summary>
+                Handles the quest probe command.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
+            <summary>
+                Tries to resolve the quest probe target from either a quest id or a
+                quest name.
+            </summary>
+            <param name="input">The command argument.</param>
+            <param name="questIdText">The resolved quest id as text.</param>
+            <param name="questName">The resolved quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>True when the quest could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the quest data structure for inspection.
+            </summary>
+            <param name="questIdText">The quest id as text.</param>
+            <param name="questName">The quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the raw Lumina quest row properties.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs all rows from the quest text sheet, not just the live todo
+                entries, so we can inspect the full structure of the quest sheet.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
+            <summary>
+                Logs the QuestPlate rows currently stored for the quest.
+            </summary>
+            <param name="questIdText">The quest id text.</param>
+            <param name="questName">The quest name.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Logs the resolved live quest progression snapshot.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves a human-readable quest name from a quest row.
+            </summary>
+            <param name="questRow">The quest row.</param>
+            <returns>The resolved quest name, if available.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
+            <summary>
+                Converts quest text to a readable string for probe output.
+            </summary>
+            <param name="text">The quest text.</param>
+            <returns>The evaluated text string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
+            <summary>
+                Formats a probe value for log output.
+            </summary>
+            <param name="value">The value to format.</param>
+            <returns>A human-readable value string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Builds the raw quest sheet name used by the game files.
+            </summary>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>The quest text sheet name, if it can be derived.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest row id as text through reflection so the probe
+                stays compatible with generated sheet shapes.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest row id as text, or an empty string if unavailable.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest sheet identifier used to mount the quest text
+                sheet path.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -7260,6 +7481,14 @@
                 Unregisters the alternate supported-toast runtime from Dalamud's
                 normal and error-toast callbacks.
             </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloTooltipRegisterLoggingCommand(System.String,System.String)">
+            <summary>
+            Starts or stops temporary logging for hover-tooltip registrations and
+            hover-hit transitions.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
             <summary>
@@ -12081,6 +12310,14 @@
                 Normalizes persisted plugin resource culture names to the locale-
                 specific resource files used by the plugin UI.
             </summary>
+        </member>
+        <member name="M:Echoglossian.PluginCultureLocaleHelper.ApplyPersistedCultureName(System.String)">
+            <summary>
+                Normalizes and applies the persisted plugin culture to the strongly
+                typed resource accessor used throughout the plugin UI.
+            </summary>
+            <param name="cultureName">The persisted culture name.</param>
+            <returns>The normalized culture applied to plugin resources.</returns>
         </member>
         <member name="M:Echoglossian.PluginCultureLocaleHelper.NormalizePersistedCultureName(System.String)">
             <summary>
@@ -27294,6 +27531,46 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
+            <summary>
+                Encapsulates the login-session gating rules for debug-only automatic
+                addon-probe watches.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
+            <summary>
+                Determines whether the current login session should start the default
+                automatic addon-probe watch set.
+            </summary>
+            <param name="isLoggedIn">Whether the client is currently logged in.</param>
+            <param name="hasStartedForCurrentLogin">
+                Whether the current login session already started its automatic probe
+                set.
+            </param>
+            <param name="isSuppressedUntilLogout">
+                Whether the user explicitly suppressed the automatic probe set until
+                the next logout.
+            </param>
+            <param name="activeManagedWatchCount">
+                How many managed automatic probe watches are currently alive.
+            </param>
+            <returns>
+                <see langword="true" /> when the automatic probe set should start.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
+            <summary>
+                Determines whether the automatic login-session gate should reset
+                because the player logged out.
+            </summary>
+            <param name="wasLoggedIn">
+                Whether the client was logged in on the previous tick.
+            </param>
+            <param name="isLoggedIn">Whether the client is logged in now.</param>
+            <returns>
+                <see langword="true" /> when the automatic probe gate should reset.
+            </returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -33186,7 +33463,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -39992,6 +40269,109 @@
             <param name="maxDistance">The distance at which the overlay becomes hidden.</param>
             <param name="minScale">The minimum scale reached at the maximum distance.</param>
             <returns>The resolved distance-aware presentation state.</returns>
+        </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics">
+            <summary>
+            Emits temporary, deduplicated diagnostics for texture-backed overlay render
+            passes while complex-script overlay regressions are under investigation.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureUnavailable(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,Echoglossian.UIOverlays.TextPresentation.TextureRenderAttemptOutcome,System.ValueTuple{System.Int32,System.Int64,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32})">
+            <summary>
+            Logs one texture-backed overlay render pass that did not reach a drawn
+            state because the backing texture was unavailable.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <param name="surfaceId">The overlay surface identifier.</param>
+            <param name="request">The active overlay render request.</param>
+            <param name="textRequest">The resolved text-layout request.</param>
+            <param name="outcome">The texture-render decision.</param>
+            <param name="stats">The current RTL texture backend stats.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureDrawn(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Logs one successful texture-backed overlay draw.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <param name="surfaceId">The overlay surface identifier.</param>
+            <param name="request">The active overlay render request.</param>
+            <param name="textRequest">The resolved text-layout request.</param>
+            <param name="renderedPosition">The actual rendered window position.</param>
+            <param name="renderedSize">The actual rendered window size.</param>
+            <param name="bodySize">The measured body-text size.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldLog(Echoglossian.Config)">
+            <summary>
+            Determines whether texture-overlay diagnostics should run for the current
+            language mode.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <returns><see langword="true" /> when diagnostics should log.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldEmit(System.String,System.String)">
+            <summary>
+            Determines whether a deduplicated diagnostic line should be emitted.
+            </summary>
+            <param name="key">The stable diagnostic event key.</param>
+            <param name="signature">The event-state signature.</param>
+            <returns><see langword="true" /> when the line should be emitted.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreviewKey(System.String)">
+            <summary>
+            Builds the preview key used for deduplication.
+            </summary>
+            <param name="text">The source text.</param>
+            <returns>The stable preview key.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreview(System.String)">
+            <summary>
+            Builds a short preview for diagnostic log lines.
+            </summary>
+            <param name="text">The source text.</param>
+            <returns>The shortened preview text.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundVector(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Rounds a vector to a coarse step size for deduplication.
+            </summary>
+            <param name="value">The source vector.</param>
+            <param name="step">The coarse rounding step.</param>
+            <returns>The rounded vector.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundToStep(System.Single,System.Single)">
+            <summary>
+            Rounds a scalar to the requested step size.
+            </summary>
+            <param name="value">The source value.</param>
+            <param name="step">The rounding step.</param>
+            <returns>The rounded scalar.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.FormatVector(System.Numerics.Vector2)">
+            <summary>
+            Formats a vector for diagnostic log output.
+            </summary>
+            <param name="value">The vector value.</param>
+            <returns>The formatted vector.</returns>
+        </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState">
+            <summary>
+            Captures the last emitted signature and time for one diagnostic key.
+            </summary>
+            <param name="Signature">The emitted diagnostic-state signature.</param>
+            <param name="EmittedAtUtc">The time the signature was emitted.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.#ctor(System.String,System.DateTime)">
+            <summary>
+            Captures the last emitted signature and time for one diagnostic key.
+            </summary>
+            <param name="Signature">The emitted diagnostic-state signature.</param>
+            <param name="EmittedAtUtc">The time the signature was emitted.</param>
+        </member>
+        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.Signature">
+            <summary>The emitted diagnostic-state signature.</summary>
+        </member>
+        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.EmittedAtUtc">
+            <summary>The time the signature was emitted.</summary>
         </member>
         <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay.RenderScale">
             <summary>

--- a/GeneralHelpers/PluginCultureLocaleHelper.cs
+++ b/GeneralHelpers/PluginCultureLocaleHelper.cs
@@ -3,6 +3,10 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using System.Globalization;
+
+using global::Echoglossian.Properties;
+
 namespace Echoglossian;
 
 /// <summary>
@@ -14,6 +18,8 @@ internal static class PluginCultureLocaleHelper
   private static readonly IReadOnlyDictionary<string, string> CanonicalCultureNames =
       new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
       {
+        ["ca"] = "ca-ES",
+        ["ca-ES"] = "ca-ES",
         ["da"] = "da-DK",
         ["da-DK"] = "da-DK",
         ["de"] = "de-DE",
@@ -28,12 +34,27 @@ internal static class PluginCultureLocaleHelper
         ["fr-FR"] = "fr-FR",
         ["it"] = "it-IT",
         ["it-IT"] = "it-IT",
+        ["nl"] = "nl-NL",
+        ["nl-NL"] = "nl-NL",
         ["pt"] = "pt-PT",
         ["pt-PT"] = "pt-PT",
         ["pt-BR"] = "pt-BR",
         ["ru"] = "ru-RU",
         ["ru-RU"] = "ru-RU",
       };
+
+  /// <summary>
+  ///     Normalizes and applies the persisted plugin culture to the strongly
+  ///     typed resource accessor used throughout the plugin UI.
+  /// </summary>
+  /// <param name="cultureName">The persisted culture name.</param>
+  /// <returns>The normalized culture applied to plugin resources.</returns>
+  internal static CultureInfo ApplyPersistedCultureName(string? cultureName)
+  {
+    var cultureInfo = new CultureInfo(NormalizePersistedCultureName(cultureName));
+    Resources.Culture = cultureInfo;
+    return cultureInfo;
+  }
 
   /// <summary>
   ///     Promotes legacy neutral culture codes to the canonical locale-

--- a/docs/localization-build-flow.md
+++ b/docs/localization-build-flow.md
@@ -8,12 +8,37 @@ Keep Echoglossian's localization build safe for:
 - Plogon / `DalamudPluginsD17`
 - environments without Visual Studio
 
+For the incident that established these rules, see the
+[August 2026 localization post-mortem](localization-crowdin-runtime-postmortem-2026-08.md).
+
 ## Source Of Truth
 
 - `Properties/Resources.resx` defines the strongly typed resource keys.
-- `Properties/Resources.*.resx` store localized values used at runtime.
+- Crowdin is the source of truth for translated values after the one-time
+  repository import.
+- `Properties/Resources.*.resx` are Crowdin outputs that store only translated,
+  approved values used at runtime. They are intentionally partial; missing keys
+  fall back to `Resources.resx`.
 - `MultilingualResources/*.xlf` remain optional localization assets and are not
   required for the plugin build to succeed.
+
+## Crowdin Safety Invariants
+
+- Keep the export mapping at
+  `Properties/Resources.%locale%.resx`. `%locale%` is required to distinguish
+  locales such as `pt-BR` and `pt-PT`; do not replace it with a two-letter
+  language placeholder.
+- Keep `skipUntranslatedStrings`, `exportTranslatedOnly`, and
+  `exportApprovedOnly` enabled in the effective Crowdin project configuration.
+- **One-time translation import after the branch is connected** may be used to
+  bootstrap an integration from known-good repository translations.
+- Keep **Always import new translations from the repository** disabled after
+  bootstrap.
+- Do not use **Sync Translations to Crowdin** during routine synchronization.
+  Use normal source synchronization so generated Crowdin output cannot become
+  translation input in a feedback loop.
+- Recheck these settings after reconnecting the GitHub integration or changing
+  its branch configuration.
 
 ## Locale Naming Rules
 
@@ -32,13 +57,20 @@ Current rule set:
 
 Runtime culture normalization now treats:
 
+- `ca` as `ca-ES`
+- `nl` as `nl-NL`
 - `pt` as `pt-PT`
 - `pt-PT` as `pt-PT`
 - `pt-BR` as its own separate locale
 
 `DefaultPluginCulture` is normalized on startup and when configuration is
-saved, so persisted plugin culture values converge to the locale-specific form
-used by the current runtime.
+saved. The normalized `CultureInfo` must be assigned to `Resources.Culture`
+before the first plugin UI or notification lookup; relying on Dalamud's thread
+UI culture can silently select the English root resource.
+
+When a target locale is added or renamed, update its normalization mapping and
+add a test that loads one translated key from the exact resource set without
+parent fallback.
 
 ## Build-Safe Rule
 
@@ -84,23 +116,39 @@ Refresh the generated support matrices and the runtime map at
 .\scripts\update-translation-surface-docs.ps1
 ```
 
-1. Add or update keys in `Properties/Resources.resx`.
-2. Add localized values in the corresponding `Properties/Resources.*.resx`
-   files.
-3. If you add or rename a runtime locale, also update the docs-site locale map
+1. Add or update English keys in `Properties/Resources.resx` only.
+2. Synchronize the source file to Crowdin. Let translators update localized
+   values there, then export approved translations to the generated branch.
+3. Review the generated PR and reject it if:
+
+   - a localized file becomes a near-complete copy of the English source
+   - localized values become source-equivalent in bulk
+   - multiple locale files become identical
+   - an unexpected locale or two-letter resource filename appears
+   - approved phrase counts or localized entry counts regress unexpectedly
+   - a supposed recovery contains only formatting changes
+4. Spot-check an established translation for every changed locale and confirm
+   that `Resources.resx` was not changed by the translation export.
+5. If you add or rename a runtime locale, also update the docs-site locale map
    and validate it:
 
 ```powershell
 node .\Echoglossian.Docs\scripts\check-locales.mjs
 ```
 
-4. Build normally:
+6. Build and run the main tests:
 
 ```powershell
 dotnet build Echoglossian.sln -c Debug --no-restore
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build
 ```
 
-5. Commit the updated `.resx` files and the generated
+7. Run the Plogon-like verification and confirm that every expected locale has
+   a matching `<locale>/Echoglossian.resources.dll` satellite assembly.
+8. Verify one known translated lookup and one missing-key English fallback. If
+   runtime culture behavior changed, also verify one user-visible label or
+   notification in-game.
+9. Commit the updated `.resx` files and the generated
    `Properties/Resources.Designer.cs`.
 
 ## Local Plogon-Like Verification

--- a/docs/localization-crowdin-runtime-postmortem-2026-08.md
+++ b/docs/localization-crowdin-runtime-postmortem-2026-08.md
@@ -1,0 +1,403 @@
+# Localization Incident Post-Mortem: Crowdin Data Integrity and Runtime Culture
+
+- **Incident window:** August 1-8, 2026
+- **Recovery date:** August 7, 2026
+- **Runtime fix:** [PR #260](https://github.com/lokinmodar/Echoglossian/pull/260)
+- **Status:** Translation data recovered; runtime fix and permanent guardrails in progress
+- **Audience:** Echoglossian maintainers and localization administrators
+
+## Executive Summary
+
+During the migration from neutral-language resource names to locale-specific
+`.resx` names, Echoglossian experienced two related but technically separate
+failures:
+
+1. Crowdin exported untranslated entries as English source text. Those
+   source-filled localized files were later imported back into Crowdin and
+   approved, displacing correct historical translations as the active
+   variants.
+2. The plugin normalized its configured locale but did not assign that culture
+   to `Echoglossian.Properties.Resources.Culture`. Most UI lookups therefore
+   depended on Dalamud's thread UI culture and could silently fall back to the
+   English root resource even when the correct locale satellite assembly was
+   packaged.
+
+No historical translation data was permanently deleted. Crowdin retained the
+previous translations as alternate variants and in translation memory. On
+August 7, maintainers corrected the export policy, restored the historical
+variants, removed only the bad active approvals, and verified representative
+translations. PR #260 makes resource lookup use the plugin's configured locale
+explicitly and adds regression coverage.
+
+The filename pattern `Resources.%locale%.resx` was not the cause and remains
+required. Region-specific locales such as `pt-BR` and `pt-PT` must remain
+distinct. The incident resulted from unsafe synchronization semantics, an
+unreviewed source-filled export/import cycle, and a missing runtime culture
+assignment.
+
+## Impact
+
+- Existing translations appeared to disappear from Crowdin because English
+  source-equivalent variants became the approved variants.
+- Generated localized `.resx` files expanded from partial translation files to
+  near-complete copies of the English source file.
+- Plugin UI could render in English on user systems even when a translated
+  satellite assembly existed and the user selected a supported plugin locale.
+- The generated localization PR became unsafe to merge as a recovery vehicle.
+- Maintainer time was required to reconstruct the event, restore approvals,
+  audit translations, and verify build artifacts.
+
+The incident affected plugin-owned UI resources. It did not change translator
+engine output, database contents, or FFXIV native UI translation data.
+
+## Detection
+
+The incident was detected through user-visible loss of translations and an
+unexpected generated localization diff. The strongest forensic signals were:
+
+- A localized file suddenly contained every source key instead of only its
+  translated subset.
+- Most localized values became byte-for-byte equal to the English source.
+- Correct Crowdin translations still existed, but as unapproved historical
+  variants.
+- Packaged locale satellite assemblies existed while runtime UI lookup still
+  returned English.
+
+These signals should have been automated invariants rather than manual
+forensics.
+
+## Timeline
+
+| Date | Event | Evidence |
+| --- | --- | --- |
+| 2026-08-01 | Runtime resource files moved toward locale-specific names. | Commit `a7ba2c6` (`chore(i18n): use locale-specific resx`). |
+| 2026-08-03 20:19 -03:00 | Crowdin mapping was changed to export `Resources.%locale%.resx`. | Commit `bec0043` (`chore: update crowdin.yml`). |
+| 2026-08-03 20:24 -03:00 | The first bad pt-BR export expanded the localized file and filled missing translations with English. | Commit `f93c46e` (`New translations resources.resx (Portuguese, Brazilian)`). |
+| 2026-08-05 | A later generated update retained the corrupted shape. | Commit `f597ab0`. |
+| 2026-08-06 | Source-equivalent values from repository files were imported into Crowdin and approved. | Crowdin translation history: for example, correct pt-BR `ConfigWindowTitle` variant ID `16221` from August 3 remained, while English variant ID `29669` was created and approved on August 6. |
+| 2026-08-07 | [PR #253](https://github.com/lokinmodar/Echoglossian/pull/253) was opened from `l10n_v4-series`. Its final diff contained only indentation changes and did not constitute translation recovery. | GitHub PR metadata and patch review. |
+| 2026-08-07 | Crowdin export/import settings were corrected, historical translations were restored, and bad active approvals were removed without deleting translation history. | Crowdin project settings, translation history, and post-recovery approval audit. |
+| 2026-08-08 | Runtime investigation confirmed that configured culture normalization did not set `Resources.Culture`; `ca` and `nl` also lacked neutral-to-locale mappings. | Startup path and resource lookup review. |
+| 2026-08-08 | Runtime correction, mappings, and regression tests were committed and submitted in [PR #260](https://github.com/lokinmodar/Echoglossian/pull/260). | Commit `98c887f` (`fix(i18n): apply plugin resource culture`). |
+
+## Technical Root Cause A: Crowdin Data Integrity
+
+The intended repository mapping was valid:
+
+```yaml
+preserve_hierarchy: true
+
+files:
+  - source: /Properties/Resources.resx
+    translation: /Properties/Resources.%locale%.resx
+    skip_untranslated_strings: true
+```
+
+However, the effective Crowdin project export behavior initially did not skip
+untranslated strings. A localized file therefore received English source text
+for every untranslated key. For pt-BR:
+
+- The known-good file at `bec0043` had 188 entries, 183 of which were genuine
+  Portuguese values. The 356 absent keys were expected to fall back to the root
+  English resource at runtime.
+- The generated file at `f93c46e` had 544 entries, and all 544 values matched
+  the English source.
+- A later version had 547 entries with only 21 values different from the
+  English source.
+
+The source-filled repository files were subsequently treated as translation
+input. Continuous or manual repository-to-Crowdin translation import created
+new English variants and made them active approvals. Correct translations did
+not vanish from storage; they were no longer the selected variants.
+
+### Five Whys
+
+1. **Why did translations appear to disappear?** English source-equivalent
+   variants became the approved translations.
+2. **Why were those variants present?** Complete source-filled localized files
+   were imported from the repository into Crowdin.
+3. **Why were localized files source-filled?** The effective Crowdin export did
+   not omit untranslated strings during the initial synchronization.
+4. **Why did the bad files become authoritative?** Repository-to-Crowdin
+   translation import remained available after Crowdin had become the
+   translation source of truth.
+5. **Why was the cycle not stopped before approval?** There was no automated
+   diff gate for mass source equality, abnormal file expansion, or approval
+   count regression.
+
+## Technical Root Cause B: Runtime Resource Loading
+
+The plugin stored a `DefaultPluginCulture` and normalized neutral codes to the
+locale-specific names used by its resource files. Before the fix, normalization
+did not apply the resulting `CultureInfo` to the generated resource class:
+
+```csharp
+Echoglossian.Properties.Resources.Culture
+```
+
+As a result, calls such as `Resources.ConfigWindowTitle` used the current
+thread's UI culture. Dalamud's thread culture is not guaranteed to equal the
+locale chosen in the plugin configuration. `ResourceManager` could therefore
+fall through to `Resources.resx` and display English.
+
+The locale migration also omitted explicit normalization for Catalan and Dutch:
+`ca -> ca-ES` and `nl -> nl-NL`.
+
+PR #260 centralizes the behavior so startup and configuration changes:
+
+1. normalize the persisted locale;
+2. construct the matching `CultureInfo`;
+3. assign it to `Resources.Culture`; and
+4. use that exact culture for subsequent strongly typed resource lookups.
+
+The regression test verifies that `fr` becomes `fr-FR`, that
+`Resources.Culture` is set, and that the localized resource set is loaded
+without relying on parent fallback.
+
+### Five Whys
+
+1. **Why did users still see English with locale files installed?** Strongly
+   typed resource lookups used the thread UI culture instead of the plugin
+   culture.
+2. **Why did they use the thread culture?** `Resources.Culture` remained null.
+3. **Why was it null?** Startup normalized the configuration value but never
+   applied it to the generated resource class.
+4. **Why did filename migration expose the gap?** Exact locale filenames made
+   the distinction between configured locale, thread locale, and fallback
+   chain observable.
+5. **Why was this not detected before release?** Build checks verified resource
+   compilation and packaging, but no test verified a real strongly typed lookup
+   under a configured plugin culture.
+
+## Contributing Control Gaps
+
+- Crowdin UI settings and `crowdin.yml` behavior were assumed to be equivalent
+  without verifying the effective exported artifact.
+- The same repository path could act as both Crowdin output and later Crowdin
+  input, creating a feedback loop.
+- A generated localization PR was not protected by content-based invariants.
+- Partial localized `.resx` files were mistaken for incomplete artifacts,
+  although omission is the correct way to preserve English runtime fallback.
+- Locale naming, build packaging, configuration normalization, and runtime
+  lookup were validated independently instead of end to end.
+- No maintained runbook explained when the one-time import must stop.
+
+This was a process and systems failure. No single maintainer action was
+sufficient to cause the incident by itself.
+
+## Recovery Performed
+
+On August 7, 2026, maintainers:
+
+1. Set the Crowdin project to omit untranslated strings and export only
+   translated, approved values.
+2. Disabled ongoing repository-to-Crowdin translation import. The one-time
+   import remains a bootstrap operation only.
+3. Reapproved known-good historical variants from August 3 across the ten
+   languages that contained translations.
+4. Imported known-good localized resources from commit `bec0043` where needed
+   to reconnect translations to recreated source string IDs.
+5. Removed only currently approved incident-window and source-equivalent
+   English variants. Historical variants and translation memory were retained.
+6. Normalized XML entities and audited all active approvals.
+7. Verified that no currently approved translation was created during the bad
+   import window and that no approved translation equaled its English source.
+8. Verified representative values, including:
+
+   - pt-BR `ConfigWindowTitle`: `Configuração do Echoglossian`
+   - pt-BR `ConfigTab1Name`: `Configurações de diálogos`
+   - fr `ConfigTab1Name`: `Paramètres de conversation`
+
+### Post-Recovery Approved Phrase Counts
+
+The source catalog contained 540 phrases at audit time.
+
+| Locale | Approved phrases |
+| --- | ---: |
+| ca | 0 |
+| da | 190 |
+| de | 195 |
+| el | 194 |
+| en | 0 |
+| es-ES | 194 |
+| eu | 196 |
+| fr | 193 |
+| it | 191 |
+| nl | 0 |
+| pt-BR | 215 |
+| pt-PT | 202 |
+| ru | 198 |
+
+Zero is valid for a configured target with no translations; it must not be
+materialized as a localized file full of English values.
+
+## Corrective and Preventive Actions
+
+| ID | Priority | Status | Owner | Action and acceptance evidence |
+| --- | --- | --- | --- | --- |
+| C1 | P0 | Complete | Crowdin administrator | Enable `skipUntranslatedStrings`, `exportTranslatedOnly`, and `exportApprovedOnly`. Confirmed in Crowdin project settings on 2026-08-07. |
+| C2 | P0 | Complete | Crowdin administrator | Restore historical approvals and remove only bad active variants. Acceptance: the post-recovery audit found zero approved incident-window variants and zero approved source-equivalent translations. |
+| C3 | P0 | Complete | Repository administrator | Keep **Always import new translations from the repository** disabled; use one-time import only for bootstrap. |
+| C4 | P0 | In PR #260 | Plugin maintainers | Apply the configured `CultureInfo` to `Resources.Culture`; add `ca` and `nl` mappings and exact-resource-set regression coverage. |
+| C5 | P0 | Complete | Plugin maintainers | Verify packaging with a Plogon-like Release build. Acceptance: 13 of 13 expected locale satellite assemblies were present and matched. |
+| P1 | P0 | Open | Plugin maintainers | Add a repeatable CI or repository script that rejects mass source-equivalent localized values, identical locale files, and abnormal localized-file expansion. It must run before the next Crowdin-generated PR is merged. |
+| P2 | P0 | Open | Crowdin administrator | Audit effective Crowdin settings after every integration reconnection or configuration change. Save the expected flags and an API response or screenshot in the PR evidence. |
+| P3 | P0 | Open | Repository administrator | Close or replace stale PR #253. Accept a replacement only when its translation diff passes all review gates below. |
+| P4 | P1 | Open | Test infrastructure maintainer | Update vendored DalaMock to the current Dalamud API. Acceptance: `Echoglossian.Mock.Tests` builds and passes after addressing `IFramework.CreateDebouncer(TimeSpan, Action)`, `IGameObject.CurrentDistance`, and `IGameObject.NextDistance`. |
+| P5 | P1 | Open | Crowdin administrator | Decide whether the `en` target locale should be removed because English is already the source language. Document the decision. |
+| P6 | P1 | Open | Plugin maintainers | Whenever a Crowdin target locale is added, add or verify configuration normalization and a localized lookup test before enabling export. |
+| P7 | P2 | Open | Plugin maintainers | Decide the long-term role of `MultilingualResources/*.xlf`. Keep XLIFF optional unless an explicit migration establishes it as the single source of truth. |
+
+## Permanent Safety Invariants
+
+These invariants apply to every future localization change:
+
+1. `Properties/Resources.resx` is the only English source file.
+2. Crowdin exports localized files to
+   `Properties/Resources.%locale%.resx`; `%locale%` must not be replaced with a
+   two-letter placeholder.
+3. Localized files are intentionally partial. An absent key falls back to the
+   English root resource at runtime.
+4. After bootstrap, Crowdin is the source of truth for translated values.
+   Repository translations must not be continuously or manually imported back
+   into Crowdin.
+5. **Always import new translations from the repository** remains off.
+6. Do not use **Sync Translations to Crowdin** during routine synchronization.
+   Use the normal source synchronization action only.
+7. Every supported runtime locale must have an explicit normalization path and
+   a matching satellite assembly.
+8. Plugin startup must set `Resources.Culture` before the first localized UI or
+   notification lookup.
+9. A generated localization PR is untrusted until its content diff and build
+   artifacts pass the checks below.
+
+## Safe Localization Runbook
+
+### A. Change English Source Strings
+
+1. Add, edit, or remove source keys only in `Properties/Resources.resx`.
+2. Use `Resources.Key` directly for plugin UI and notifications.
+3. Do not copy English values into localized files to make them look complete.
+4. Commit the source change before asking Crowdin to synchronize it.
+
+### B. Synchronize Crowdin
+
+1. Confirm the integration targets the intended repository branch.
+2. For a new integration only, enable **One-time translation import after the
+   branch is connected** if existing repository translations must seed Crowdin.
+3. Keep **Always import new translations from the repository** off.
+4. Confirm effective settings:
+
+   - `skipUntranslatedStrings = true`
+   - `exportTranslatedOnly = true`
+   - `exportApprovedOnly = true`
+5. Run normal source synchronization. Do not run **Sync Translations to
+   Crowdin** after bootstrap.
+6. Wait for translators and approval; then request/export translations to the
+   generated branch.
+
+The GitHub integration field **Branches to Sync Automatically** applies to
+future branch discovery. A pattern such as `*translate*` does not retroactively
+change the existing `v4-series` branch configuration.
+
+### C. Review a Crowdin-Generated PR
+
+Reject or stop the PR if any of these signals appear:
+
+- a localized file gains nearly every English key without a corresponding jump
+  in approved translations;
+- a large percentage of localized values equals the English source;
+- two or more locale files become identical;
+- a locale file changes from a partial resource into a complete source mirror;
+- an unexpected locale or two-letter filename appears;
+- approved phrase counts drop unexpectedly;
+- the diff is only formatting after a supposed translation recovery.
+
+Before merge:
+
+1. Compare changed keys and values, not only file counts.
+2. Spot-check at least one established translation per changed locale.
+3. Compare Crowdin approved counts with emitted localized entry counts.
+4. Confirm `Resources.resx` was not modified by a translation export.
+5. Confirm the PR contains actual recovered or new localized values.
+
+PR #253 must not be merged as the recovery: its reviewed diff does not contain
+the restored translations.
+
+### D. Validate Build and Runtime
+
+Run:
+
+```powershell
+dotnet build Echoglossian.sln -c Debug --no-restore
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build
+.\scripts\test-plogon-like-build.ps1
+```
+
+Then verify:
+
+1. Every expected locale has a matching
+   `<locale>/Echoglossian.resources.dll` satellite assembly.
+2. Selecting a plugin locale assigns the exact normalized culture to
+   `Resources.Culture`.
+3. A known translated key returns its localized value while an absent key
+   falls back to English.
+4. At least one user-visible UI label or notification is checked in-game when
+   runtime localization behavior changes.
+
+The 2026-08-08 validation passed the main build and 1,107 unit tests. A local
+Plogon-like Release build produced all 13 expected satellite assemblies. Hosted
+Mock validation remained blocked by the pre-existing DalaMock API mismatch
+listed in action P4; startup-only Mock tests would not replace the localized
+lookup regression in any case.
+
+## Rollback Procedure
+
+If translation corruption is suspected:
+
+1. Stop translation exports and disable repository-to-Crowdin translation
+   import. Do not delete files, variants, or translation memory.
+2. Preserve evidence: generated branch/PR, affected commit hashes, Crowdin
+   settings, string history, approval counts, and timestamps.
+3. Identify the last known-good repository commit before source-filled files.
+4. Compare localized entry counts and source-equality rates before and after
+   that commit.
+5. In Crowdin, restore correct historical variants as the active approvals.
+   Prefer reapproval over deletion.
+6. Remove approval only from variants proven to be part of the incident window
+   or equal to the English source. Preserve alternates and TM.
+7. Reimport known-good localized resources only when needed to reconnect
+   translations to current source string IDs, and inspect the import preview.
+8. Audit every active approved variant after recovery.
+9. Generate a fresh export branch. Do not reuse a branch containing the bad
+   artifacts.
+10. Apply the review and build/runtime gates above before merge.
+
+If runtime lookup is wrong but Crowdin data is intact, do not rename or rewrite
+localized files first. Verify, in order:
+
+1. configured locale normalization;
+2. `Resources.Culture` assignment;
+3. satellite assembly packaging;
+4. exact resource-set lookup; and
+5. English fallback for an intentionally absent key.
+
+## Lessons
+
+- Partial localized resources are correct and safer than English-padded files.
+- A successful build proves compilation and packaging, not that runtime culture
+  selection is correct.
+- Translation platforms preserve useful history, so recovery should prefer
+  reapproval and audits over destructive cleanup.
+- A localization integration is bidirectional data movement unless explicitly
+  constrained; every direction needs an owner and a stopping rule.
+- Locale-specific naming solves ambiguity but must be implemented across
+  Crowdin mapping, configuration normalization, resource lookup, packaging, and
+  tests as one end-to-end contract.
+
+## Related References
+
+- [Localization build flow](localization-build-flow.md)
+- [Crowdin project](https://crowdin.com/project/echoglossian)
+- [Stale generated localization PR #253](https://github.com/lokinmodar/Echoglossian/pull/253)
+- [Runtime culture fix PR #260](https://github.com/lokinmodar/Echoglossian/pull/260)

--- a/docs/superpowers/plans/2026-08-08-localization-incident-postmortem.md
+++ b/docs/superpowers/plans/2026-08-08-localization-incident-postmortem.md
@@ -1,0 +1,99 @@
+# Localization Incident Post-Mortem Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document the August 2026 Crowdin data-integrity and runtime resource-culture incident and make its preventive controls part of the repository's permanent localization workflow.
+
+**Architecture:** Create one evidence-based incident record that separates the Crowdin synchronization failure from the runtime resource-loading failure while showing their shared control gaps. Add only the operational guardrails to the existing localization build guide so maintainers encounter them during normal work.
+
+**Tech Stack:** Markdown, Git history, Crowdin project audit evidence, .NET RESX/ResourceManager terminology, repository-local validation commands.
+
+## Global Constraints
+
+- Keep `Properties/Resources.resx` as the only English source of truth.
+- Keep localized output at `Properties/Resources.%locale%.resx`.
+- Do not alter Crowdin translations or RESX content while writing the incident record.
+- Distinguish verified facts from recommendations and unresolved follow-up work.
+- Keep the account blameless and never include credentials or tokens.
+
+---
+
+### Task 1: Create the incident record
+
+**Files:**
+- Create: `docs/localization-crowdin-runtime-postmortem-2026-08.md`
+
+**Interfaces:**
+- Consumes: Git commits `a7ba2c6`, `bec0043`, `f93c46e`; PRs #253 and #260; Crowdin recovery audit results from 2026-08-07.
+- Produces: Canonical incident timeline, root causes, recovery record, corrective-action register, safe runbook, and rollback procedure.
+
+- [x] **Step 1: Record the incident scope and impact**
+
+Describe the Crowdin approval corruption and runtime fallback-to-English behavior as separate failure tracks with one shared localization migration context.
+
+- [x] **Step 2: Record the evidence-backed timeline and root causes**
+
+Include the locale rename, Crowdin configuration change, English fallback export/import, recovery, and runtime fix chronology. Identify the missing `Resources.Culture` assignment and missing `ca`/`nl` mappings.
+
+- [x] **Step 3: Record recovery and prevention controls**
+
+Include completed Crowdin settings, restored approval counts, PR #260, mandatory synchronization rules, diff review gates, runtime checks, and open automation work with acceptance criteria.
+
+- [x] **Step 4: Add rollback and verification procedures**
+
+Document how to stop synchronization, preserve historical variants/TM, restore from a known-good Git commit, audit approvals, and verify satellite assemblies and resource lookup.
+
+### Task 2: Put guardrails in the daily workflow
+
+**Files:**
+- Modify: `docs/localization-build-flow.md`
+
+**Interfaces:**
+- Consumes: The canonical incident record from Task 1.
+- Produces: A concise pre-sync, PR-review, build, and runtime checklist maintainers encounter during ordinary localization work.
+
+- [x] **Step 1: Add Crowdin integration safety rules**
+
+State that continuous translation import and manual `Sync Translations to Crowdin` are prohibited after Crowdin becomes the source of truth.
+
+- [x] **Step 2: Add generated-PR review gates**
+
+Require rejection of mass source-equivalent replacements, identical localized files, unexpected locale additions, and large approval-count regressions.
+
+- [x] **Step 3: Add runtime culture validation**
+
+Require culture normalization, `Resources.Culture` application, exact satellite assembly presence, and a localized lookup test.
+
+### Task 3: Review and publish
+
+**Files:**
+- Review: `docs/localization-crowdin-runtime-postmortem-2026-08.md`
+- Review: `docs/localization-build-flow.md`
+- Review: `docs/superpowers/plans/2026-08-08-localization-incident-postmortem.md`
+
+**Interfaces:**
+- Consumes: Documentation produced by Tasks 1 and 2.
+- Produces: A committed and pushed documentation update on PR #260.
+
+- [x] **Step 1: Run the documentation self-review**
+
+Search for placeholders, contradictions, ambiguous ownership, unsupported claims, missing links, and accidentally included secrets.
+
+- [x] **Step 2: Run repository checks**
+
+Run:
+
+```powershell
+git diff --check
+node .\Echoglossian.Docs\scripts\check-locales.mjs
+```
+
+Expected: no diff errors; locale compatibility check exits successfully.
+
+- [x] **Step 3: Commit and push**
+
+```powershell
+git add -- docs/localization-crowdin-runtime-postmortem-2026-08.md docs/localization-build-flow.md docs/superpowers/plans/2026-08-08-localization-incident-postmortem.md
+git commit -m "docs: add localization incident post-mortem"
+git push
+```


### PR DESCRIPTION
## Summary

- apply the normalized plugin UI culture to the strongly typed `Resources` accessor during startup
- preserve locale-specific RESX names such as `fr-FR`, `pt-PT`, and `pt-BR`
- add missing neutral-code mappings for Catalan and Dutch
- add regression coverage for culture application and exact satellite resource loading
- document the August 2026 Crowdin data-integrity/runtime incident and permanent localization guardrails

## Root cause

The locale-specific RESX files were compiled and packaged correctly, but the plugin only created a `CultureInfo` instance. It never assigned that culture to `Resources.Culture`. Most plugin UI text uses strongly typed `Resources.Key` accessors, so those lookups fell back to the Dalamud thread UI culture and could display English.

The accompanying post-mortem separately records the Crowdin feedback loop: untranslated entries were exported as English, later imported back as translations, and approved over correct historical variants. The `%locale%` filename pattern was not the cause and remains required.

## Impact

Persisted neutral codes such as `fr`, `pt`, `ca`, and `nl` are normalized to the concrete locale used by the packaged satellite assembly and applied before the first localized string is read.

## Documentation

- `docs/localization-crowdin-runtime-postmortem-2026-08.md` contains the evidence-backed timeline, two root causes, five-whys analyses, recovery record, approval counts, action register, runbook, PR review gates, and rollback procedure
- `docs/localization-build-flow.md` now makes the Crowdin one-time-import boundary, partial-RESX behavior, `%locale%` naming, and runtime lookup checks part of the daily workflow
- PR #253 is explicitly recorded as stale and not a translation recovery vehicle

## Validation

- `git diff --cached --check`
- `node .\Echoglossian.Docs\scripts\check-locales.mjs`
- `dotnet build Echoglossian.sln -c Debug --no-restore` — 0 errors
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build` — 1107 passed
- `.\scripts\test-plogon-like-build.ps1 -UseLocalBuild`
- verified 13 expected locale RESX files produced 13 matching satellite assemblies
- regression test verifies the exact `fr-FR` resource set loads without parent fallback

The locale check reports the expected informational warning that plugin resources include `ca` and `nl`, which are not yet published by the docs site.

## Known validation gap

`Echoglossian.Mock.Tests` currently cannot compile because the vendored DalaMock is behind the current Dalamud interfaces (`IFramework.CreateDebouncer`, `IGameObject.CurrentDistance`, and `IGameObject.NextDistance`). This is pre-existing and unrelated to this patch, and is tracked as an open corrective action in the post-mortem.