### PR TITLE
chore: prepare v4.2601.0809.0046 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
+## Submitted Release `v4.2601.0809.0046`
+
+This package submits the runtime localization correction merged through
+[PR #260](https://github.com/lokinmodar/Echoglossian/pull/260). It keeps the
+locale-specific resource naming introduced for Crowdin while ensuring the
+plugin actually loads the locale selected in its configuration.
+
+Highlights:
+
+- applies the normalized plugin UI culture before the first strongly typed
+  resource lookup, preventing Dalamud's thread culture from silently falling
+  back to English
+- preserves distinct locale-specific resources such as `pt-BR`, `pt-PT`, and
+  `fr-FR`, and adds the missing `ca -> ca-ES` and `nl -> nl-NL` normalization
+  mappings
+- adds exact-resource-set regression coverage and permanent Crowdin review,
+  synchronization, recovery, and rollback guardrails
+
 ## Published Release `v4.2601.0807.1730`
 
 This package was published to the official Dalamud feed after the follow-up

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0807</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">1730</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0809</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">0046</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>


### PR DESCRIPTION
## Summary

- prepare `v4.2601.0809.0046` from the updated `v4-series` head after PR #260
- publish the plugin UI culture fix so configured locale-specific RESX resources load explicitly instead of depending on Dalamud thread culture
- record the submitted release in `CHANGELOG.md`

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build` — 1107 passed
- [x] `dotnet build Echoglossian.csproj -c Release --no-restore`
- [ ] in-game verification was not repeated during release preparation; PR #260 includes exact-resource-set regression coverage and the prior Plogon-like build verified all 13 satellite assemblies

## AI Usage Disclosure

- [x] `Assist` — human-led work with AI used for specific tasks

AI scope:
- tooling used: Codex
- files or areas most affected: bounded plugin culture fix, regression test, localization RCA, release version, and changelog
- how the result was reviewed/tested: the maintainer selected the scope and release path; the final diff was reviewed and validated with Debug/Release builds and 1107 unit tests

## AI-Generated Assets Disclosure

AI-generated assets:
- none