### PR TITLE
fix(#214): keep dialogue translation work off callbacks

### DIFF
--- a/.superpowers/sdd/2026-08-10-issue-214-quest-dialogue-interlocutor-metadata-implementation-plan/task-3-report.md
+++ b/.superpowers/sdd/2026-08-10-issue-214-quest-dialogue-interlocutor-metadata-implementation-plan/task-3-report.md
@@ -1,0 +1,179 @@
+# Task 3 Report: Generate quest dialogue metadata asynchronously from accepted quests
+
+## Status
+
+DONE_WITH_CONCERNS
+
+## Commit
+
+`69a8f84 feat(#214): precompute quest dialogue metadata on quest accept`
+
+## Implementation
+
+- Reused `ScheduleAcceptedQuestPrefetch` after its existing immutable work-item capture succeeds.
+- Added an `OwnedAsyncOperationSet` dedicated to dialogue metadata generation; it runs separately from `AsyncSerialActionPump` and is disposed during plugin shutdown.
+- Captured `QuestProgressSnapshot`, `SourceClientLanguage`, game version, derivation version (`v1`), and accepted-quest generation before the handoff.
+- The background operation invokes `ReadDialogueEntries`, `BuildEntries`, and `UpsertQuestDialogueMetadataBatchAsync`; it rejects stale generations immediately before persistence. `OwnedAsyncOperationSet` observes ordinary cancellation without logging it.
+- Extended the source-level contract test to enforce the owned background handoff and helper calls while preserving the tick scheduling contract.
+
+## TDD Evidence
+
+The new `ScheduleAcceptedQuestPrefetch_StartsOwnedDialogueMetadataGeneration` test was written before runtime changes. Its first execution failed as expected because `acceptedQuestDialogueMetadataOperations` did not exist. After the implementation, the focused contract suite passed (2/2).
+
+## Validation
+
+- `dotnet build Echoglossian.sln -c Debug --no-restore`: passed, 0 errors. Existing repository warnings remain.
+- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore -p:VSTestMaxCpuCount=1`: passed, 1140/1140.
+- `dotnet build Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-restore`: blocked by existing vendored DalaMock/API drift: `MockFramework` lacks `IFramework.CreateDebouncer(TimeSpan, Action)` and `MockCharacter` lacks `IGameObject.CurrentDistance` and `IGameObject.NextDistance`.
+
+## Remaining Verification
+
+The DalaMock build failure prevents an automated hosted-runtime check. In-game verification should confirm that accepting a quest schedules metadata generation without affecting prefetch responsiveness and that configuration refreshes suppress stale metadata writes.
+
+## Fix Round 1: Stale Generation Cancellation
+
+Review identified that the generation comparison before the asynchronous database call was a TOCTOU guard. The accepted-quest state clear now rotates and cancels a generation-scoped token source. The captured token is linked through the existing `OwnedAsyncOperationSet`, and the metadata operation checks the linked token immediately before calling the database upsert. The initial regression test failed because no generation cancellation source existed; the covering suite passes after the fix.
+
+Commit: `ee51a47 fix(#214): cancel stale quest dialogue metadata writes`
+
+Exact command and output:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore --filter "FullyQualifiedName~AcceptedQuestPrefetchRuntimeContractTests"
+
+Execução de teste para C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.Tests\bin\x64\Debug\net10.0-windows\Echoglossian.Tests.dll (.NETCoreApp,Version=v10.0)
+Versão do VSTest 18.0.2 (x64)
+
+Iniciando execução de teste, espere...
+1 arquivos de teste no total corresponderam ao padrão especificado.
+
+Aprovado!  – Com falha:     0, Aprovado:     3, Ignorado:     0, Total:     3, Duração: 14 ms - Echoglossian.Tests.dll (net10.0)
+```
+
+## Fix Round 2: Commit-Boundary Generation Guard
+
+Review confirmed that a cancellation check before calling persistence cannot protect a later commit. The public two-parameter metadata upsert API remains unchanged. Its implementation now delegates to a private guarded overload that executes the full deduplicated batch in one transaction, invokes the accepted-quest generation guard immediately before `CommitAsync`, and returns without committing when the generation is stale.
+
+Commit: `ec5d9e9 fix(#214): guard quest metadata transaction commits`
+
+Exact command and output:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore --filter "FullyQualifiedName~AcceptedQuestPrefetchRuntimeContractTests|FullyQualifiedName~QuestDialogueMetadataPersistenceTests"
+
+Execução de teste para C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.Tests\bin\x64\Debug\net10.0-windows\Echoglossian.Tests.dll (.NETCoreApp,Version=v10.0)
+Versão do VSTest 18.0.2 (x64)
+
+Iniciando execução de teste, espere...
+1 arquivos de teste no total corresponderam ao padrão especificado.
+
+Aprovado!  – Com falha:     0, Aprovado:     6, Ignorado:     0, Total:     6, Duração: 3 s - Echoglossian.Tests.dll (net10.0)
+```
+
+## Fix Round 3: Behavioral Commit-Cancellation Evidence
+
+The public two-parameter upsert API remains unchanged. The guarded overload is now internal to the existing friend test assembly. `UpsertQuestDialogueMetadataBatchAsync_CancelledAtCommitBoundary_RollsBackRows` runs against a migrated SQLite database, cancels the token from the final commit guard, asserts that `CommitAsync` throws an `OperationCanceledException` subtype, and verifies that transaction disposal leaves no metadata rows. This provides behavioral evidence that the generation-linked cancellation token reaches the persistence commit boundary and stale work does not become observable.
+
+Commit: `8f30d63 test(#214): verify quest metadata commit cancellation`
+
+Exact command and output:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore --filter "FullyQualifiedName~AcceptedQuestPrefetchRuntimeContractTests|FullyQualifiedName~QuestDialogueMetadataPersistenceTests"
+
+Execução de teste para C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.Tests\bin\x64\Debug\net10.0-windows\Echoglossian.Tests.dll (.NETCoreApp,Version=v10.0)
+Versão do VSTest 18.0.2 (x64)
+
+Iniciando execução de teste, espere...
+1 arquivos de teste no total corresponderam ao padrão especificado.
+
+Aprovado!  – Com falha:     0, Aprovado:     7, Ignorado:     0, Total:     7, Duração: 3 s - Echoglossian.Tests.dll (net10.0)
+```
+
+## Fix Round 4: Stale Completion Non-Observability
+
+The round-2 commit guard and round-3 cancellation test have been removed. A
+managed generation check and a SQLite commit cannot be made one atomic action:
+the generation is process memory while the commit is provider-owned database
+state. Holding a synchronous lock across the commit would allow a framework
+configuration-refresh callback to block on database work, violating the binding
+non-blocking constraint. Making the generation part of the database transaction
+would require a persisted runtime/session epoch and read-side filtering, which is
+a schema and lookup-semantics expansion beyond Task 3.
+
+The residual race is instead made non-load-bearing at the data boundary:
+
+- `BuildEntries` captures `UpdatedAtUtc` before the existing generation and
+  cancellation checks. Therefore, an old-generation operation that reaches the
+  guard-to-commit race carries an earlier observation timestamp than a replacement
+  generated after the state clear.
+- The existing exact logical key includes quest id, quest sequence, source
+  language, game version, source row key, source text hash, and derivation version.
+  A stale row with a different source identity cannot satisfy a current lookup.
+- For the same exact key, `ON CONFLICT DO UPDATE` now executes only when the
+  incoming `UpdatedAtUtc` is at least as new as the persisted value. An older
+  write that completes after a newer write cannot replace or become observable
+  instead of the newer current result.
+- If no newer exact-key row exists, a raced row is still exact-key metadata
+  derived deterministically from the same versioned quest sheet and source hash;
+  its generation is not part of persisted lookup semantics, so retaining it does
+  not redefine the DB source of truth.
+
+The public two-parameter `UpsertQuestDialogueMetadataBatchAsync` API remains
+unchanged. The ineffective internal guard overload and its source-text contract
+test were removed. No database, provider, sheet, file, model-list, prompt,
+glossary, configuration, or session operation was moved onto a framework/ImGui
+callback.
+
+### TDD Evidence
+
+The replacement persistence test was written before the SQL predicate. Its first
+run failed on the intended stale-overwrite behavior:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore -p:VSTestMaxCpuCount=1 --filter "FullyQualifiedName~UpsertQuestDialogueMetadataBatchAsync_OlderBatchCompletesLast_PreservesNewerRow"
+
+Com falha Echoglossian.Tests.QuestDialogueMetadataPersistenceTests.UpsertQuestDialogueMetadataBatchAsync_OlderBatchCompletesLast_PreservesNewerRow [979 ms]
+Mensagem de erro:
+ Assert.Equal() Failure: Strings differ
+         ↓ (pos 0)
+Expected: "Current speaker"
+Actual:   "Stale speaker"
+         ↑ (pos 0)
+
+Com falha! – Com falha:     1, Aprovado:     0, Ignorado:     0, Total:     1, Duração: 989 ms - Echoglossian.Tests.dll (net10.0)
+```
+
+After the production change, the focused covering suites passed:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore -p:VSTestMaxCpuCount=1 --filter "FullyQualifiedName~AcceptedQuestPrefetchRuntimeContractTests|FullyQualifiedName~QuestDialogueMetadataPersistenceTests"
+
+  Dalamud.NET.Sdk: root at C:\Users\lokin\AppData\Roaming\XIVLauncher\addon\Hooks\dev\
+C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.csproj(50,5): warning : Echoglossian.csproj is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed.
+  Echoglossian -> C:\Users\lokin\.codex\worktrees\7417\Echoglossian\bin\x64\Debug\win-x64\Echoglossian.dll
+  Echoglossian.Tests -> C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.Tests\bin\x64\Debug\net10.0-windows\Echoglossian.Tests.dll
+Execução de teste para C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.Tests\bin\x64\Debug\net10.0-windows\Echoglossian.Tests.dll (.NETCoreApp,Version=v10.0)
+Versão do VSTest 18.0.2 (x64)
+
+Iniciando execução de teste, espere...
+1 arquivos de teste no total corresponderam ao padrão especificado.
+
+Aprovado!  – Com falha:     0, Aprovado:     6, Ignorado:     0, Total:     6, Duração: 3 s - Echoglossian.Tests.dll (net10.0)
+```
+
+### Additional Validation
+
+```text
+dotnet build Echoglossian.sln -c Debug --no-restore
+
+Compilação com êxito.
+    1 Aviso(s)
+    0 Erro(s)
+```
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore -p:VSTestMaxCpuCount=1
+
+Aprovado!  – Com falha:     0, Aprovado:  1142, Ignorado:     0, Total:  1142, Duração: 25 s - Echoglossian.Tests.dll (net10.0)
+```

--- a/.superpowers/sdd/2026-08-10-issue-214-quest-dialogue-interlocutor-metadata-implementation-plan/task-3-report.md
+++ b/.superpowers/sdd/2026-08-10-issue-214-quest-dialogue-interlocutor-metadata-implementation-plan/task-3-report.md
@@ -177,3 +177,135 @@ dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --n
 
 Aprovado!  – Com falha:     0, Aprovado:  1142, Ignorado:     0, Total:  1142, Duração: 25 s - Echoglossian.Tests.dll (net10.0)
 ```
+
+## Fix Round 5: Capture-Ordered Exact-Key Persistence
+
+Status: `DONE_WITH_CONCERNS`
+
+Round 4 correctly removed the ineffective pre-commit guard, but its ordering
+argument had one gap: `DateTime.UtcNow` was sampled by `BuildEntries` after the
+background handoff. An old-generation operation delayed before derivation could
+therefore receive a later `UpdatedAtUtc` than a new-generation replacement and
+defeat the timestamp-monotonic exact-key upsert.
+
+The accepted-quest callback now captures `ObservedAtUtc` into the immutable
+managed work item before the background handoff. The capture uses a lock-free
+compare/exchange loop to make values strictly increasing even when the system
+clock has insufficient resolution or moves backward. `BuildEntries` consumes
+that captured value instead of sampling the clock in background execution. This
+keeps the callback non-blocking and makes persistence ordering follow capture
+ordering rather than task scheduling/completion ordering.
+
+The public two-parameter `UpsertQuestDialogueMetadataBatchAsync` API and its
+existing replacement behavior remain unchanged. No provider, database, sheet,
+file, model-list, prompt, glossary, configuration, or session operation was
+moved onto the framework/ImGui callback.
+
+### Atomicity Adjudication
+
+The literal generation-to-commit atomicity requested by the reviewer is not
+achievable between the current process-memory generation and provider-owned
+SQLite transaction without changing one of the binding constraints:
+
+- A managed generation read and `CommitAsync` have distinct linearization
+  points. Moving the read adjacent to `CommitAsync` leaves a scheduler-visible
+  interval and is still TOCTOU.
+- Holding a managed lock across `CommitAsync` would require the framework-side
+  generation change to acquire that lock to be atomic. It could then wait on
+  database I/O, violating the non-blocking callback constraint. Letting the
+  callback mutate generation without acquiring the lock restores the race.
+- Cancellation is advisory. Cancellation requested after SQLite has accepted
+  the commit cannot retroactively roll it back, so a cancellation-token test
+  cannot prove generation/commit atomicity.
+- A SQLite-side atomic predicate requires generation/session authority in the
+  same database transaction. That means a persisted session/generation model,
+  schema migration, write ordering for framework-side invalidations, and
+  generation-aware lookup semantics. Those are explicitly beyond Task 3's
+  current persistence and lookup model.
+
+No replacement “guard-to-commit” test was added because production no longer
+has such a guard, and adding a test-only callback before `CommitAsync` would
+again test cancellation before commit begins rather than the provider commit
+race. A transaction wrapper that pauses `CommitAsync` would test the wrapper,
+not establish atomicity in SQLite.
+
+The residual physical-write race is non-load-bearing under current semantics:
+
+- Current lookup requires an exact match on quest id, quest sequence, source
+  language, game version, source row key, source text hash, and derivation
+  version. A stale row with different source identity cannot satisfy the lookup.
+- For the same exact key, derivation is deterministic for the same versioned
+  source row/hash and derivation version. Generation is runtime scheduling
+  state, not persisted data identity.
+- Capture timestamps are now strictly ordered before handoff. Therefore, if a
+  newer exact-key generation persists, the existing SQL timestamp predicate
+  prevents an older captured operation that commits later from replacing it.
+- If no newer exact-key row exists, the raced row remains valid reusable
+  metadata for that exact versioned source identity. Rejecting it after restart
+  would require redefining persistence around session generations.
+
+The literal reviewer finding remains technically true: a stale transaction can
+physically commit after the in-memory check. The patch instead closes the only
+ordering hole found in the exact-key non-observability guarantee without
+claiming false atomicity or expanding the schema/session model.
+
+### TDD Evidence
+
+The runtime contract assertions were added before the production change. The
+first focused run failed because observation time was not captured into the
+work item:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore -p:VSTestMaxCpuCount=1 --filter "FullyQualifiedName~ScheduleAcceptedQuestPrefetch_StartsOwnedDialogueMetadataGeneration"
+
+Com falha Echoglossian.Tests.AcceptedQuestPrefetchRuntimeContractTests.ScheduleAcceptedQuestPrefetch_StartsOwnedDialogueMetadataGeneration [3 ms]
+Mensagem de erro:
+ Assert.Contains() Failure: Sub-string not found
+Not found: "this.CaptureAcceptedQuestDialogueMetadata"...
+
+Com falha! – Com falha:     1, Aprovado:     0, Ignorado:     0, Total:     1, Duração: 13 ms - Echoglossian.Tests.dll (net10.0)
+```
+
+After the production change, the focused covering suites passed:
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore -p:VSTestMaxCpuCount=1 --filter "FullyQualifiedName~AcceptedQuestPrefetchRuntimeContractTests|FullyQualifiedName~QuestDialogueMetadataPersistenceTests"
+
+Execução de teste para C:\Users\lokin\.codex\worktrees\7417\Echoglossian\Echoglossian.Tests\bin\x64\Debug\net10.0-windows\Echoglossian.Tests.dll (.NETCoreApp,Version=v10.0)
+Versão do VSTest 18.0.2 (x64)
+
+Iniciando execução de teste, espere...
+1 arquivos de teste no total corresponderam ao padrão especificado.
+
+Aprovado!  – Com falha:     0, Aprovado:     6, Ignorado:     0, Total:     6, Duração: 3 s - Echoglossian.Tests.dll (net10.0)
+```
+
+### Additional Validation
+
+```text
+dotnet build Echoglossian.sln -c Debug --no-restore
+
+Compilação com êxito.
+    1 Aviso(s)
+    0 Erro(s)
+```
+
+```text
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --no-restore -p:VSTestMaxCpuCount=1
+
+Aprovado!  – Com falha:     0, Aprovado:  1142, Ignorado:     0, Total:  1142, Duração: 25 s - Echoglossian.Tests.dll (net10.0)
+```
+
+```text
+dotnet build Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-restore
+
+FALHA da compilação.
+MockFramework does not implement IFramework.CreateDebouncer(TimeSpan, Action).
+MockCharacter does not implement IGameObject.CurrentDistance or NextDistance.
+    3 Erro(s)
+```
+
+The Mock failure is unchanged vendored DalaMock/Dalamud API drift and prevents a
+hosted runtime test. In-game verification remains required to confirm that
+configuration refresh during metadata generation stays responsive and that
+later captures remain the visible exact-key metadata.

--- a/.superpowers/sdd/2026-08-12-llm-capability-matrix-implementation-plan/task-7-verification-followup-report.md
+++ b/.superpowers/sdd/2026-08-12-llm-capability-matrix-implementation-plan/task-7-verification-followup-report.md
@@ -38,3 +38,53 @@ project warnings, including the unavailable Multilingual App Toolkit warning.
 Confirm in-game that live NPC speaker metadata logs `speakerGender=true` for
 numeric customize-sex values, and that `gpt-5.6-terra` accepts structured tool
 requests with `reasoning_effort: none`.
+
+## Review fix round
+
+### Root cause
+
+The initial follow-up assigned `ChatReasoningEffortLevel.None` directly in the
+structured ChatGPT request. This bypassed the effective capability snapshot,
+and the installed OpenAI SDK documents only `Low`, `Medium`, and `High` as
+supported values. The source-contract test did not exercise the runtime policy
+decision.
+
+### Fix
+
+- Removed the unconditional `None` assignment.
+- Added `ApplyStructuredReasoningEffortPolicy`, which reads the shared
+  capability snapshot, clears any unsupported/default-only effort, and only
+  leaves a configured value eligible when the resolved policy supports it.
+- Structured exception learning now runs only when an effort value was eligible
+  for transmission.
+- Replaced the source-text assertion with behavior tests for unsupported
+  omission and an exact-model supported overlay retaining an SDK-supported
+  `Low` value.
+
+### Review-fix TDD evidence
+
+RED command:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests"
+```
+
+RED result: compilation failed as expected because
+`ApplyStructuredReasoningEffortPolicy` did not exist. After adding the method,
+the first test run exposed a temporary test cleanup file lock; the supported
+overlay test was changed to use the existing in-memory capability cache seam.
+
+GREEN command:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~DialogueInterlocutorMetadataResolverTests|FullyQualifiedName~LlmCapabilityPolicyServiceTests"
+```
+
+GREEN result: 23 passed, 0 failed, 0 skipped. The build emitted only the
+existing Multilingual App Toolkit warning.
+
+### Updated runtime verification
+
+Verify in-game that `gpt-5.6-terra` structured tool requests omit
+`reasoning_effort`. A supported exact-model rule may retain a valid configured
+SDK effort value; the plugin does not invent one.

--- a/.superpowers/sdd/2026-08-12-llm-capability-matrix-implementation-plan/task-7-verification-followup-report.md
+++ b/.superpowers/sdd/2026-08-12-llm-capability-matrix-implementation-plan/task-7-verification-followup-report.md
@@ -1,0 +1,40 @@
+# Task 7 verification follow-up report
+
+## Scope
+
+- Normalized live-actor customize-sex values `"0"` to `"male"` and `"1"` to
+  `"female"`, retaining the existing textual mappings and null fallback.
+- Set structured ChatGPT tool requests to
+  `ChatReasoningEffortLevel.None` and recorded reasoning-effort provider
+  failures through the exact model capability scope.
+- Preserved pre-existing pending diagnostics edits in `ChatGPTTranslator.cs`.
+
+## TDD evidence
+
+RED command:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~DialogueInterlocutorMetadataResolverTests|FullyQualifiedName~LlmCapabilityPolicyServiceTests"
+```
+
+RED result: 3 failed, 19 passed, 22 total. The expected failures were missing
+numeric sex mappings, missing structured reasoning-effort configuration and
+learning call, and no promoted reasoning-effort rule for the raw provider
+message. The last assertion was revised to verify the existing observation-only
+feedback behavior for that message because it does not meet the classifier's
+explicit-unsupported promotion criteria.
+
+GREEN command:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~DialogueInterlocutorMetadataResolverTests|FullyQualifiedName~LlmCapabilityPolicyServiceTests"
+```
+
+GREEN result: 22 passed, 0 failed, 0 skipped. The build emitted pre-existing
+project warnings, including the unavailable Multilingual App Toolkit warning.
+
+## Remaining runtime verification
+
+Confirm in-game that live NPC speaker metadata logs `speakerGender=true` for
+numeric customize-sex values, and that `gpt-5.6-terra` accepts structured tool
+requests with `reasoning_effort: none`.

--- a/Cache/LlmCapabilityCacheManager.cs
+++ b/Cache/LlmCapabilityCacheManager.cs
@@ -75,6 +75,41 @@ public static class LlmCapabilityCacheManager
     }
 
     /// <summary>
+    ///     Publishes one persisted rule to the DB-free runtime cache.
+    /// </summary>
+    /// <param name="rule">The persisted rule definition to publish.</param>
+    internal static void PublishRule(LlmCapabilityRuleDefinition rule)
+    {
+        lock (SyncLock)
+        {
+            var updatedRules = cachedRules
+                .Where(existing => !HasSameLookupIdentity(existing, rule))
+                .Append(rule)
+                .ToArray();
+            cachedRules = Array.AsReadOnly(updatedRules);
+        }
+    }
+
+    /// <summary>
+    ///     Publishes one persisted provider-feedback observation to the bounded
+    ///     runtime audit snapshot.
+    /// </summary>
+    /// <param name="observation">The observation to publish.</param>
+    internal static void PublishObservation(
+        LlmModelCapabilityObservation observation)
+    {
+        lock (SyncLock)
+        {
+            var updatedObservations = cachedObservations
+                .Prepend(observation)
+                .OrderByDescending(static row => row.ObservedAtUtc)
+                .Take(128)
+                .ToArray();
+            cachedObservations = Array.AsReadOnly(updatedObservations);
+        }
+    }
+
+    /// <summary>
     ///     Clears the runtime capability snapshots.
     /// </summary>
     public static void Clear()
@@ -86,5 +121,24 @@ public static class LlmCapabilityCacheManager
             cachedObservations = Array.AsReadOnly(
                 Array.Empty<LlmModelCapabilityObservation>());
         }
+    }
+
+    /// <summary>
+    ///     Determines whether two rules address the same persisted lookup
+    ///     identity.
+    /// </summary>
+    /// <param name="left">The first rule to compare.</param>
+    /// <param name="right">The second rule to compare.</param>
+    /// <returns><see langword="true" /> if both rules share one lookup identity; otherwise, <see langword="false" />.</returns>
+    private static bool HasSameLookupIdentity(
+        LlmCapabilityRuleDefinition left,
+        LlmCapabilityRuleDefinition right)
+    {
+        return string.Equals(left.Engine, right.Engine, StringComparison.Ordinal) &&
+            string.Equals(left.ProviderScope, right.ProviderScope, StringComparison.Ordinal) &&
+            string.Equals(left.EndpointScope, right.EndpointScope, StringComparison.Ordinal) &&
+            left.MatchType == right.MatchType &&
+            string.Equals(left.MatchValue, right.MatchValue, StringComparison.Ordinal) &&
+            left.ParameterName == right.ParameterName;
     }
 }

--- a/Cache/LlmCapabilityCacheManager.cs
+++ b/Cache/LlmCapabilityCacheManager.cs
@@ -101,6 +101,7 @@ public static class LlmCapabilityCacheManager
         lock (SyncLock)
         {
             var updatedObservations = cachedObservations
+                .Where(existing => !HasSameObservationIdentity(existing, observation))
                 .Prepend(observation)
                 .OrderByDescending(static row => row.ObservedAtUtc)
                 .Take(128)
@@ -140,5 +141,25 @@ public static class LlmCapabilityCacheManager
             left.MatchType == right.MatchType &&
             string.Equals(left.MatchValue, right.MatchValue, StringComparison.Ordinal) &&
             left.ParameterName == right.ParameterName;
+    }
+
+    /// <summary>
+    ///     Determines whether two observations represent the same bounded
+    ///     provider-feedback event identity.
+    /// </summary>
+    /// <param name="left">The first observation to compare.</param>
+    /// <param name="right">The second observation to compare.</param>
+    /// <returns><see langword="true" /> if both observations share one identity; otherwise, <see langword="false" />.</returns>
+    private static bool HasSameObservationIdentity(
+        LlmModelCapabilityObservation left,
+        LlmModelCapabilityObservation right)
+    {
+        return string.Equals(left.Engine, right.Engine, StringComparison.Ordinal) &&
+            string.Equals(left.ProviderScope, right.ProviderScope, StringComparison.Ordinal) &&
+            string.Equals(left.EndpointScope, right.EndpointScope, StringComparison.Ordinal) &&
+            string.Equals(left.ModelId, right.ModelId, StringComparison.Ordinal) &&
+            string.Equals(left.ParameterName, right.ParameterName, StringComparison.Ordinal) &&
+            left.StatusCode == right.StatusCode &&
+            string.Equals(left.MessageExcerpt, right.MessageExcerpt, StringComparison.Ordinal);
     }
 }

--- a/Cache/LlmCapabilityCacheManager.cs
+++ b/Cache/LlmCapabilityCacheManager.cs
@@ -1,0 +1,84 @@
+// <copyright file="LlmCapabilityCacheManager.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.EFCoreSqlite;
+using Echoglossian.EFCoreSqlite.Models;
+using Echoglossian.Translators.Capabilities;
+
+namespace Echoglossian.Cache;
+
+/// <summary>
+///     Maintains DB-free runtime snapshots of persisted LLM capability data.
+/// </summary>
+public static class LlmCapabilityCacheManager
+{
+    private static readonly object SyncLock = new();
+    private static IReadOnlyList<LlmCapabilityRuleDefinition> cachedRules = [];
+    private static IReadOnlyList<LlmModelCapabilityObservation> cachedObservations = [];
+
+    /// <summary>
+    ///     Hydrates the runtime cache from persisted capability tables.
+    /// </summary>
+    /// <param name="configDir">The plugin configuration directory.</param>
+    public static void Initialize(string configDir)
+    {
+        try
+        {
+            using var context = new EchoglossianDbContext(configDir);
+            var rules = context.LlmModelCapabilityRules
+                .AsNoTracking()
+                .ToList()
+                .Select(static row => row.ToDefinition())
+                .ToList();
+            var observations = context.LlmModelCapabilityObservations
+                .AsNoTracking()
+                .OrderByDescending(static row => row.ObservedAtUtc)
+                .Take(128)
+                .ToList();
+
+            lock (SyncLock)
+            {
+                cachedRules = rules;
+                cachedObservations = observations;
+            }
+        }
+        catch (Exception ex)
+        {
+            lock (SyncLock)
+            {
+                cachedRules = [];
+                cachedObservations = [];
+            }
+
+            PluginRuntimeLog.Error(
+                $"[LlmCapabilityCacheManager] Failed to initialize cache: {ex}");
+        }
+    }
+
+    /// <summary>
+    ///     Gets the current persisted capability rule definitions without
+    ///     querying SQLite.
+    /// </summary>
+    /// <returns>The cached rule definitions.</returns>
+    public static IReadOnlyList<LlmCapabilityRuleDefinition> GetRuleDefinitions()
+    {
+        lock (SyncLock)
+        {
+            return cachedRules;
+        }
+    }
+
+    /// <summary>
+    ///     Clears the runtime capability snapshots.
+    /// </summary>
+    public static void Clear()
+    {
+        lock (SyncLock)
+        {
+            cachedRules = [];
+            cachedObservations = [];
+        }
+    }
+}

--- a/Cache/LlmCapabilityCacheManager.cs
+++ b/Cache/LlmCapabilityCacheManager.cs
@@ -15,8 +15,10 @@ namespace Echoglossian.Cache;
 public static class LlmCapabilityCacheManager
 {
     private static readonly object SyncLock = new();
-    private static IReadOnlyList<LlmCapabilityRuleDefinition> cachedRules = [];
-    private static IReadOnlyList<LlmModelCapabilityObservation> cachedObservations = [];
+    private static IReadOnlyList<LlmCapabilityRuleDefinition> cachedRules =
+        Array.AsReadOnly(Array.Empty<LlmCapabilityRuleDefinition>());
+    private static IReadOnlyList<LlmModelCapabilityObservation> cachedObservations =
+        Array.AsReadOnly(Array.Empty<LlmModelCapabilityObservation>());
 
     /// <summary>
     ///     Hydrates the runtime cache from persisted capability tables.
@@ -40,16 +42,18 @@ public static class LlmCapabilityCacheManager
 
             lock (SyncLock)
             {
-                cachedRules = rules;
-                cachedObservations = observations;
+                cachedRules = Array.AsReadOnly(rules.ToArray());
+                cachedObservations = Array.AsReadOnly(observations.ToArray());
             }
         }
         catch (Exception ex)
         {
             lock (SyncLock)
             {
-                cachedRules = [];
-                cachedObservations = [];
+                cachedRules = Array.AsReadOnly(
+                    Array.Empty<LlmCapabilityRuleDefinition>());
+                cachedObservations = Array.AsReadOnly(
+                    Array.Empty<LlmModelCapabilityObservation>());
             }
 
             PluginRuntimeLog.Error(
@@ -77,8 +81,10 @@ public static class LlmCapabilityCacheManager
     {
         lock (SyncLock)
         {
-            cachedRules = [];
-            cachedObservations = [];
+            cachedRules = Array.AsReadOnly(
+                Array.Empty<LlmCapabilityRuleDefinition>());
+            cachedObservations = Array.AsReadOnly(
+                Array.Empty<LlmModelCapabilityObservation>());
         }
     }
 }

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -171,6 +171,71 @@ public partial class Echoglossian
   }
 
   /// <summary>
+  ///     Asynchronously finds and returns a TalkMessage from the database.
+  /// </summary>
+  /// <param name="talkMessage">The TalkMessage to find in the database.</param>
+  /// <param name="cancellationToken">The token that cancels the database lookup.</param>
+  /// <returns>A matching <see cref="TalkMessage" />, or <see langword="null" />.</returns>
+  /// <exception cref="OperationCanceledException">
+  ///     The database lookup is cancelled.
+  /// </exception>
+  public async Task<TalkMessage?> FindAndReturnTalkMessageAsync(
+      TalkMessage talkMessage,
+      CancellationToken cancellationToken)
+  {
+    using var context = new EchoglossianDbContext(ConfigDirectory);
+
+    try
+    {
+      if (!TranslationReuseScope.TryCreate(
+              this.configuration,
+              talkMessage.TranslationEngine,
+              out var scope))
+      {
+        return null;
+      }
+
+      var existingTalkMessages = await context.TalkMessage.AsNoTracking().Where(t =>
+              t.SenderName == talkMessage.SenderName &&
+              t.OriginalTalkMessage == talkMessage.OriginalTalkMessage &&
+              t.TranslationLang == talkMessage.TranslationLang)
+          .ToListAsync(cancellationToken)
+          .ConfigureAwait(false);
+      var candidates = existingTalkMessages.Where(t =>
+          scope.Matches(
+              t.OriginalTalkMessageLang,
+              t.TranslationLang,
+              t.TranslationEngine));
+
+      var localFoundTalkMessage = OrderTalkMessageLookupQuery(
+              candidates.AsQueryable())
+          .FirstOrDefault();
+      if (localFoundTalkMessage == null ||
+          localFoundTalkMessage.OriginalTalkMessage !=
+              talkMessage.OriginalTalkMessage ||
+          !TranslationPersistenceGuard.IsUsableDialogueTranslation(
+              localFoundTalkMessage.OriginalTalkMessage,
+              localFoundTalkMessage.TranslatedTalkMessage,
+              localFoundTalkMessage.OriginalTalkMessageLang,
+              localFoundTalkMessage.TranslationLang))
+      {
+        return null;
+      }
+
+      return localFoundTalkMessage;
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (Exception e)
+    {
+      PluginRuntimeLog.Debug($"FindAndReturnTalkMessageAsync exception {e}");
+      return null;
+    }
+  }
+
+  /// <summary>
   /// Finds and returns a ToastMessage from the database.
   /// </summary>
   /// <param name="toastMessage">Formatted ToastMessage to be found in the database</param>
@@ -446,6 +511,79 @@ public partial class Echoglossian
     catch (Exception e)
     {
       PluginRuntimeLog.Debug($"FindAndReturnBattleTalkMessage exception {e}");
+      return null;
+    }
+  }
+
+  /// <summary>
+  ///     Asynchronously finds and returns a BattleTalkMessage from the
+  ///     database.
+  /// </summary>
+  /// <param name="battleTalkMessage">The BattleTalkMessage to find in the database.</param>
+  /// <param name="cancellationToken">The token that cancels the database lookup.</param>
+  /// <returns>
+  ///     A matching <see cref="BattleTalkMessage" />, or <see langword="null" />.
+  /// </returns>
+  /// <exception cref="OperationCanceledException">
+  ///     The database lookup is cancelled.
+  /// </exception>
+  public async Task<BattleTalkMessage?> FindAndReturnBattleTalkMessageAsync(
+      BattleTalkMessage battleTalkMessage,
+      CancellationToken cancellationToken)
+  {
+    using var context = new EchoglossianDbContext(ConfigDirectory);
+
+    try
+    {
+      if (!TranslationReuseScope.TryCreate(
+              this.configuration,
+              battleTalkMessage.TranslationEngine,
+              out var scope))
+      {
+        return null;
+      }
+
+      var existingBattleTalkMessages = await context.BattleTalkMessage.AsNoTracking().Where(t =>
+              t.SenderName == battleTalkMessage.SenderName &&
+              t.OriginalBattleTalkMessage ==
+              battleTalkMessage.OriginalBattleTalkMessage &&
+              t.TranslationLang == battleTalkMessage.TranslationLang &&
+              t.TranslatedBattleTalkMessage != null &&
+              t.TranslatedBattleTalkMessage != string.Empty)
+          .ToListAsync(cancellationToken)
+          .ConfigureAwait(false);
+      var candidates = existingBattleTalkMessages.Where(t =>
+          scope.Matches(
+              t.OriginalBattleTalkMessageLang,
+              t.TranslationLang,
+              t.TranslationEngine));
+
+      var localFoundBattleTalkMessage =
+          OrderBattleTalkMessageLookupQuery(candidates.AsQueryable())
+              .FirstOrDefault();
+      if (localFoundBattleTalkMessage == null ||
+          localFoundBattleTalkMessage.OriginalBattleTalkMessage !=
+              battleTalkMessage.OriginalBattleTalkMessage ||
+          !TranslationPersistenceGuard.IsUsableDialogueTranslation(
+              localFoundBattleTalkMessage.OriginalBattleTalkMessage,
+              localFoundBattleTalkMessage.TranslatedBattleTalkMessage,
+              localFoundBattleTalkMessage.OriginalBattleTalkMessageLang,
+              localFoundBattleTalkMessage.TranslationLang))
+      {
+        return null;
+      }
+
+      FoundBattleTalkMessage = localFoundBattleTalkMessage;
+      return localFoundBattleTalkMessage;
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (Exception e)
+    {
+      PluginRuntimeLog.Debug(
+          $"FindAndReturnBattleTalkMessageAsync exception {e}");
       return null;
     }
   }

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -11,6 +11,18 @@ using Dalamud.Game.Gui.NamePlate;
 namespace Echoglossian;
 
 /// <summary>
+///     Identifies one exact versioned quest dialogue metadata row.
+/// </summary>
+public readonly record struct QuestDialogueMetadataLookup(
+    uint QuestId,
+    ushort QuestSequence,
+    string SourceLanguageCode,
+    string GameVersion,
+    string SourceRowKey,
+    string SourceTextHash,
+    string DerivationVersion);
+
+/// <summary>
 ///  Defines operations for managing and retrieving translation data
 /// </summary>
 public partial class Echoglossian
@@ -168,6 +180,92 @@ public partial class Echoglossian
     {
       return null;
     }
+  }
+
+  /// <summary>
+  ///     Finds metadata that exactly matches one quest dialogue source row and
+  ///     derivation version.
+  /// </summary>
+  /// <param name="lookup">The exact source row lookup values.</param>
+  /// <param name="cancellationToken">The token that cancels the database lookup.</param>
+  /// <returns>A matching metadata row; otherwise, <see langword="null" />.</returns>
+  /// <exception cref="OperationCanceledException">
+  ///     The database lookup is cancelled.
+  /// </exception>
+  public async Task<QuestDialogueMetadata?> FindQuestDialogueMetadataAsync(
+      QuestDialogueMetadataLookup lookup,
+      CancellationToken cancellationToken)
+  {
+    if (string.IsNullOrWhiteSpace(lookup.SourceRowKey))
+    {
+      return null;
+    }
+
+    using var context = new EchoglossianDbContext(ConfigDirectory);
+    var matches = await context.QuestDialogueMetadata
+        .AsNoTracking()
+        .Where(row => row.QuestId == lookup.QuestId &&
+                      row.QuestSequence == lookup.QuestSequence &&
+                      row.SourceLanguageCode == lookup.SourceLanguageCode &&
+                      row.GameVersion == lookup.GameVersion &&
+                      row.SourceRowKey == lookup.SourceRowKey &&
+                      row.SourceTextHash == lookup.SourceTextHash &&
+                      row.DerivationVersion == lookup.DerivationVersion)
+        .ToListAsync(cancellationToken)
+        .ConfigureAwait(false);
+    return matches.SingleOrDefault();
+  }
+
+  /// <summary>
+  ///     Replaces persisted metadata rows with the supplied exact logical rows.
+  /// </summary>
+  /// <param name="rows">The metadata rows to persist.</param>
+  /// <param name="cancellationToken">The token that cancels the database operation.</param>
+  /// <exception cref="OperationCanceledException">
+  ///     The database operation is cancelled.
+  /// </exception>
+  public async Task UpsertQuestDialogueMetadataBatchAsync(
+      IReadOnlyList<QuestDialogueMetadata> rows,
+      CancellationToken cancellationToken)
+  {
+    if (rows.Count == 0)
+    {
+      return;
+    }
+
+    var rowsByLogicalKey = rows
+        .GroupBy(row => new
+        {
+          row.QuestId,
+          row.QuestSequence,
+          row.SourceLanguageCode,
+          row.GameVersion,
+          row.SourceRowKey,
+          row.SourceTextHash,
+          row.DerivationVersion,
+        })
+        .Select(group => group.Last())
+        .ToList();
+    using var context = new EchoglossianDbContext(ConfigDirectory);
+
+    foreach (var row in rowsByLogicalKey)
+    {
+      var existingRows = await context.QuestDialogueMetadata
+          .Where(existing => existing.QuestId == row.QuestId &&
+                             existing.QuestSequence == row.QuestSequence &&
+                             existing.SourceLanguageCode == row.SourceLanguageCode &&
+                             existing.GameVersion == row.GameVersion &&
+                             existing.SourceRowKey == row.SourceRowKey &&
+                             existing.SourceTextHash == row.SourceTextHash &&
+                             existing.DerivationVersion == row.DerivationVersion)
+          .ToListAsync(cancellationToken)
+          .ConfigureAwait(false);
+      context.QuestDialogueMetadata.RemoveRange(existingRows);
+      row.Id = 0;
+      context.QuestDialogueMetadata.Add(row);
+    }
+
+    await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -228,31 +228,6 @@ public partial class Echoglossian
       IReadOnlyList<QuestDialogueMetadata> rows,
       CancellationToken cancellationToken)
   {
-    await this.UpsertQuestDialogueMetadataBatchAsync(
-            rows,
-            static () => true,
-            cancellationToken)
-        .ConfigureAwait(false);
-  }
-
-  /// <summary>
-  ///     Replaces persisted metadata rows with the supplied exact logical rows
-  ///     when the caller still permits the transaction to commit.
-  /// </summary>
-  /// <param name="rows">The metadata rows to persist.</param>
-  /// <param name="commitGuard">The callback that permits committing the transaction.</param>
-  /// <param name="cancellationToken">The token that cancels the database operation.</param>
-  /// <returns>A task representing the guarded database operation.</returns>
-  /// <exception cref="OperationCanceledException">
-  ///     The database operation is cancelled.
-  /// </exception>
-  internal async Task UpsertQuestDialogueMetadataBatchAsync(
-      IReadOnlyList<QuestDialogueMetadata> rows,
-      Func<bool> commitGuard,
-      CancellationToken cancellationToken)
-  {
-    ArgumentNullException.ThrowIfNull(commitGuard);
-
     if (rows.Count == 0)
     {
       return;
@@ -305,17 +280,13 @@ public partial class Echoglossian
               Provenance = excluded.Provenance,
               ConfidenceTier = excluded.ConfidenceTier,
               CreatedAtUtc = excluded.CreatedAtUtc,
-              UpdatedAtUtc = excluded.UpdatedAtUtc;
+              UpdatedAtUtc = excluded.UpdatedAtUtc
+          WHERE excluded.UpdatedAtUtc >= questdialoguemetadata.UpdatedAtUtc;
           """,
           cancellationToken).ConfigureAwait(false);
     }
 
     cancellationToken.ThrowIfCancellationRequested();
-    if (!commitGuard())
-    {
-      return;
-    }
-
     await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
   }
 

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -246,7 +246,7 @@ public partial class Echoglossian
   /// <exception cref="OperationCanceledException">
   ///     The database operation is cancelled.
   /// </exception>
-  private async Task UpsertQuestDialogueMetadataBatchAsync(
+  internal async Task UpsertQuestDialogueMetadataBatchAsync(
       IReadOnlyList<QuestDialogueMetadata> rows,
       Func<bool> commitGuard,
       CancellationToken cancellationToken)

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -228,6 +228,31 @@ public partial class Echoglossian
       IReadOnlyList<QuestDialogueMetadata> rows,
       CancellationToken cancellationToken)
   {
+    await this.UpsertQuestDialogueMetadataBatchAsync(
+            rows,
+            static () => true,
+            cancellationToken)
+        .ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Replaces persisted metadata rows with the supplied exact logical rows
+  ///     when the caller still permits the transaction to commit.
+  /// </summary>
+  /// <param name="rows">The metadata rows to persist.</param>
+  /// <param name="commitGuard">The callback that permits committing the transaction.</param>
+  /// <param name="cancellationToken">The token that cancels the database operation.</param>
+  /// <returns>A task representing the guarded database operation.</returns>
+  /// <exception cref="OperationCanceledException">
+  ///     The database operation is cancelled.
+  /// </exception>
+  private async Task UpsertQuestDialogueMetadataBatchAsync(
+      IReadOnlyList<QuestDialogueMetadata> rows,
+      Func<bool> commitGuard,
+      CancellationToken cancellationToken)
+  {
+    ArgumentNullException.ThrowIfNull(commitGuard);
+
     if (rows.Count == 0)
     {
       return;
@@ -246,9 +271,12 @@ public partial class Echoglossian
         })
         .Select(group => group.Last())
         .ToList();
+    using var context = new EchoglossianDbContext(ConfigDirectory);
+    await using var transaction = await context.Database
+        .BeginTransactionAsync(cancellationToken)
+        .ConfigureAwait(false);
     foreach (var row in rowsByLogicalKey)
     {
-      using var context = new EchoglossianDbContext(ConfigDirectory);
       await context.Database.ExecuteSqlInterpolatedAsync(
           $"""
           INSERT INTO questdialoguemetadata (
@@ -281,6 +309,14 @@ public partial class Echoglossian
           """,
           cancellationToken).ConfigureAwait(false);
     }
+
+    cancellationToken.ThrowIfCancellationRequested();
+    if (!commitGuard())
+    {
+      return;
+    }
+
+    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -244,7 +244,7 @@ public partial class Echoglossian
           row.SourceTextHash,
           row.DerivationVersion,
         })
-        .Select(group => group.Last())
+        .Select(group => group.MaxBy(row => row.UpdatedAtUtc)!)
         .ToList();
     using var context = new EchoglossianDbContext(ConfigDirectory);
     await using var transaction = await context.Database
@@ -279,7 +279,6 @@ public partial class Echoglossian
               AddresseeRoleHint = excluded.AddresseeRoleHint,
               Provenance = excluded.Provenance,
               ConfidenceTier = excluded.ConfidenceTier,
-              CreatedAtUtc = excluded.CreatedAtUtc,
               UpdatedAtUtc = excluded.UpdatedAtUtc
           WHERE excluded.UpdatedAtUtc >= questdialoguemetadata.UpdatedAtUtc;
           """,

--- a/DBHelpers/DbOperations.cs
+++ b/DBHelpers/DbOperations.cs
@@ -246,26 +246,41 @@ public partial class Echoglossian
         })
         .Select(group => group.Last())
         .ToList();
-    using var context = new EchoglossianDbContext(ConfigDirectory);
-
     foreach (var row in rowsByLogicalKey)
     {
-      var existingRows = await context.QuestDialogueMetadata
-          .Where(existing => existing.QuestId == row.QuestId &&
-                             existing.QuestSequence == row.QuestSequence &&
-                             existing.SourceLanguageCode == row.SourceLanguageCode &&
-                             existing.GameVersion == row.GameVersion &&
-                             existing.SourceRowKey == row.SourceRowKey &&
-                             existing.SourceTextHash == row.SourceTextHash &&
-                             existing.DerivationVersion == row.DerivationVersion)
-          .ToListAsync(cancellationToken)
-          .ConfigureAwait(false);
-      context.QuestDialogueMetadata.RemoveRange(existingRows);
-      row.Id = 0;
-      context.QuestDialogueMetadata.Add(row);
+      using var context = new EchoglossianDbContext(ConfigDirectory);
+      await context.Database.ExecuteSqlInterpolatedAsync(
+          $"""
+          INSERT INTO questdialoguemetadata (
+              QuestId, QuestSequence, SourceLanguageCode, GameVersion,
+              QuestSheetId, QuestTextSheetName, SourceRowKey, SourceTextHash,
+              SourceTextPreview, SpeakerHint, AddresseeHint, SpeakerRoleHint,
+              AddresseeRoleHint, Provenance, ConfidenceTier, DerivationVersion,
+              CreatedAtUtc, UpdatedAtUtc)
+          VALUES (
+              {row.QuestId}, {row.QuestSequence}, {row.SourceLanguageCode}, {row.GameVersion},
+              {row.QuestSheetId}, {row.QuestTextSheetName}, {row.SourceRowKey}, {row.SourceTextHash},
+              {row.SourceTextPreview}, {row.SpeakerHint}, {row.AddresseeHint}, {row.SpeakerRoleHint},
+              {row.AddresseeRoleHint}, {row.Provenance}, {row.ConfidenceTier}, {row.DerivationVersion},
+              {row.CreatedAtUtc}, {row.UpdatedAtUtc})
+          ON CONFLICT (
+              QuestId, QuestSequence, SourceLanguageCode, GameVersion,
+              SourceRowKey, SourceTextHash, DerivationVersion)
+          DO UPDATE SET
+              QuestSheetId = excluded.QuestSheetId,
+              QuestTextSheetName = excluded.QuestTextSheetName,
+              SourceTextPreview = excluded.SourceTextPreview,
+              SpeakerHint = excluded.SpeakerHint,
+              AddresseeHint = excluded.AddresseeHint,
+              SpeakerRoleHint = excluded.SpeakerRoleHint,
+              AddresseeRoleHint = excluded.AddresseeRoleHint,
+              Provenance = excluded.Provenance,
+              ConfidenceTier = excluded.ConfidenceTier,
+              CreatedAtUtc = excluded.CreatedAtUtc,
+              UpdatedAtUtc = excluded.UpdatedAtUtc;
+          """,
+          cancellationToken).ConfigureAwait(false);
     }
-
-    await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>

--- a/DBHelpers/LlmCapabilityPersistenceHelper.cs
+++ b/DBHelpers/LlmCapabilityPersistenceHelper.cs
@@ -1,0 +1,76 @@
+// <copyright file="LlmCapabilityPersistenceHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.EFCoreSqlite;
+using Echoglossian.EFCoreSqlite.Models;
+
+namespace Echoglossian.DBHelpers;
+
+/// <summary>
+///     Persists LLM capability overlays and provider-feedback observations.
+/// </summary>
+public static class LlmCapabilityPersistenceHelper
+{
+    /// <summary>
+    ///     Inserts or updates capability rules by their scoped lookup identity.
+    /// </summary>
+    /// <param name="configDir">The plugin configuration directory.</param>
+    /// <param name="rules">The rules to persist.</param>
+    public static void UpsertRules(
+        string configDir,
+        IReadOnlyList<LlmModelCapabilityRule> rules)
+    {
+        using var context = new EchoglossianDbContext(configDir);
+        context.Database.Migrate();
+
+        foreach (var rule in rules)
+        {
+            var existing = context.LlmModelCapabilityRules.FirstOrDefault(row =>
+                row.Engine == rule.Engine &&
+                row.ProviderScope == rule.ProviderScope &&
+                row.EndpointScope == rule.EndpointScope &&
+                row.MatchType == rule.MatchType &&
+                row.MatchValue == rule.MatchValue &&
+                row.ParameterName == rule.ParameterName);
+            if (existing is null)
+            {
+                context.LlmModelCapabilityRules.Add(rule);
+                continue;
+            }
+
+            existing.SupportState = rule.SupportState;
+            existing.MinValue = rule.MinValue;
+            existing.MaxValue = rule.MaxValue;
+            existing.AllowedEnumValuesJson = rule.AllowedEnumValuesJson;
+            existing.OmitWhenDefaultOnly = rule.OmitWhenDefaultOnly;
+            existing.Source = rule.Source;
+            existing.Reason = rule.Reason;
+            existing.Confidence = rule.Confidence;
+            existing.ObservedAtUtc = rule.ObservedAtUtc;
+            existing.ExpiresAtUtc = rule.ExpiresAtUtc;
+            existing.UpdatedAtUtc = DateTime.UtcNow;
+        }
+
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    ///     Records one provider-feedback observation for later audit.
+    /// </summary>
+    /// <param name="configDir">The plugin configuration directory.</param>
+    /// <param name="observation">The observation to persist.</param>
+    public static void RecordObservation(
+        string configDir,
+        LlmModelCapabilityObservation observation)
+    {
+        using var context = new EchoglossianDbContext(configDir);
+        context.Database.Migrate();
+        observation.ObservedAtUtc = observation.ObservedAtUtc == default
+            ? DateTime.UtcNow
+            : observation.ObservedAtUtc;
+        context.LlmModelCapabilityObservations.Add(observation);
+        context.SaveChanges();
+    }
+}

--- a/DBHelpers/LlmCapabilityPersistenceHelper.cs
+++ b/DBHelpers/LlmCapabilityPersistenceHelper.cs
@@ -57,7 +57,8 @@ public static class LlmCapabilityPersistenceHelper
     }
 
     /// <summary>
-    ///     Records one provider-feedback observation for later audit.
+    ///     Records or refreshes one provider-feedback observation for later
+    ///     audit.
     /// </summary>
     /// <param name="configDir">The plugin configuration directory.</param>
     /// <param name="observation">The observation to persist.</param>
@@ -70,6 +71,22 @@ public static class LlmCapabilityPersistenceHelper
         observation.ObservedAtUtc = observation.ObservedAtUtc == default
             ? DateTime.UtcNow
             : observation.ObservedAtUtc;
+        var existing = context.LlmModelCapabilityObservations.FirstOrDefault(row =>
+            row.Engine == observation.Engine &&
+            row.ProviderScope == observation.ProviderScope &&
+            row.EndpointScope == observation.EndpointScope &&
+            row.ModelId == observation.ModelId &&
+            row.ParameterName == observation.ParameterName &&
+            row.StatusCode == observation.StatusCode &&
+            row.MessageExcerpt == observation.MessageExcerpt);
+        if (existing is not null)
+        {
+            existing.ProviderErrorCode = observation.ProviderErrorCode;
+            existing.ObservedAtUtc = observation.ObservedAtUtc;
+            context.SaveChanges();
+            return;
+        }
+
         context.LlmModelCapabilityObservations.Add(observation);
         context.SaveChanges();
     }

--- a/EFCoreSqlite/EchoglossianDBContext.cs
+++ b/EFCoreSqlite/EchoglossianDBContext.cs
@@ -178,6 +178,16 @@ public class EchoglossianDbContext : DbContext
   public DbSet<TranslationFailure> TranslationFailures { get; set; }
 
   /// <summary>
+  ///     Gets or sets persisted LLM capability overlay rules.
+  /// </summary>
+  public DbSet<LlmModelCapabilityRule> LlmModelCapabilityRules { get; set; }
+
+  /// <summary>
+  ///     Gets or sets provider-feedback observations for LLM capabilities.
+  /// </summary>
+  public DbSet<LlmModelCapabilityObservation> LlmModelCapabilityObservations { get; set; }
+
+  /// <summary>
   ///     Gets or sets the translated string array records.   Configures the database context options.
   /// </summary>
   /// <param name="optionsBuilder"></param>
@@ -419,6 +429,21 @@ public class EchoglossianDbContext : DbContext
         })
         .IsUnique()
         .HasDatabaseName("IX_translationfailures_lookup");
+    modelBuilder.Entity<LlmModelCapabilityRule>().ToTable("llmmodelcapabilityrules");
+    modelBuilder.Entity<LlmModelCapabilityRule>()
+        .HasIndex(row => new
+        {
+          row.Engine,
+          row.ProviderScope,
+          row.EndpointScope,
+          row.MatchType,
+          row.MatchValue,
+          row.ParameterName,
+        })
+        .IsUnique()
+        .HasDatabaseName("IX_llmmodelcapabilityrules_lookup");
+    modelBuilder.Entity<LlmModelCapabilityObservation>()
+        .ToTable("llmmodelcapabilityobservations");
     modelBuilder.Entity<StringArrayDatas>()
         .HasIndex(s => new
         {

--- a/EFCoreSqlite/EchoglossianDBContext.cs
+++ b/EFCoreSqlite/EchoglossianDBContext.cs
@@ -88,6 +88,11 @@ public class EchoglossianDbContext : DbContext
   /// </summary>
   public DbSet<QuestPopupText> QuestPopupTexts { get; set; }
 
+  /// <summary>
+  ///     Gets or sets derived metadata for exact quest dialogue source rows.
+  /// </summary>
+  public DbSet<QuestDialogueMetadata> QuestDialogueMetadata { get; set; }
+
   public DbSet<NpcNames> NpcName { get; set; }
 
   public DbSet<LocationName> LocationNames { get; set; }
@@ -386,6 +391,20 @@ public class EchoglossianDbContext : DbContext
           q.TranslationEngine
         })
         .HasDatabaseName("IX_questpopuptexts_lookup");
+    modelBuilder.Entity<QuestDialogueMetadata>().ToTable("questdialoguemetadata");
+    modelBuilder.Entity<QuestDialogueMetadata>()
+        .HasIndex(q => new
+        {
+          q.QuestId,
+          q.QuestSequence,
+          q.SourceLanguageCode,
+          q.GameVersion,
+          q.SourceRowKey,
+          q.SourceTextHash,
+          q.DerivationVersion,
+        })
+        .IsUnique()
+        .HasDatabaseName("IX_questdialoguemetadata_lookup");
     modelBuilder.Entity<NpcNames>().ToTable("npcnames");
     modelBuilder.Entity<LocationName>().ToTable("locationnames");
     modelBuilder.Entity<TranslationFailure>().ToTable("translationfailures");

--- a/EFCoreSqlite/Migrations/20260810023100_AddQuestDialogueMetadata.Designer.cs
+++ b/EFCoreSqlite/Migrations/20260810023100_AddQuestDialogueMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Echoglossian.EFCoreSqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Echoglossian.EFCoreSqlite.Migrations
 {
     [DbContext(typeof(EchoglossianDbContext))]
-    partial class EchoglossianDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810023100_AddQuestDialogueMetadata")]
+    partial class AddQuestDialogueMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/EFCoreSqlite/Migrations/20260810023100_AddQuestDialogueMetadata.cs
+++ b/EFCoreSqlite/Migrations/20260810023100_AddQuestDialogueMetadata.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Echoglossian.EFCoreSqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuestDialogueMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "questdialoguemetadata",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    QuestId = table.Column<uint>(type: "INTEGER", nullable: false),
+                    QuestSequence = table.Column<ushort>(type: "INTEGER", nullable: false),
+                    SourceLanguageCode = table.Column<string>(type: "TEXT", nullable: false),
+                    GameVersion = table.Column<string>(type: "TEXT", nullable: false),
+                    QuestSheetId = table.Column<string>(type: "TEXT", nullable: false),
+                    QuestTextSheetName = table.Column<string>(type: "TEXT", nullable: false),
+                    SourceRowKey = table.Column<string>(type: "TEXT", nullable: false),
+                    SourceTextHash = table.Column<string>(type: "TEXT", nullable: false),
+                    SourceTextPreview = table.Column<string>(type: "TEXT", nullable: false),
+                    SpeakerHint = table.Column<string>(type: "TEXT", nullable: false),
+                    AddresseeHint = table.Column<string>(type: "TEXT", nullable: false),
+                    SpeakerRoleHint = table.Column<string>(type: "TEXT", nullable: false),
+                    AddresseeRoleHint = table.Column<string>(type: "TEXT", nullable: false),
+                    Provenance = table.Column<string>(type: "TEXT", nullable: false),
+                    ConfidenceTier = table.Column<int>(type: "INTEGER", nullable: false),
+                    DerivationVersion = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_questdialoguemetadata", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_questdialoguemetadata_lookup",
+                table: "questdialoguemetadata",
+                columns: new[] { "QuestId", "QuestSequence", "SourceLanguageCode", "GameVersion", "SourceRowKey", "SourceTextHash", "DerivationVersion" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "questdialoguemetadata");
+        }
+    }
+}

--- a/EFCoreSqlite/Migrations/20260812130000_AddLlmCapabilityMatrix.Designer.cs
+++ b/EFCoreSqlite/Migrations/20260812130000_AddLlmCapabilityMatrix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Echoglossian.EFCoreSqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Echoglossian.EFCoreSqlite.Migrations
 {
     [DbContext(typeof(EchoglossianDbContext))]
-    partial class EchoglossianDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812130000_AddLlmCapabilityMatrix")]
+    partial class AddLlmCapabilityMatrix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/EFCoreSqlite/Migrations/20260812130000_AddLlmCapabilityMatrix.cs
+++ b/EFCoreSqlite/Migrations/20260812130000_AddLlmCapabilityMatrix.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Echoglossian.EFCoreSqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLlmCapabilityMatrix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "llmmodelcapabilityobservations",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Engine = table.Column<string>(type: "TEXT", nullable: false),
+                    ProviderScope = table.Column<string>(type: "TEXT", nullable: false),
+                    EndpointScope = table.Column<string>(type: "TEXT", nullable: false),
+                    ModelId = table.Column<string>(type: "TEXT", nullable: false),
+                    ParameterName = table.Column<string>(type: "TEXT", nullable: false),
+                    StatusCode = table.Column<int>(type: "INTEGER", nullable: false),
+                    ProviderErrorCode = table.Column<string>(type: "TEXT", nullable: false),
+                    MessageExcerpt = table.Column<string>(type: "TEXT", nullable: false),
+                    ObservedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_llmmodelcapabilityobservations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "llmmodelcapabilityrules",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Engine = table.Column<string>(type: "TEXT", nullable: false),
+                    ProviderScope = table.Column<string>(type: "TEXT", nullable: false),
+                    EndpointScope = table.Column<string>(type: "TEXT", nullable: false),
+                    MatchType = table.Column<string>(type: "TEXT", nullable: false),
+                    MatchValue = table.Column<string>(type: "TEXT", nullable: false),
+                    ParameterName = table.Column<string>(type: "TEXT", nullable: false),
+                    SupportState = table.Column<string>(type: "TEXT", nullable: false),
+                    MinValue = table.Column<float>(type: "REAL", nullable: true),
+                    MaxValue = table.Column<float>(type: "REAL", nullable: true),
+                    AllowedEnumValuesJson = table.Column<string>(type: "TEXT", nullable: false),
+                    OmitWhenDefaultOnly = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Source = table.Column<string>(type: "TEXT", nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", nullable: false),
+                    Confidence = table.Column<string>(type: "TEXT", nullable: false),
+                    ObservedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_llmmodelcapabilityrules", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_llmmodelcapabilityrules_lookup",
+                table: "llmmodelcapabilityrules",
+                columns: new[] { "Engine", "ProviderScope", "EndpointScope", "MatchType", "MatchValue", "ParameterName" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "llmmodelcapabilityobservations");
+
+            migrationBuilder.DropTable(
+                name: "llmmodelcapabilityrules");
+        }
+    }
+}

--- a/EFCoreSqlite/Models/Journal/QuestDialogueMetadata.cs
+++ b/EFCoreSqlite/Models/Journal/QuestDialogueMetadata.cs
@@ -1,0 +1,110 @@
+// <copyright file="QuestDialogueMetadata.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.EFCoreSqlite.Models.Journal;
+
+/// <summary>
+///     Stores derived speaker and addressee metadata for one exact quest
+///     dialogue source row.
+/// </summary>
+[Table("questdialoguemetadata")]
+public sealed class QuestDialogueMetadata
+{
+    /// <summary>
+    ///     Gets or sets the primary key.
+    /// </summary>
+    [Key]
+    public long Id { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the canonical quest id.
+    /// </summary>
+    public uint QuestId { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the quest sequence containing the source row.
+    /// </summary>
+    public ushort QuestSequence { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the source language code.
+    /// </summary>
+    public string SourceLanguageCode { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the game version that supplied the source row.
+    /// </summary>
+    public string GameVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the quest sheet id.
+    /// </summary>
+    public string QuestSheetId { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the quest text sheet name.
+    /// </summary>
+    public string QuestTextSheetName { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the exact quest text row key.
+    /// </summary>
+    public string SourceRowKey { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the hash of the exact source text.
+    /// </summary>
+    public string SourceTextHash { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets a diagnostic preview of the source text.
+    /// </summary>
+    public string SourceTextPreview { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the derived speaker hint.
+    /// </summary>
+    public string SpeakerHint { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the derived addressee hint.
+    /// </summary>
+    public string AddresseeHint { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the derived speaker role hint.
+    /// </summary>
+    public string SpeakerRoleHint { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the derived addressee role hint.
+    /// </summary>
+    public string AddresseeRoleHint { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the metadata derivation provenance.
+    /// </summary>
+    public string Provenance { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the confidence tier assigned by derivation.
+    /// </summary>
+    public int ConfidenceTier { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the version of the metadata derivation algorithm.
+    /// </summary>
+    public string DerivationVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Gets or sets the UTC timestamp at which the row was created.
+    /// </summary>
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the UTC timestamp at which the row was last updated.
+    /// </summary>
+    public DateTime UpdatedAtUtc { get; set; }
+}

--- a/EFCoreSqlite/Models/LlmModelCapabilityObservation.cs
+++ b/EFCoreSqlite/Models/LlmModelCapabilityObservation.cs
@@ -1,0 +1,45 @@
+// <copyright file="LlmModelCapabilityObservation.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.EFCoreSqlite.Models;
+
+/// <summary>
+///     Represents one provider capability-feedback observation retained for
+///     later audit or conservative rule promotion.
+/// </summary>
+[Table("llmmodelcapabilityobservations")]
+public sealed class LlmModelCapabilityObservation
+{
+    /// <summary>Gets or sets the primary key.</summary>
+    [Key]
+    public long Id { get; set; }
+
+    /// <summary>Gets or sets the engine identifier.</summary>
+    public string Engine { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the provider scope.</summary>
+    public string ProviderScope { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the endpoint scope.</summary>
+    public string EndpointScope { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the observed model identifier.</summary>
+    public string ModelId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the rejected parameter name.</summary>
+    public string ParameterName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the provider response status code.</summary>
+    public int StatusCode { get; set; }
+
+    /// <summary>Gets or sets the provider error code.</summary>
+    public string ProviderErrorCode { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the sanitized provider message excerpt.</summary>
+    public string MessageExcerpt { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets when the observation occurred in UTC.</summary>
+    public DateTime ObservedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/EFCoreSqlite/Models/LlmModelCapabilityRule.cs
+++ b/EFCoreSqlite/Models/LlmModelCapabilityRule.cs
@@ -1,0 +1,145 @@
+// <copyright file="LlmModelCapabilityRule.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators.Capabilities;
+
+namespace Echoglossian.EFCoreSqlite.Models;
+
+/// <summary>
+///     Represents one persisted LLM capability overlay rule.
+/// </summary>
+[Table("llmmodelcapabilityrules")]
+public sealed class LlmModelCapabilityRule
+{
+    /// <summary>Gets or sets the primary key.</summary>
+    [Key]
+    public long Id { get; set; }
+
+    /// <summary>Gets or sets the engine identifier.</summary>
+    public string Engine { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the provider scope.</summary>
+    public string ProviderScope { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the endpoint scope.</summary>
+    public string EndpointScope { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the model matching strategy.</summary>
+    public string MatchType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the model identifier or family prefix.</summary>
+    public string MatchValue { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the governed parameter name.</summary>
+    public string ParameterName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the parameter support state.</summary>
+    public string SupportState { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the inclusive minimum supported value.</summary>
+    public float? MinValue { get; set; }
+
+    /// <summary>Gets or sets the inclusive maximum supported value.</summary>
+    public float? MaxValue { get; set; }
+
+    /// <summary>Gets or sets serialized allowed enum values.</summary>
+    public string AllowedEnumValuesJson { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether default-only values are omitted.</summary>
+    public bool OmitWhenDefaultOnly { get; set; }
+
+    /// <summary>Gets or sets the rule source.</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the rule rationale.</summary>
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the source confidence.</summary>
+    public string Confidence { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets when the rule was observed in UTC.</summary>
+    public DateTime ObservedAtUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gets or sets when the rule expires in UTC.</summary>
+    public DateTime? ExpiresAtUtc { get; set; }
+
+    /// <summary>Gets or sets when the row was created in UTC.</summary>
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gets or sets when the row was last updated in UTC.</summary>
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    ///     Creates a persisted exact-model capability rule.
+    /// </summary>
+    /// <param name="engine">The engine identifier.</param>
+    /// <param name="providerScope">The provider identity.</param>
+    /// <param name="endpointScope">The endpoint identity.</param>
+    /// <param name="modelId">The complete model identifier.</param>
+    /// <param name="parameterName">The governed parameter.</param>
+    /// <param name="supportState">The known support state.</param>
+    /// <param name="minValue">The inclusive lower bound, when known.</param>
+    /// <param name="maxValue">The inclusive upper bound, when known.</param>
+    /// <param name="omitWhenDefaultOnly"><see langword="true" /> to omit the parameter when only its default is allowed; otherwise, <see langword="false" />.</param>
+    /// <param name="source">The source that established the rule.</param>
+    /// <param name="reason">The explanation for the rule.</param>
+    /// <returns>A persisted exact-model capability rule.</returns>
+    public static LlmModelCapabilityRule CreateExactModel(
+        string engine,
+        string providerScope,
+        string endpointScope,
+        string modelId,
+        LlmCapabilityParameterName parameterName,
+        LlmCapabilitySupportState supportState,
+        float? minValue = null,
+        float? maxValue = null,
+        bool omitWhenDefaultOnly = false,
+        string source = "",
+        string reason = "")
+    {
+        return new LlmModelCapabilityRule
+        {
+            Engine = engine,
+            ProviderScope = providerScope,
+            EndpointScope = endpointScope,
+            MatchType = LlmCapabilityRuleMatchType.ExactModel.ToString(),
+            MatchValue = modelId,
+            ParameterName = parameterName.ToString(),
+            SupportState = supportState.ToString(),
+            MinValue = minValue,
+            MaxValue = maxValue,
+            OmitWhenDefaultOnly = omitWhenDefaultOnly,
+            Source = source,
+            Reason = reason,
+        };
+    }
+
+    /// <summary>
+    ///     Converts this persisted row to the shared resolver rule contract.
+    /// </summary>
+    /// <returns>The shared capability rule definition.</returns>
+    public LlmCapabilityRuleDefinition ToDefinition()
+    {
+        return new LlmCapabilityRuleDefinition(
+            this.Engine,
+            this.ProviderScope,
+            this.EndpointScope,
+            Enum.TryParse<LlmCapabilityRuleMatchType>(this.MatchType, out var matchType)
+                ? matchType
+                : (LlmCapabilityRuleMatchType)(-1),
+            this.MatchValue,
+            Enum.TryParse<LlmCapabilityParameterName>(this.ParameterName, out var parameterName)
+                ? parameterName
+                : (LlmCapabilityParameterName)(-1),
+            Enum.TryParse<LlmCapabilitySupportState>(this.SupportState, out var supportState)
+                ? supportState
+                : LlmCapabilitySupportState.Unknown,
+            this.MinValue,
+            this.MaxValue,
+            this.OmitWhenDefaultOnly,
+            this.Source,
+            this.Reason);
+    }
+}

--- a/Echoglossian.Mock.Tests/HostedPreviewPluginSessionTests.cs
+++ b/Echoglossian.Mock.Tests/HostedPreviewPluginSessionTests.cs
@@ -180,6 +180,7 @@ public sealed class HostedPreviewPluginSessionTests
                 TranslateYesNoScreen = true,
                 TranslateSelectOk = true,
                 TranslateSelectString = true,
+                TranslateSelectIconString = true,
             });
 
         await using var session = await HostedPreviewPluginSessionFactory.StartAsync(

--- a/Echoglossian.Mock.Tests/MockFrameworkDebouncerTests.cs
+++ b/Echoglossian.Mock.Tests/MockFrameworkDebouncerTests.cs
@@ -32,6 +32,61 @@ public sealed class MockFrameworkDebouncerTests
         debouncer.Debounce();
         debouncer.Debounce();
 
+        InvokeTimerElapsed(debouncer, 1L);
+        framework.FireUpdate();
+
+        actionCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Ensures cancellation still invalidates an action after timer expiry but
+    /// before the framework executes the queued callback.
+    /// </summary>
+    [Fact]
+    public void Cancel_after_timer_expiry_invalidates_queued_action()
+    {
+        var framework = new MockFramework();
+        var actionCount = 0;
+        using var debouncer = framework.CreateDebouncer(
+            TimeSpan.FromHours(1),
+            () => actionCount++);
+
+        debouncer.Debounce();
+        InvokeTimerElapsed(debouncer, 1L);
+        debouncer.Cancel();
+        framework.FireUpdate();
+
+        actionCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Ensures re-debouncing after timer expiry invalidates the already queued
+    /// callback while retaining the replacement generation.
+    /// </summary>
+    [Fact]
+    public void Redebounce_after_timer_expiry_invalidates_old_queued_action()
+    {
+        var framework = new MockFramework();
+        var actionCount = 0;
+        using var debouncer = framework.CreateDebouncer(
+            TimeSpan.FromHours(1),
+            () => actionCount++);
+
+        debouncer.Debounce();
+        InvokeTimerElapsed(debouncer, 1L);
+        debouncer.Debounce();
+        framework.FireUpdate();
+
+        actionCount.Should().Be(0);
+
+        InvokeTimerElapsed(debouncer, 2L);
+        framework.FireUpdate();
+
+        actionCount.Should().Be(1);
+    }
+
+    private static void InvokeTimerElapsed(object debouncer, long generation)
+    {
         var debouncerType = typeof(MockFramework).GetNestedType(
             "MockDebouncer",
             BindingFlags.NonPublic);
@@ -44,9 +99,6 @@ public sealed class MockFrameworkDebouncerTests
             modifiers: null);
         onTimerElapsed.Should().NotBeNull();
 
-        onTimerElapsed!.Invoke(debouncer, new object[] { 1L });
-        framework.FireUpdate();
-
-        actionCount.Should().Be(0);
+        onTimerElapsed!.Invoke(debouncer, new object[] { generation });
     }
 }

--- a/Echoglossian.Mock.Tests/MockFrameworkDebouncerTests.cs
+++ b/Echoglossian.Mock.Tests/MockFrameworkDebouncerTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="MockFrameworkDebouncerTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System;
+using System.Reflection;
+using DalaMock.Core.Mocks.DalamudServices;
+using FluentAssertions;
+using Xunit;
+
+namespace Echoglossian.Mock.Tests;
+
+/// <summary>
+/// Covers the DalaMock implementation of Dalamud framework debouncing.
+/// </summary>
+public sealed class MockFrameworkDebouncerTests
+{
+    /// <summary>
+    /// Ensures a timer callback from a superseded debounce generation does not
+    /// queue the action on the next framework tick.
+    /// </summary>
+    [Fact]
+    public void Superseded_timer_generation_does_not_queue_action()
+    {
+        var framework = new MockFramework();
+        var actionCount = 0;
+        using var debouncer = framework.CreateDebouncer(
+            TimeSpan.FromHours(1),
+            () => actionCount++);
+
+        debouncer.Debounce();
+        debouncer.Debounce();
+
+        var debouncerType = typeof(MockFramework).GetNestedType(
+            "MockDebouncer",
+            BindingFlags.NonPublic);
+        debouncerType.Should().NotBeNull();
+        var onTimerElapsed = debouncerType!.GetMethod(
+            "OnTimerElapsed",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(long) },
+            modifiers: null);
+        onTimerElapsed.Should().NotBeNull();
+
+        onTimerElapsed!.Invoke(debouncer, new object[] { 1L });
+        framework.FireUpdate();
+
+        actionCount.Should().Be(0);
+    }
+}

--- a/Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs
+++ b/Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs
@@ -5,6 +5,11 @@
 
 using Echoglossian.PluginRuntime.Startup;
 using Echoglossian.Cache;
+using Echoglossian.DBHelpers;
+using Echoglossian.EFCoreSqlite;
+using Echoglossian.EFCoreSqlite.Models;
+using Echoglossian.Mock.Hosting;
+using Echoglossian.Translators.Capabilities;
 
 using DalaMock.Core.Plugin;
 using FluentAssertions;
@@ -110,11 +115,67 @@ public class PluginStartupSmokeTests
     [Fact]
     public async Task StartPluginAsync_initializes_the_llm_capability_cache()
     {
-        LlmCapabilityCacheManager.Clear();
+        var stateRoot = new DirectoryInfo(Path.Combine(
+            Path.GetTempPath(),
+            "Echoglossian.Mock.Tests",
+            Guid.NewGuid().ToString("N")));
+        var seedDirectory = stateRoot.CreateSubdirectory("seed");
+        var seedDatabasePath = Path.Combine(seedDirectory.FullName, "Echoglossian.db");
+        LlmCapabilityPersistenceHelper.UpsertRules(
+            seedDirectory.FullName,
+            [
+                LlmModelCapabilityRule.CreateExactModel(
+                    "ChatGPT",
+                    "OpenAI",
+                    "https://api.openai.com/v1",
+                    "gpt-5.6-terra",
+                    LlmCapabilityParameterName.Temperature,
+                    LlmCapabilitySupportState.Unsupported,
+                    omitWhenDefaultOnly: true,
+                    source: "Observed400",
+                    reason: "provider rejected non-default temperature"),
+                ]);
 
-        using var started = await new TestBoot().StartPluginAsync();
+        try
+        {
+            using (var seedContext = new EchoglossianDbContext(seedDirectory.FullName))
+            {
+                seedContext.LlmModelCapabilityRules
+                    .Should()
+                    .ContainSingle(rule => rule.MatchValue == "gpt-5.6-terra");
+            }
 
-        LlmCapabilityCacheManager.GetRuleDefinitions().Should().NotBeNull();
+            LlmCapabilityCacheManager.Clear();
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            await using var session = await HostedPreviewPluginSessionFactory.StartAsync(
+                new HostedPreviewPluginOptions(
+                    stateRoot,
+                    new DirectoryInfo(Path.Combine(stateRoot.FullName, ".dalamock")),
+                    new FileInfo(Path.Combine(stateRoot.FullName, "test.json")),
+                    seedDatabasePath,
+                    CreateWindow: false));
+
+            using (var context = new EchoglossianDbContext(
+                global::Echoglossian.Echoglossian.ConfigDirectory))
+            {
+                context.LlmModelCapabilityRules
+                    .Should()
+                    .ContainSingle(rule => rule.MatchValue == "gpt-5.6-terra");
+            }
+
+            LlmCapabilityCacheManager.GetRuleDefinitions()
+                .Should()
+                .ContainSingle(rule => rule.MatchValue == "gpt-5.6-terra");
+        }
+        finally
+        {
+            LlmCapabilityCacheManager.Clear();
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (stateRoot.Exists)
+            {
+                stateRoot.Delete(recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs
+++ b/Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.PluginRuntime.Startup;
+using Echoglossian.Cache;
 
 using DalaMock.Core.Plugin;
 using FluentAssertions;
@@ -104,6 +105,16 @@ public class PluginStartupSmokeTests
         snapshot.HasStage(PluginStartupStage.AddonHandlersRegistered).Should().BeTrue();
         snapshot.HasStage(PluginStartupStage.OverlaysRegistered).Should().BeTrue();
         snapshot.HasStage(PluginStartupStage.StartupComplete).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task StartPluginAsync_initializes_the_llm_capability_cache()
+    {
+        LlmCapabilityCacheManager.Clear();
+
+        using var started = await new TestBoot().StartPluginAsync();
+
+        LlmCapabilityCacheManager.GetRuleDefinitions().Should().NotBeNull();
     }
 
     [Fact]

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -77,6 +77,18 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
             "workItem.Generation !=\n        Volatile.Read(ref this.acceptedQuestPrefetchGeneration)",
             source,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc(),",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "workItem.ObservedAtUtc);",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "workItem.DerivationVersion,\n        DateTime.UtcNow);",
+            source,
+            StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -115,42 +115,6 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
             StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// Ensures a stale accepted-quest generation cannot commit dialogue
-    /// metadata after its transaction has begun.
-    /// </summary>
-    [Fact]
-    public void UpsertQuestDialogueMetadataBatchAsync_RevalidatesGenerationAtTransactionCommit()
-    {
-        var root = FindRepositoryRoot();
-        var runtimeSource = File.ReadAllText(Path.Combine(
-            root.FullName,
-            "NativeUI",
-            "Helpers",
-            "AcceptedQuestPrefetchRuntime.cs"));
-        var persistenceSource = File.ReadAllText(Path.Combine(
-            root.FullName,
-            "DBHelpers",
-            "DbOperations.cs"));
-
-        Assert.Contains(
-            "() => workItem.Generation ==\n                Volatile.Read(ref this.acceptedQuestPrefetchGeneration)",
-            runtimeSource,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "Func<bool> commitGuard",
-            persistenceSource,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "BeginTransactionAsync(cancellationToken)",
-            persistenceSource,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "if (!commitGuard())\n    {\n      return;\n    }\n\n    await transaction.CommitAsync(cancellationToken)",
-            persistenceSource,
-            StringComparison.Ordinal);
-    }
-
     private static DirectoryInfo FindRepositoryRoot()
     {
         var current = new DirectoryInfo(Directory.GetCurrentDirectory());

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.IO;
+using System.Reflection;
 using Xunit;
 
 namespace Echoglossian.Tests;
@@ -14,6 +15,51 @@ namespace Echoglossian.Tests;
 /// </summary>
 public sealed class AcceptedQuestPrefetchRuntimeContractTests
 {
+    /// <summary>
+    /// Ensures dialogue metadata generation follows dialogue settings while
+    /// canonical quest prefetch remains gated by quest-window settings.
+    /// </summary>
+    /// <param name="translate">Whether global translation is enabled.</param>
+    /// <param name="translateTalk">Whether Talk translation is enabled.</param>
+    /// <param name="translateBattleTalk">Whether BattleTalk translation is enabled.</param>
+    /// <param name="translateJournal">Whether Journal translation is enabled.</param>
+    /// <param name="expectedMetadata">Whether metadata generation should run.</param>
+    /// <param name="expectedCanonical">Whether canonical prefetch should run.</param>
+    [Theory]
+    [InlineData(true, true, false, false, true, false)]
+    [InlineData(true, false, true, false, true, false)]
+    [InlineData(true, false, false, true, false, true)]
+    [InlineData(true, false, false, false, false, false)]
+    [InlineData(false, true, true, true, false, false)]
+    public void AcceptedQuestScheduling_UsesIndependentConfigurationPolicies(
+        bool translate,
+        bool translateTalk,
+        bool translateBattleTalk,
+        bool translateJournal,
+        bool expectedMetadata,
+        bool expectedCanonical)
+    {
+        var configuration = new Config
+        {
+            Translate = translate,
+            TranslateTalk = translateTalk,
+            TranslateBattleTalk = translateBattleTalk,
+            TranslateJournal = translateJournal,
+        };
+        const BindingFlags Flags = BindingFlags.Static | BindingFlags.NonPublic;
+        var metadataPolicy = typeof(Echoglossian).GetMethod(
+            "IsAcceptedQuestDialogueMetadataGenerationEnabled",
+            Flags);
+        var canonicalPolicy = typeof(Echoglossian).GetMethod(
+            "IsAcceptedQuestCanonicalPrefetchEnabled",
+            Flags);
+
+        Assert.NotNull(metadataPolicy);
+        Assert.NotNull(canonicalPolicy);
+        Assert.Equal(expectedMetadata, metadataPolicy.Invoke(null, [configuration]));
+        Assert.Equal(expectedCanonical, canonicalPolicy.Invoke(null, [configuration]));
+    }
+
     /// <summary>
     /// Ensures the plugin tick schedules accepted-quest prefetch work instead
     /// of invoking the heavy prefetch routine inline.

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -79,6 +79,42 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
             StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Ensures clearing accepted-quest state cancels metadata work captured by
+    /// the prior generation before it can reach the database upsert boundary.
+    /// </summary>
+    [Fact]
+    public void ClearAcceptedQuestPrefetchState_CancelsPriorGenerationMetadataWrites()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "NativeUI",
+            "Helpers",
+            "AcceptedQuestPrefetchRuntime.cs"));
+
+        Assert.Contains(
+            "private CancellationTokenSource acceptedQuestDialogueMetadataGenerationCancellationSource",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Interlocked.Exchange(\n        ref this.acceptedQuestDialogueMetadataGenerationCancellationSource,\n        new CancellationTokenSource())",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "previousGenerationCancellationSource.Cancel();",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "workItem.GenerationCancellationToken);",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "cancellationToken.ThrowIfCancellationRequested();\n\n    await this.UpsertQuestDialogueMetadataBatchAsync(",
+            source,
+            StringComparison.Ordinal);
+    }
+
     private static DirectoryInfo FindRepositoryRoot()
     {
         var current = new DirectoryInfo(Directory.GetCurrentDirectory());

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -85,6 +85,59 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
     }
 
     /// <summary>
+    /// Ensures framework-thread work-item capture copies only the live quest id
+    /// and sequence instead of materializing Lumina quest snapshots inline.
+    /// </summary>
+    [Fact]
+    public void TryCaptureAcceptedQuestPrefetchWorkItem_CapturesSequenceWithoutLuminaTraversal()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "AcceptedQuestPrefetchRuntime.cs"));
+        var methodBody = ExtractMethodBody(
+            source,
+            "private bool TryCaptureAcceptedQuestPrefetchWorkItem(");
+
+        Assert.Contains("QuestManager.GetQuestSequence(", methodBody, StringComparison.Ordinal);
+        Assert.Contains("new QuestProgressCapture(", methodBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "QuestProgressResolver.TryResolveQuestProgress(",
+            methodBody,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures generation invalidation that occurs during managed sheet
+    /// resolution prevents either downstream prefetch path from starting.
+    /// </summary>
+    [Fact]
+    public void ProcessAcceptedQuestPrefetchWorkItem_RechecksGenerationAfterSheetResolution()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "AcceptedQuestPrefetchRuntime.cs"));
+        var methodBody = ExtractMethodBody(
+            source,
+            "private void ProcessAcceptedQuestPrefetchWorkItem(");
+        var resolutionIndex = methodBody.IndexOf(
+            "QuestProgressResolver.TryResolveQuestProgress(",
+            StringComparison.Ordinal);
+        var generationCheckIndex = methodBody.IndexOf(
+            "workItem.Generation !=\n        Volatile.Read(ref this.acceptedQuestPrefetchGeneration)",
+            resolutionIndex + 1,
+            StringComparison.Ordinal);
+
+        Assert.True(resolutionIndex >= 0, "Could not find managed quest resolution.");
+        Assert.True(
+            generationCheckIndex > resolutionIndex,
+            "Generation must be rechecked after managed quest resolution.");
+    }
+
+    /// <summary>
     /// Ensures accepted-quest capture starts dialogue metadata generation in a
     /// separately owned operation instead of performing sheet or database work
     /// on the framework tick.
@@ -124,11 +177,11 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
             source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc(),",
+            "this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc()",
             source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "workItem.ObservedAtUtc);",
+            "workItem.ObservedAtUtc,\n        cancellationToken);",
             source,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -187,5 +240,14 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
         }
 
         throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    private static string ExtractMethodBody(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find method signature '{signature}'.");
+        var end = source.IndexOf("\n  /// <summary>", start + signature.Length, StringComparison.Ordinal);
+        Assert.True(end > start, $"Could not find the end of method '{signature}'.");
+        return source[start..end];
     }
 }

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -115,6 +115,42 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
             StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Ensures a stale accepted-quest generation cannot commit dialogue
+    /// metadata after its transaction has begun.
+    /// </summary>
+    [Fact]
+    public void UpsertQuestDialogueMetadataBatchAsync_RevalidatesGenerationAtTransactionCommit()
+    {
+        var root = FindRepositoryRoot();
+        var runtimeSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "NativeUI",
+            "Helpers",
+            "AcceptedQuestPrefetchRuntime.cs"));
+        var persistenceSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "DBHelpers",
+            "DbOperations.cs"));
+
+        Assert.Contains(
+            "() => workItem.Generation ==\n                Volatile.Read(ref this.acceptedQuestPrefetchGeneration)",
+            runtimeSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Func<bool> commitGuard",
+            persistenceSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "BeginTransactionAsync(cancellationToken)",
+            persistenceSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if (!commitGuard())\n    {\n      return;\n    }\n\n    await transaction.CommitAsync(cancellationToken)",
+            persistenceSource,
+            StringComparison.Ordinal);
+    }
+
     private static DirectoryInfo FindRepositoryRoot()
     {
         var current = new DirectoryInfo(Directory.GetCurrentDirectory());

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -67,12 +67,10 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
     [Fact]
     public void TickAcceptedQuestPrefetch_QueuesBackgroundWorkInsteadOfCallingPrefetchInline()
     {
-        var root = FindRepositoryRoot();
-        var source = File.ReadAllText(Path.Combine(
-            root.FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "AcceptedQuestPrefetchRuntime.cs"));
+            "AcceptedQuestPrefetchRuntime.cs");
 
         Assert.Contains(
             "this.ScheduleAcceptedQuestPrefetch(",
@@ -91,11 +89,10 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
     [Fact]
     public void TryCaptureAcceptedQuestPrefetchWorkItem_CapturesSequenceWithoutLuminaTraversal()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "AcceptedQuestPrefetchRuntime.cs"));
+            "AcceptedQuestPrefetchRuntime.cs");
         var methodBody = ExtractMethodBody(
             source,
             "private bool TryCaptureAcceptedQuestPrefetchWorkItem(");
@@ -115,11 +112,10 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
     [Fact]
     public void ProcessAcceptedQuestPrefetchWorkItem_RechecksGenerationAfterSheetResolution()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "AcceptedQuestPrefetchRuntime.cs"));
+            "AcceptedQuestPrefetchRuntime.cs");
         var methodBody = ExtractMethodBody(
             source,
             "private void ProcessAcceptedQuestPrefetchWorkItem(");
@@ -145,12 +141,10 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
     [Fact]
     public void ScheduleAcceptedQuestPrefetch_StartsOwnedDialogueMetadataGeneration()
     {
-        var root = FindRepositoryRoot();
-        var source = File.ReadAllText(Path.Combine(
-            root.FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "AcceptedQuestPrefetchRuntime.cs"));
+            "AcceptedQuestPrefetchRuntime.cs");
 
         Assert.Contains(
             "private readonly OwnedAsyncOperationSet acceptedQuestDialogueMetadataOperations",
@@ -197,12 +191,10 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
     [Fact]
     public void ClearAcceptedQuestPrefetchState_CancelsPriorGenerationMetadataWrites()
     {
-        var root = FindRepositoryRoot();
-        var source = File.ReadAllText(Path.Combine(
-            root.FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "AcceptedQuestPrefetchRuntime.cs"));
+            "AcceptedQuestPrefetchRuntime.cs");
 
         Assert.Contains(
             "private CancellationTokenSource acceptedQuestDialogueMetadataGenerationCancellationSource",
@@ -240,6 +232,36 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
         }
 
         throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    /// <summary>
+    /// Reads contract source text with normalized line endings so multi-line
+    /// assertions remain checkout-format agnostic.
+    /// </summary>
+    /// <param name="relativePathSegments">The repository-relative path segments.</param>
+    /// <returns>The normalized source text.</returns>
+    private static string ReadContractSource(params string[] relativePathSegments)
+    {
+        var path = FindRepositoryRoot().FullName;
+        foreach (var relativePathSegment in relativePathSegments)
+        {
+            path = Path.Combine(path, relativePathSegment);
+        }
+
+        return NormalizeLineEndings(File.ReadAllText(path));
+    }
+
+    /// <summary>
+    /// Normalizes mixed checkout line endings to line-feed-only text for
+    /// substring contract assertions.
+    /// </summary>
+    /// <param name="source">The source text to normalize.</param>
+    /// <returns>The normalized source text.</returns>
+    private static string NormalizeLineEndings(string source)
+    {
+        return source
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal);
     }
 
     private static string ExtractMethodBody(string source, string signature)

--- a/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
+++ b/Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs
@@ -38,6 +38,47 @@ public sealed class AcceptedQuestPrefetchRuntimeContractTests
             StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Ensures accepted-quest capture starts dialogue metadata generation in a
+    /// separately owned operation instead of performing sheet or database work
+    /// on the framework tick.
+    /// </summary>
+    [Fact]
+    public void ScheduleAcceptedQuestPrefetch_StartsOwnedDialogueMetadataGeneration()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "NativeUI",
+            "Helpers",
+            "AcceptedQuestPrefetchRuntime.cs"));
+
+        Assert.Contains(
+            "private readonly OwnedAsyncOperationSet acceptedQuestDialogueMetadataOperations",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "this.acceptedQuestDialogueMetadataOperations.Run(",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "QuestDialogueMetadataDerivation.ReadDialogueEntries(",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "QuestDialogueMetadataDerivation.BuildEntries(",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "this.UpsertQuestDialogueMetadataBatchAsync(",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "workItem.Generation !=\n        Volatile.Read(ref this.acceptedQuestPrefetchGeneration)",
+            source,
+            StringComparison.Ordinal);
+    }
+
     private static DirectoryInfo FindRepositoryRoot()
     {
         var current = new DirectoryInfo(Directory.GetCurrentDirectory());

--- a/Echoglossian.Tests/ConfigDefaultsTests.cs
+++ b/Echoglossian.Tests/ConfigDefaultsTests.cs
@@ -126,4 +126,25 @@ public class ConfigDefaultsTests
         Assert.NotNull(field);
         Assert.Equal(0.9f, Assert.IsType<float>(field!.GetValue(config)));
     }
+
+    /// <summary>
+    ///     Ensures every LLM engine keeps the shared fallback temperature used
+    ///     by the capability-gated configuration controls.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(Config.ChatGptTemperature))]
+    [InlineData(nameof(Config.ClaudeTemperature))]
+    [InlineData(nameof(Config.DeepSeekTemperature))]
+    [InlineData(nameof(Config.GeminiTemperature))]
+    [InlineData(nameof(Config.LmStudioTemperature))]
+    [InlineData(nameof(Config.OllamaTemperature))]
+    [InlineData(nameof(Config.OpenRouterTemperature))]
+    public void LlmTemperatureDefaults_DefaultToPointOne(string propertyName)
+    {
+        var config = new Config();
+        var field = typeof(Config).GetField(propertyName);
+
+        Assert.NotNull(field);
+        Assert.Equal(0.1f, Assert.IsType<float>(field!.GetValue(config)));
+    }
 }

--- a/Echoglossian.Tests/DalaMockDalamudCompatibilityContractTests.cs
+++ b/Echoglossian.Tests/DalaMockDalamudCompatibilityContractTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="DalaMockDalamudCompatibilityContractTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.IO;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+/// Verifies the vendored DalaMock services remain compatible with the current
+/// Dalamud members required to build the Mock validation harness.
+/// </summary>
+public sealed class DalaMockDalamudCompatibilityContractTests
+{
+    /// <summary>
+    /// Ensures MockFramework implements the current debouncer factory member.
+    /// </summary>
+    [Fact]
+    public void MockFramework_implements_current_debouncer_factory_contract()
+    {
+        var source = this.ReadVendorSource("Mocks", "DalamudServices", "MockFramework.cs");
+
+        Assert.Contains("public IDebouncer CreateDebouncer(TimeSpan", source);
+        Assert.Contains("System.Action action", source);
+    }
+
+    /// <summary>
+    /// Ensures MockCharacter implements the current distance members as bytes.
+    /// </summary>
+    [Fact]
+    public void MockCharacter_implements_current_byte_distance_contract()
+    {
+        var source = this.ReadVendorSource("Mocks", "Objects", "MockCharacter.cs");
+
+        Assert.Contains("public byte CurrentDistance", source);
+        Assert.Contains("public byte NextDistance", source);
+    }
+
+    /// <summary>
+    /// Reads a source file from the vendored DalaMock project.
+    /// </summary>
+    /// <param name="pathSegments">The source file path relative to the DalaMock project.</param>
+    /// <returns>The source file contents.</returns>
+    private string ReadVendorSource(params string[] pathSegments)
+    {
+        var root = FindRepositoryRoot();
+        var path = Path.Combine(new[] { root.FullName, "vendor", "DalaMock", "DalaMock" }.Concat(pathSegments).ToArray());
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// Finds the repository root from the test output directory.
+    /// </summary>
+    /// <returns>The repository root directory.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Echoglossian.sln")))
+            {
+                return current;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+}

--- a/Echoglossian.Tests/DbOperationsTests.cs
+++ b/Echoglossian.Tests/DbOperationsTests.cs
@@ -888,6 +888,245 @@ public class DbOperationsTests
     }
 
     /// <summary>
+    ///     Ensures asynchronous dialogue lookup selects the same persisted row
+    ///     as the existing synchronous lookup.
+    /// </summary>
+    /// <param name="retrieval">The dialogue retrieval path to invoke.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData("Talk")]
+    [InlineData("BattleTalk")]
+    public async Task DialogueLookupAsync_MatchesSynchronousLookupSelection(
+        string retrieval)
+    {
+        var result = await this.RunDialogueLookupParityAsync(retrieval);
+
+        Assert.Equal(("Japanese", 7, result.ExpectedUpdatedDate), result.Sync);
+        Assert.Equal(result.Sync, result.Async);
+    }
+
+    /// <summary>
+    ///     Ensures asynchronous dialogue lookup observes an already-cancelled
+    ///     token before materializing database candidates.
+    /// </summary>
+    /// <param name="retrieval">The dialogue retrieval path to invoke.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Theory]
+    [InlineData("Talk")]
+    [InlineData("BattleTalk")]
+    public async Task DialogueLookupAsync_AlreadyCancelledToken_Cancels(
+        string retrieval)
+    {
+        await this.AssertDialogueLookupCancellationAsync(retrieval);
+    }
+
+    /// <summary>
+    ///     Runs synchronous and asynchronous dialogue lookups against the same
+    ///     competing persisted candidates.
+    /// </summary>
+    /// <param name="retrieval">The dialogue retrieval path to invoke.</param>
+    /// <returns>The synchronous and asynchronous lookup scopes.</returns>
+    private async Task<(
+        (string? SourceLanguage, int? TranslationEngine, DateTime? UpdatedDate) Sync,
+        (string? SourceLanguage, int? TranslationEngine, DateTime? UpdatedDate) Async,
+        DateTime ExpectedUpdatedDate)> RunDialogueLookupParityAsync(
+        string retrieval)
+    {
+        var configDir = Path.Combine(
+            Path.GetTempPath(),
+            "Echoglossian.Tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDir);
+        var previousClientState = PluginEntry.ClientStateInterface;
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        var previousLanguages = PluginEntry.LangDict;
+        var plugin = CreateFormattingPlugin(new Config
+        {
+            Lang = 28,
+            ChosenTransEngine = 4,
+            TranslateAlreadyTranslatedTexts = true,
+        });
+        var expectedUpdatedDate = new DateTime(
+            2026,
+            8,
+            6,
+            12,
+            0,
+            0,
+            DateTimeKind.Utc);
+
+        try
+        {
+            PluginEntry.ClientStateInterface =
+                TranslationReuseScopeTests.CreateClientState(
+                    ClientLanguage.Japanese);
+            PluginEntry.ConfigDirectory =
+                configDir + Path.DirectorySeparatorChar;
+            PluginEntry.LangDict = CreateTargetLanguages();
+
+            using (var context = new EchoglossianDbContext(configDir))
+            {
+                context.Database.Migrate();
+                SeedDialogueLookupRows(context, retrieval, expectedUpdatedDate);
+                context.SaveChanges();
+            }
+
+            return retrieval switch
+            {
+                "Talk" => (
+                    GetLookupScope(plugin.FindAndReturnTalkMessage(
+                        CreateTalkMessage("ja", 7, expectedUpdatedDate))),
+                    GetLookupScope(await plugin.FindAndReturnTalkMessageAsync(
+                        CreateTalkMessage("ja", 7, expectedUpdatedDate),
+                        CancellationToken.None).ConfigureAwait(false)),
+                    expectedUpdatedDate),
+                "BattleTalk" => (
+                    GetLookupScope(plugin.FindAndReturnBattleTalkMessage(
+                        CreateBattleTalkMessage("ja", 7, expectedUpdatedDate))),
+                    GetLookupScope(await plugin.FindAndReturnBattleTalkMessageAsync(
+                        CreateBattleTalkMessage("ja", 7, expectedUpdatedDate),
+                        CancellationToken.None).ConfigureAwait(false)),
+                    expectedUpdatedDate),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(retrieval),
+                    retrieval,
+                    "Unknown dialogue retrieval."),
+            };
+        }
+        finally
+        {
+            PluginEntry.LangDict = previousLanguages;
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            PluginEntry.ClientStateInterface = previousClientState;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
+    ///     Verifies that one dialogue lookup honors a pre-cancelled token.
+    /// </summary>
+    /// <param name="retrieval">The dialogue retrieval path to invoke.</param>
+    /// <returns>A task representing the cancellation assertion.</returns>
+    private async Task AssertDialogueLookupCancellationAsync(string retrieval)
+    {
+        var configDir = Path.Combine(
+            Path.GetTempPath(),
+            "Echoglossian.Tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDir);
+        var previousClientState = PluginEntry.ClientStateInterface;
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        var previousLanguages = PluginEntry.LangDict;
+
+        try
+        {
+            PluginEntry.ClientStateInterface =
+                TranslationReuseScopeTests.CreateClientState(
+                    ClientLanguage.Japanese);
+            PluginEntry.ConfigDirectory =
+                configDir + Path.DirectorySeparatorChar;
+            PluginEntry.LangDict = CreateTargetLanguages();
+            var plugin = CreateFormattingPlugin(new Config
+            {
+                Lang = 28,
+                ChosenTransEngine = 7,
+                TranslateAlreadyTranslatedTexts = true,
+            });
+            using (var context = new EchoglossianDbContext(configDir))
+            {
+                context.Database.Migrate();
+            }
+
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+            switch (retrieval)
+            {
+                case "Talk":
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                        () => plugin.FindAndReturnTalkMessageAsync(
+                            CreateTalkMessage("ja", 7, DateTime.UtcNow),
+                            cancellationTokenSource.Token)).ConfigureAwait(false);
+                    break;
+                case "BattleTalk":
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                        () => plugin.FindAndReturnBattleTalkMessageAsync(
+                            CreateBattleTalkMessage("ja", 7, DateTime.UtcNow),
+                            cancellationTokenSource.Token)).ConfigureAwait(false);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(retrieval),
+                        retrieval,
+                        "Unknown dialogue retrieval.");
+            }
+        }
+        finally
+        {
+            PluginEntry.LangDict = previousLanguages;
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            PluginEntry.ClientStateInterface = previousClientState;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
+    ///     Seeds dialogue rows that exercise source, engine, target, and
+    ///     recency selection rules.
+    /// </summary>
+    /// <param name="context">The temporary database context.</param>
+    /// <param name="retrieval">The dialogue retrieval path under test.</param>
+    /// <param name="expectedUpdatedDate">The timestamp of the expected row.</param>
+    private static void SeedDialogueLookupRows(
+        EchoglossianDbContext context,
+        string retrieval,
+        DateTime expectedUpdatedDate)
+    {
+        switch (retrieval)
+        {
+            case "Talk":
+                context.TalkMessage.AddRange(CreateDialogueLookupRows(
+                    CreateTalkMessage,
+                    expectedUpdatedDate));
+                break;
+            case "BattleTalk":
+                context.BattleTalkMessage.AddRange(CreateDialogueLookupRows(
+                    CreateBattleTalkMessage,
+                    expectedUpdatedDate));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(retrieval),
+                    retrieval,
+                    "Unknown dialogue retrieval.");
+        }
+    }
+
+    /// <summary>
+    ///     Creates competing dialogue rows with one newest compatible row.
+    /// </summary>
+    /// <typeparam name="T">The dialogue row type.</typeparam>
+    /// <param name="create">The row factory.</param>
+    /// <param name="expectedUpdatedDate">The timestamp of the expected row.</param>
+    /// <returns>The competing persisted rows.</returns>
+    private static T[] CreateDialogueLookupRows<T>(
+        Func<string, int, DateTime, T> create,
+        DateTime expectedUpdatedDate)
+        where T : class
+    {
+        var wrongTarget = create("Japanese", 7, expectedUpdatedDate.AddMinutes(3));
+        SetObjectProperty(wrongTarget, "TranslationLang", "Portuguese");
+
+        return
+        [
+            create("en", 7, expectedUpdatedDate.AddMinutes(4)),
+            create("Japanese", 4, expectedUpdatedDate.AddMinutes(2)),
+            wrongTarget,
+            create("Japanese", 7, expectedUpdatedDate.AddMinutes(-1)),
+            create("Japanese", 7, expectedUpdatedDate),
+        ];
+    }
+
+    /// <summary>
     ///     Ensures explicit Talk retranslation persistence updates the existing
     ///     row for the same source line and engine instead of growing duplicate
     ///     exact-engine history.
@@ -1673,6 +1912,19 @@ public class DbOperationsTests
     }
 
     /// <summary>
+    ///     Gets the persisted lookup fields from a Talk row.
+    /// </summary>
+    /// <param name="row">The selected row.</param>
+    /// <returns>The row's source identity, engine, and update timestamp.</returns>
+    private static (string?, int?, DateTime?) GetLookupScope(TalkMessage? row)
+    {
+        return (
+            row?.OriginalTalkMessageLang,
+            row?.TranslationEngine,
+            row?.UpdatedDate);
+    }
+
+    /// <summary>
     ///     Gets the stored scope fields from a toast row.
     /// </summary>
     /// <param name="row">The selected row.</param>
@@ -1690,6 +1942,20 @@ public class DbOperationsTests
     private static (string?, int?) GetScope(BattleTalkMessage? row)
     {
         return (row?.OriginalBattleTalkMessageLang, row?.TranslationEngine);
+    }
+
+    /// <summary>
+    ///     Gets the persisted lookup fields from a BattleTalk row.
+    /// </summary>
+    /// <param name="row">The selected row.</param>
+    /// <returns>The row's source identity, engine, and update timestamp.</returns>
+    private static (string?, int?, DateTime?) GetLookupScope(
+        BattleTalkMessage? row)
+    {
+        return (
+            row?.OriginalBattleTalkMessageLang,
+            row?.TranslationEngine,
+            row?.UpdatedDate);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/DeepSeekModelManagerTests.cs
+++ b/Echoglossian.Tests/DeepSeekModelManagerTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.DeepSeek;
+using Echoglossian.Translators.OpenAI;
 using FluentAssertions;
 using Xunit;
 
@@ -14,6 +15,36 @@ namespace Echoglossian.Tests;
 /// </summary>
 public class DeepSeekModelManagerTests
 {
+    /// <summary>
+    ///     Ensures successful DeepSeek model discovery retains the discovered
+    ///     list while capability overlay promotion runs best-effort.
+    /// </summary>
+    [Fact]
+    public void ApplyRefreshSuccess_WithDiscoveredModels_RetainsDiscoveredModelList()
+    {
+        DeepSeekModelManager.ResetToDefault();
+
+        DeepSeekModelManager.ApplyRefreshSuccess(
+            "https://api.deepseek.com/v1",
+            [
+                new LlmTextModel(
+                    "deepseek-chat",
+                    "DeepSeek Chat",
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    "DeepSeek"),
+            ],
+            new DateTime(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc));
+
+        DeepSeekModelManager.CurrentModelList
+            .Select(static model => model.Id)
+            .Should()
+            .Equal("deepseek-chat");
+    }
+
     /// <summary>
     ///     Ensures the configured DeepSeek base URL maps to the models
     ///     endpoint without duplicating version segments.

--- a/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
+++ b/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
@@ -83,6 +83,53 @@ public class DialogueContextPromptHelperTests
     }
 
     /// <summary>
+    ///     Ensures resolved interlocutor hints contribute ordered prompt metadata
+    ///     and distinct cache identity without changing prior-turn history.
+    /// </summary>
+    [Fact]
+    public void ContextWithInterlocutorHints_ShouldProjectPromptAndCacheIdentity()
+    {
+        DialogueTranslationContext hintedContext = new(
+            "Talk",
+            "quest-1",
+            "Krile",
+            [CreateTurn("Thancred", "We move now.")],
+            SpeakerRoleHint: "npc",
+            SpeakerGenderHint: "female",
+            AddresseeHint: "Alphinaud",
+            AddresseeRoleHint: "npc",
+            AddresseeGenderHint: "male",
+            MetadataProvenance: "quest-sheet",
+            MetadataConfidenceTier: "exact");
+        DialogueTranslationContext emptyHintContext = new(
+            "Talk",
+            "quest-1",
+            "Krile",
+            [CreateTurn("Thancred", "We move now.")]);
+
+        string prompt = DialogueContextPromptHelper.AppendDialogueContext(
+            "Translate this line.",
+            hintedContext,
+            static text => text);
+        string hintedKey = DialogueContextPromptHelper.BuildDialogueContextCacheKey(
+            "Advance.",
+            "English",
+            "Portuguese",
+            hintedContext);
+        string emptyHintKey = DialogueContextPromptHelper.BuildDialogueContextCacheKey(
+            "Advance.",
+            "English",
+            "Portuguese",
+            emptyHintContext);
+
+        prompt.Should().Contain(
+            $"Current speaker: Krile{Environment.NewLine}Speaker role: npc{Environment.NewLine}Speaker gender: female{Environment.NewLine}Addressee: Alphinaud{Environment.NewLine}Addressee role: npc{Environment.NewLine}Addressee gender: male{Environment.NewLine}[1] Thancred: We move now.");
+        hintedKey.Should().NotBe(emptyHintKey);
+        emptyHintKey.Should().NotContain("SpeakerGenderHint");
+        emptyHintKey.Should().NotContain("AddresseeHint");
+    }
+
+    /// <summary>
     ///     Ensures the cache key is namespaced by session and serialized with
     ///     content instead of delimiter-sensitive concatenation.
     /// </summary>

--- a/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
+++ b/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
@@ -131,6 +131,44 @@ public class DialogueContextPromptHelperTests
     }
 
     /// <summary>
+    ///     Ensures diagnostics can report dialogue-context richness without
+    ///     leaking speaker names, addressee names, or prior dialogue text.
+    /// </summary>
+    [Fact]
+    public void SummarizeDialogueContextForDiagnostics_ShouldReportPresenceWithoutLeakingNames()
+    {
+        DialogueTranslationContext context = new(
+            "Talk",
+            "quest-1",
+            "Krile",
+            [CreateTurn("Thancred", "We move now.")],
+            SpeakerRoleHint: "npc",
+            SpeakerGenderHint: "female",
+            AddresseeHint: "Alphinaud",
+            AddresseeRoleHint: "npc",
+            AddresseeGenderHint: "male",
+            MetadataProvenance: "QuestSheetDerivedExact",
+            MetadataConfidenceTier: 2);
+
+        string summary = DialogueContextPromptHelper.SummarizeDialogueContextForDiagnostics(
+            context);
+
+        summary.Should().Contain("metadata=populated");
+        summary.Should().Contain("sessionNamespace=Talk");
+        summary.Should().Contain("priorTurns=1");
+        summary.Should().Contain("speaker=true");
+        summary.Should().Contain("speakerGender=true");
+        summary.Should().Contain("addressee=true");
+        summary.Should().Contain("addresseeGender=true");
+        summary.Should().Contain("metadataProvenance=QuestSheetDerivedExact");
+        summary.Should().Contain("metadataConfidenceTier=2");
+        summary.Should().NotContain("Krile");
+        summary.Should().NotContain("Thancred");
+        summary.Should().NotContain("Alphinaud");
+        summary.Should().NotContain("We move now.");
+    }
+
+    /// <summary>
     ///     Ensures the cache key is namespaced by session and serialized with
     ///     content instead of delimiter-sensitive concatenation.
     /// </summary>

--- a/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
+++ b/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
@@ -19,24 +19,41 @@ public class DialogueContextPromptHelperTests
         new(2026, 5, 13, 12, 0, 0, DateTimeKind.Utc);
 
     /// <summary>
-    ///     Ensures usable context is detected only when prior turns exist.
+    ///     Ensures a first dialogue turn contributes speaker context to prompts
+    ///     and cache identity without requiring prior history.
     /// </summary>
     [Fact]
-    public void HasUsableDialogueContext_ShouldReflectPriorTurns()
+    public void FirstTurnContext_ShouldIncludeSpeakerInPromptAndCacheKey()
     {
-        DialogueTranslationContext emptyContext = new(
+        DialogueTranslationContext alphinaudContext = new(
             "Talk",
             "speaker",
-            "Krile",
+            "Alphinaud",
             []);
-        DialogueTranslationContext populatedContext = new(
+        DialogueTranslationContext alisaieContext = new(
             "Talk",
             "speaker",
-            "Krile",
-            [CreateTurn("Krile", "Stay alert.")]);
+            "Alisaie",
+            []);
 
-        DialogueContextPromptHelper.HasUsableDialogueContext(emptyContext).Should().BeFalse();
-        DialogueContextPromptHelper.HasUsableDialogueContext(populatedContext).Should().BeTrue();
+        string prompt = DialogueContextPromptHelper.AppendDialogueContext(
+            "Translate this line.",
+            alphinaudContext,
+            static text => text);
+        string alphinaudKey = DialogueContextPromptHelper.BuildDialogueContextCacheKey(
+            "Advance.",
+            "English",
+            "Portuguese",
+            alphinaudContext);
+        string alisaieKey = DialogueContextPromptHelper.BuildDialogueContextCacheKey(
+            "Advance.",
+            "English",
+            "Portuguese",
+            alisaieContext);
+
+        DialogueContextPromptHelper.HasUsableDialogueContext(alphinaudContext).Should().BeTrue();
+        prompt.Should().Contain("Current speaker: Alphinaud");
+        alphinaudKey.Should().NotBe(alisaieKey);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
+++ b/Echoglossian.Tests/DialogueContextPromptHelperTests.cs
@@ -100,7 +100,7 @@ public class DialogueContextPromptHelperTests
             AddresseeRoleHint: "npc",
             AddresseeGenderHint: "male",
             MetadataProvenance: "quest-sheet",
-            MetadataConfidenceTier: "exact");
+            MetadataConfidenceTier: 2);
         DialogueTranslationContext emptyHintContext = new(
             "Talk",
             "quest-1",
@@ -125,6 +125,7 @@ public class DialogueContextPromptHelperTests
         prompt.Should().Contain(
             $"Current speaker: Krile{Environment.NewLine}Speaker role: npc{Environment.NewLine}Speaker gender: female{Environment.NewLine}Addressee: Alphinaud{Environment.NewLine}Addressee role: npc{Environment.NewLine}Addressee gender: male{Environment.NewLine}[1] Thancred: We move now.");
         hintedKey.Should().NotBe(emptyHintKey);
+        hintedKey.Should().Contain("\"MetadataConfidenceTier\":2");
         emptyHintKey.Should().NotContain("SpeakerGenderHint");
         emptyHintKey.Should().NotContain("AddresseeHint");
     }

--- a/Echoglossian.Tests/DialogueGlossaryTermProtectorTests.cs
+++ b/Echoglossian.Tests/DialogueGlossaryTermProtectorTests.cs
@@ -1,0 +1,98 @@
+// <copyright file="DialogueGlossaryTermProtectorTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators;
+using Echoglossian.Translators.Helpers;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers deterministic dialogue glossary marker protection and restoration.
+/// </summary>
+public class DialogueGlossaryTermProtectorTests
+{
+    /// <summary>
+    ///     Ensures protection prefers the longest matching phrase and restores
+    ///     each protected occurrence to the configured target text.
+    /// </summary>
+    [Fact]
+    public void Protect_LongestMatchFirst_RestoresConfiguredTargets()
+    {
+        StructuredDialogueGlossaryEntry[] glossary =
+        [
+            new("Twin Adder", "Viper Order", null, null, null),
+            new("The Order of the Twin Adder", "The Twin Serpent Order", null, null, null),
+        ];
+
+        var protection = DialogueGlossaryTermProtector.Protect(
+            "The Order of the Twin Adder will brief every Twin Adder recruit.",
+            glossary);
+
+        protection.Occurrences.Should().HaveCount(2);
+        protection.ProtectedText.Should().NotContain("The Order of the Twin Adder");
+        protection.ProtectedText.Should().NotContain("Twin Adder recruit");
+
+        var restoreResult = DialogueGlossaryTermProtector.TryRestore(
+            protection.ProtectedText,
+            protection);
+
+        restoreResult.Succeeded.Should().BeTrue();
+        restoreResult.RestoredText.Should().Be(
+            "The Twin Serpent Order will brief every Viper Order recruit.");
+    }
+
+    /// <summary>
+    ///     Ensures protection does not replace glossary terms embedded inside
+    ///     larger unrelated words.
+    /// </summary>
+    [Fact]
+    public void Protect_DoesNotReplaceInsideUnrelatedWords()
+    {
+        StructuredDialogueGlossaryEntry[] glossary =
+        [
+            new("Scions", "Scions [GLOSSARY-OK]", null, null, null),
+        ];
+
+        var protection = DialogueGlossaryTermProtector.Protect(
+            "Scions and HyperScions remain distinct.",
+            glossary);
+
+        var restoreResult = DialogueGlossaryTermProtector.TryRestore(
+            protection.ProtectedText,
+            protection);
+
+        restoreResult.Succeeded.Should().BeTrue();
+        restoreResult.RestoredText.Should().Be(
+            "Scions [GLOSSARY-OK] and HyperScions remain distinct.");
+    }
+
+    /// <summary>
+    ///     Ensures restoration rejects provider output that removes a required
+    ///     protected marker.
+    /// </summary>
+    [Fact]
+    public void TryRestore_MissingMarker_FailsWithStableReason()
+    {
+        StructuredDialogueGlossaryEntry[] glossary =
+        [
+            new("Triple Triad", "Triple Triad [GLOSSARY-OK]", null, null, null),
+        ];
+
+        var protection = DialogueGlossaryTermProtector.Protect(
+            "Triple Triad is popular here.",
+            glossary);
+
+        var restoreResult = DialogueGlossaryTermProtector.TryRestore(
+            "This provider removed the marker entirely.",
+            protection);
+
+        restoreResult.Succeeded.Should().BeFalse();
+        restoreResult.FailureReason.Should().Be("missing-required-marker");
+    }
+}

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -221,6 +221,33 @@ public class DialogueInterlocutorMetadataResolverTests
     }
 
     /// <summary>
+    ///     Ensures a unique visible speaker can still contribute live actor hints
+    ///     when persisted quest metadata is not available yet.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_VisibleSpeakerMatchWithoutPersistedMetadata_ReturnsLiveActorFallback()
+    {
+        var resolver = this.CreateResolver(
+            returnPersistedMetadata: false,
+            liveActors:
+            [
+                new("Oriel", 1045123, "female", "elezen", "wildwood"),
+            ]);
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal("LiveActorVisibleSpeakerFallback", result.ResolutionTier.ToString());
+        Assert.Equal("LiveActorFallback", result.Provenance);
+        Assert.Equal(0, result.ConfidenceTier);
+        Assert.Equal("Oriel", result.SpeakerHint);
+        Assert.Equal("female", result.SpeakerGenderHint);
+        Assert.Equal("elezen", result.SpeakerRaceHint);
+        Assert.Equal("wildwood", result.SpeakerBodyTypeHint);
+        Assert.Equal((uint)1045123, result.SpeakerActor!.DataId);
+    }
+
+    /// <summary>
     ///     Creates a resolver backed by deterministic managed quest, metadata,
     ///     actor, and player-state snapshots.
     /// </summary>
@@ -235,6 +262,7 @@ public class DialogueInterlocutorMetadataResolverTests
     private DialogueInterlocutorMetadataResolver CreateResolver(
         QuestDialogueMetadata? metadata = null,
         IReadOnlyList<LiveDialogueActorSnapshot>? liveActors = null,
+        bool returnPersistedMetadata = true,
         string? playerSex = null,
         Action? nativeCaptureObserved = null,
         Action? questTraversalObserved = null,
@@ -254,7 +282,7 @@ public class DialogueInterlocutorMetadataResolverTests
         [
             new("LucKbb111_03263_NPC_000_000", "Welcome, adventurer.", 0, 0),
         ];
-        var expectedMetadata = metadata ?? this.CreateMetadata();
+        var expectedMetadata = returnPersistedMetadata ? metadata ?? this.CreateMetadata() : null;
 
         return new DialogueInterlocutorMetadataResolver(
             tryCollectAcceptedQuestIds: () =>

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -55,21 +55,27 @@ public class DialogueInterlocutorMetadataResolverTests
     }
 
     /// <summary>
-    ///     Ensures all game-owned resolver reads execute inside the capture
-    ///     scheduler and database lookup begins only after capture completes.
+    ///     Ensures native resolver values are captured on the framework thread,
+    ///     while quest progress and sheet traversal execute after that boundary.
     /// </summary>
     [Fact]
-    public async Task ResolveAsync_CaptureScheduler_ContainsGameOwnedReadsBeforeDatabaseLookup()
+    public async Task ResolveAsync_CaptureScheduler_OnlyContainsNativeCaptureBeforeQuestTraversal()
     {
         var insideCapture = false;
         var captureSchedulerCalls = 0;
-        var captureReadCalls = 0;
+        var nativeCaptureReadCalls = 0;
+        var questTraversalCalls = 0;
         var databaseLookupCalls = 0;
         var resolver = this.CreateResolver(
-            captureObserved: () =>
+            nativeCaptureObserved: () =>
             {
                 Assert.True(insideCapture);
-                captureReadCalls++;
+                nativeCaptureReadCalls++;
+            },
+            questTraversalObserved: () =>
+            {
+                Assert.False(insideCapture);
+                questTraversalCalls++;
             },
             lookupObserved: () =>
             {
@@ -97,7 +103,8 @@ public class DialogueInterlocutorMetadataResolverTests
 
         Assert.NotNull(result);
         Assert.Equal(1, captureSchedulerCalls);
-        Assert.Equal(6, captureReadCalls);
+        Assert.Equal(4, nativeCaptureReadCalls);
+        Assert.Equal(2, questTraversalCalls);
         Assert.Equal(1, databaseLookupCalls);
     }
 
@@ -195,7 +202,8 @@ public class DialogueInterlocutorMetadataResolverTests
     /// <param name="metadata">The persisted metadata returned by the exact lookup.</param>
     /// <param name="liveActors">The managed live actor snapshots.</param>
     /// <param name="playerSex">The managed player sex hint.</param>
-    /// <param name="captureObserved">The callback invoked for each game-owned read.</param>
+    /// <param name="nativeCaptureObserved">The callback invoked for each native capture read.</param>
+    /// <param name="questTraversalObserved">The callback invoked for each quest traversal read.</param>
     /// <param name="lookupObserved">The callback invoked at the database lookup boundary.</param>
     /// <param name="runOnFrameworkThreadAsync">The capture scheduler override.</param>
     /// <returns>A configured resolver.</returns>
@@ -203,7 +211,8 @@ public class DialogueInterlocutorMetadataResolverTests
         QuestDialogueMetadata? metadata = null,
         IReadOnlyList<LiveDialogueActorSnapshot>? liveActors = null,
         string? playerSex = null,
-        Action? captureObserved = null,
+        Action? nativeCaptureObserved = null,
+        Action? questTraversalObserved = null,
         Action? lookupObserved = null,
         Func<Action, CancellationToken, Task>? runOnFrameworkThreadAsync = null)
     {
@@ -225,17 +234,17 @@ public class DialogueInterlocutorMetadataResolverTests
         return new DialogueInterlocutorMetadataResolver(
             tryCollectAcceptedQuestIds: () =>
             {
-                captureObserved?.Invoke();
+                nativeCaptureObserved?.Invoke();
                 return [68799];
             },
             tryResolveQuestProgress: questId =>
             {
-                captureObserved?.Invoke();
+                questTraversalObserved?.Invoke();
                 return questId == 68799 ? snapshot : null;
             },
             readDialogueEntries: _ =>
             {
-                captureObserved?.Invoke();
+                questTraversalObserved?.Invoke();
                 return rows;
             },
             findMetadataAsync: (lookup, _) =>
@@ -249,17 +258,17 @@ public class DialogueInterlocutorMetadataResolverTests
             },
             captureLiveActors: () =>
             {
-                captureObserved?.Invoke();
+                nativeCaptureObserved?.Invoke();
                 return liveActors ?? [];
             },
             localPlayerName: () =>
             {
-                captureObserved?.Invoke();
+                nativeCaptureObserved?.Invoke();
                 return "Player Name";
             },
             playerSexHint: () =>
             {
-                captureObserved?.Invoke();
+                nativeCaptureObserved?.Invoke();
                 return playerSex;
             },
             runOnFrameworkThreadAsync: runOnFrameworkThreadAsync);

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -55,6 +55,31 @@ public class DialogueInterlocutorMetadataResolverTests
     }
 
     /// <summary>
+    /// Ensures accepted quest sequences are copied during native capture and
+    /// supplied to managed quest resolution outside the framework scheduler.
+    /// </summary>
+    [Fact]
+    public void Resolver_QuestProgressBoundary_UsesCapturedSequenceForManagedResolution()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "DialogueInterlocutorMetadataResolver.cs"));
+
+        Assert.Contains("new QuestProgressCapture(", source, StringComparison.Ordinal);
+        Assert.Contains("this.captureQuestSequence(", source, StringComparison.Ordinal);
+        Assert.Contains(
+            "this.tryResolveQuestProgress(\n                acceptedQuest.QuestId,\n                acceptedQuest.QuestSequence,\n                cancellationToken)",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "this.readDialogueEntries(questProgress.Value, cancellationToken)",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     ///     Ensures native resolver values are captured on the framework thread,
     ///     while quest progress and sheet traversal execute after that boundary.
     /// </summary>
@@ -103,7 +128,7 @@ public class DialogueInterlocutorMetadataResolverTests
 
         Assert.NotNull(result);
         Assert.Equal(1, captureSchedulerCalls);
-        Assert.Equal(4, nativeCaptureReadCalls);
+        Assert.Equal(5, nativeCaptureReadCalls);
         Assert.Equal(2, questTraversalCalls);
         Assert.Equal(1, databaseLookupCalls);
     }
@@ -237,14 +262,23 @@ public class DialogueInterlocutorMetadataResolverTests
                 nativeCaptureObserved?.Invoke();
                 return [68799];
             },
-            tryResolveQuestProgress: questId =>
+            captureQuestSequence: questId =>
+            {
+                nativeCaptureObserved?.Invoke();
+                Assert.Equal((uint)68799, questId);
+                return 0;
+            },
+            tryResolveQuestProgress: (questId, questSequence, cancellationToken) =>
             {
                 questTraversalObserved?.Invoke();
+                Assert.Equal((byte)0, questSequence);
+                Assert.False(cancellationToken.IsCancellationRequested);
                 return questId == 68799 ? snapshot : null;
             },
-            readDialogueEntries: _ =>
+            readDialogueEntries: (_, cancellationToken) =>
             {
                 questTraversalObserved?.Invoke();
+                Assert.False(cancellationToken.IsCancellationRequested);
                 return rows;
             },
             findMetadataAsync: (lookup, _) =>

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -248,6 +248,23 @@ public class DialogueInterlocutorMetadataResolverTests
     }
 
     /// <summary>
+    ///     Ensures native actor customize-sex values retain their semantic
+    ///     gender when the visible-speaker fallback captures live actors.
+    /// </summary>
+    [Fact]
+    public void CaptureLiveActors_NumericCustomizeSex_NormalizesToGenderHints()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "DialogueInterlocutorMetadataResolver.cs"));
+
+        Assert.Contains("\"0\" => \"male\"", source, StringComparison.Ordinal);
+        Assert.Contains("\"1\" => \"female\"", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     ///     Creates a resolver backed by deterministic managed quest, metadata,
     ///     actor, and player-state snapshots.
     /// </summary>

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="DialogueInterlocutorMetadataResolverTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.EFCoreSqlite.Models.Journal;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers resolution of persisted quest dialogue metadata with optional
+///     managed live actor and player-state hints.
+/// </summary>
+public class DialogueInterlocutorMetadataResolverTests
+{
+    /// <summary>
+    ///     Ensures exact accepted-quest metadata resolves without a live actor.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_PersistedAcceptedQuestMetadata_ReturnsQuestSheetDerivedExact()
+    {
+        var resolver = this.CreateResolver();
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(DialogueInterlocutorResolutionTier.QuestSheetDerivedExact, result.ResolutionTier);
+        Assert.Equal("Oriel", result.SpeakerHint);
+        Assert.Equal("Radovan", result.AddresseeHint);
+        Assert.Null(result.AddresseeGenderHint);
+    }
+
+    /// <summary>
+    ///     Ensures a loaded actor matching the persisted addressee upgrades the
+    ///     result while retaining the persisted quest metadata.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_PersistedAddresseeWithMatchingLoadedActor_ReturnsQuestSheetPlusLiveFusion()
+    {
+        var resolver = this.CreateResolver(
+            liveActors: new Dictionary<string, LiveDialogueActorSnapshot>(StringComparer.Ordinal)
+            {
+                ["Radovan"] = new("Radovan", 1045123, "male", "hyur", "midlander"),
+            });
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(DialogueInterlocutorResolutionTier.QuestSheetPlusLiveFusion, result.ResolutionTier);
+        Assert.Equal("male", result.AddresseeGenderHint);
+        Assert.Equal("hyur", result.AddresseeRaceHint);
+        Assert.Equal("midlander", result.AddresseeBodyTypeHint);
+        Assert.Equal((uint)1045123, result.AddresseeActor!.DataId);
+    }
+
+    /// <summary>
+    ///     Ensures player addressee detection derives gender from player state
+    ///     without changing persisted quest metadata.
+    /// </summary>
+    [Theory]
+    [InlineData("male")]
+    [InlineData("female")]
+    public async Task ResolveAsync_PlayerAddressee_UsesPlayerSexWithoutChangingQuestMetadata(string playerSex)
+    {
+        var metadata = this.CreateMetadata(addresseeHint: "Adventurer", addresseeRoleHint: "player");
+        var resolver = this.CreateResolver(metadata: metadata, playerSex: playerSex);
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(DialogueInterlocutorResolutionTier.QuestSheetDerivedExact, result.ResolutionTier);
+        Assert.Equal(playerSex, result.AddresseeGenderHint);
+        Assert.Equal("Adventurer", result.AddresseeHint);
+        Assert.Equal("player", result.AddresseeRoleHint);
+    }
+
+    /// <summary>
+    ///     Creates a resolver backed by deterministic managed quest, metadata,
+    ///     actor, and player-state snapshots.
+    /// </summary>
+    /// <param name="metadata">The persisted metadata returned by the exact lookup.</param>
+    /// <param name="liveActors">The managed live actor snapshots.</param>
+    /// <param name="playerSex">The managed player sex hint.</param>
+    /// <returns>A configured resolver.</returns>
+    private DialogueInterlocutorMetadataResolver CreateResolver(
+        QuestDialogueMetadata? metadata = null,
+        IReadOnlyDictionary<string, LiveDialogueActorSnapshot>? liveActors = null,
+        string? playerSex = null)
+    {
+        var snapshot = new QuestProgressSnapshot(
+            QuestId: 68799,
+            QuestSequence: 0,
+            QuestName: "For Better or Worse",
+            QuestSheetName: "quest/032/LucKbb111_03263",
+            QuestSteps: [],
+            QuestSeqTexts: [],
+            QuestSystemTexts: [],
+            ContentHash: "quest-content-hash");
+        QuestDialogueSheetEntry[] rows =
+        [
+            new("LucKbb111_03263_NPC_000_000", "Welcome, adventurer.", 0, 0),
+        ];
+        var expectedMetadata = metadata ?? this.CreateMetadata();
+
+        return new DialogueInterlocutorMetadataResolver(
+            tryCollectAcceptedQuestIds: () => [68799],
+            tryResolveQuestProgress: questId => questId == 68799 ? snapshot : null,
+            readDialogueEntries: _ => rows,
+            findMetadataAsync: (lookup, _) =>
+            {
+                Assert.Equal("LucKbb111_03263_NPC_000_000", lookup.SourceRowKey);
+                Assert.Equal(
+                    QuestContentHash.ComputeLine(lookup.SourceRowKey, "Welcome, adventurer."),
+                    lookup.SourceTextHash);
+                return Task.FromResult<QuestDialogueMetadata?>(expectedMetadata);
+            },
+            captureLiveActors: () => liveActors ?? new Dictionary<string, LiveDialogueActorSnapshot>(),
+            localPlayerName: () => "Player Name",
+            playerSexHint: () => playerSex);
+    }
+
+    /// <summary>
+    ///     Creates the fixed dialogue lookup request.
+    /// </summary>
+    /// <returns>A fixed dialogue lookup request.</returns>
+    private DialogueInterlocutorMetadataRequest CreateRequest()
+    {
+        return new DialogueInterlocutorMetadataRequest(
+            "Welcome, adventurer.",
+            "Oriel",
+            "en",
+            "2026.08.10.0000",
+            "v1");
+    }
+
+    /// <summary>
+    ///     Creates fixed persisted quest dialogue metadata.
+    /// </summary>
+    /// <param name="addresseeHint">The derived addressee name.</param>
+    /// <param name="addresseeRoleHint">The derived addressee role.</param>
+    /// <returns>The persisted metadata row.</returns>
+    private QuestDialogueMetadata CreateMetadata(
+        string addresseeHint = "Radovan",
+        string addresseeRoleHint = "npc")
+    {
+        return new QuestDialogueMetadata
+        {
+            QuestId = 68799,
+            QuestSequence = 0,
+            SourceLanguageCode = "en",
+            GameVersion = "2026.08.10.0000",
+            SourceRowKey = "LucKbb111_03263_NPC_000_000",
+            SourceTextHash = QuestContentHash.ComputeLine(
+                "LucKbb111_03263_NPC_000_000",
+                "Welcome, adventurer."),
+            DerivationVersion = "v1",
+            SpeakerHint = "Oriel",
+            AddresseeHint = addresseeHint,
+            SpeakerRoleHint = "npc",
+            AddresseeRoleHint = addresseeRoleHint,
+            Provenance = "QuestSheetDerived",
+            ConfidenceTier = 2,
+        };
+    }
+}

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -30,6 +30,96 @@ public class DialogueInterlocutorMetadataResolverTests
         Assert.Equal("Oriel", result.SpeakerHint);
         Assert.Equal("Radovan", result.AddresseeHint);
         Assert.Null(result.AddresseeGenderHint);
+        var provenanceProperty = typeof(DialogueInterlocutorMetadata).GetProperty("Provenance");
+        var confidenceProperty = typeof(DialogueInterlocutorMetadata).GetProperty("ConfidenceTier");
+        Assert.NotNull(provenanceProperty);
+        Assert.NotNull(confidenceProperty);
+        Assert.Equal("QuestSheetDerived", provenanceProperty.GetValue(result));
+        Assert.Equal(2, confidenceProperty.GetValue(result));
+    }
+
+    /// <summary>
+    ///     Ensures production resolver capture is marshaled through the Dalamud
+    ///     framework before database work crosses an await boundary.
+    /// </summary>
+    [Fact]
+    public void Resolver_ProductionCapture_UsesFrameworkThreadMarshal()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "DialogueInterlocutorMetadataResolver.cs"));
+
+        Assert.Contains("FrameworkInterface.RunOnFrameworkThread(", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Ensures all game-owned resolver reads execute inside the capture
+    ///     scheduler and database lookup begins only after capture completes.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_CaptureScheduler_ContainsGameOwnedReadsBeforeDatabaseLookup()
+    {
+        var insideCapture = false;
+        var captureSchedulerCalls = 0;
+        var captureReadCalls = 0;
+        var databaseLookupCalls = 0;
+        var resolver = this.CreateResolver(
+            captureObserved: () =>
+            {
+                Assert.True(insideCapture);
+                captureReadCalls++;
+            },
+            lookupObserved: () =>
+            {
+                Assert.False(insideCapture);
+                databaseLookupCalls++;
+            },
+            runOnFrameworkThreadAsync: (capture, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                captureSchedulerCalls++;
+                insideCapture = true;
+                try
+                {
+                    capture();
+                }
+                finally
+                {
+                    insideCapture = false;
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(1, captureSchedulerCalls);
+        Assert.Equal(6, captureReadCalls);
+        Assert.Equal(1, databaseLookupCalls);
+    }
+
+    /// <summary>
+    ///     Ensures production wiring preserves persisted provenance and numeric
+    ///     confidence instead of substituting the resolver evidence tier.
+    /// </summary>
+    [Fact]
+    public void AddonHandlerWiring_PreservesPersistedMetadataIdentity()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "AddonHandlerWiring.cs"));
+
+        Assert.Contains("metadata.Provenance", source, StringComparison.Ordinal);
+        Assert.Contains("metadata.ConfidenceTier", source, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "metadata.ResolutionTier.ToString(),\n            metadata.ResolutionTier.ToString()",
+            source,
+            StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -105,11 +195,17 @@ public class DialogueInterlocutorMetadataResolverTests
     /// <param name="metadata">The persisted metadata returned by the exact lookup.</param>
     /// <param name="liveActors">The managed live actor snapshots.</param>
     /// <param name="playerSex">The managed player sex hint.</param>
+    /// <param name="captureObserved">The callback invoked for each game-owned read.</param>
+    /// <param name="lookupObserved">The callback invoked at the database lookup boundary.</param>
+    /// <param name="runOnFrameworkThreadAsync">The capture scheduler override.</param>
     /// <returns>A configured resolver.</returns>
     private DialogueInterlocutorMetadataResolver CreateResolver(
         QuestDialogueMetadata? metadata = null,
         IReadOnlyList<LiveDialogueActorSnapshot>? liveActors = null,
-        string? playerSex = null)
+        string? playerSex = null,
+        Action? captureObserved = null,
+        Action? lookupObserved = null,
+        Func<Action, CancellationToken, Task>? runOnFrameworkThreadAsync = null)
     {
         var snapshot = new QuestProgressSnapshot(
             QuestId: 68799,
@@ -127,20 +223,46 @@ public class DialogueInterlocutorMetadataResolverTests
         var expectedMetadata = metadata ?? this.CreateMetadata();
 
         return new DialogueInterlocutorMetadataResolver(
-            tryCollectAcceptedQuestIds: () => [68799],
-            tryResolveQuestProgress: questId => questId == 68799 ? snapshot : null,
-            readDialogueEntries: _ => rows,
+            tryCollectAcceptedQuestIds: () =>
+            {
+                captureObserved?.Invoke();
+                return [68799];
+            },
+            tryResolveQuestProgress: questId =>
+            {
+                captureObserved?.Invoke();
+                return questId == 68799 ? snapshot : null;
+            },
+            readDialogueEntries: _ =>
+            {
+                captureObserved?.Invoke();
+                return rows;
+            },
             findMetadataAsync: (lookup, _) =>
             {
+                lookupObserved?.Invoke();
                 Assert.Equal("LucKbb111_03263_NPC_000_000", lookup.SourceRowKey);
                 Assert.Equal(
                     QuestContentHash.ComputeLine(lookup.SourceRowKey, "Welcome, adventurer."),
                     lookup.SourceTextHash);
                 return Task.FromResult<QuestDialogueMetadata?>(expectedMetadata);
             },
-            captureLiveActors: () => liveActors ?? [],
-            localPlayerName: () => "Player Name",
-            playerSexHint: () => playerSex);
+            captureLiveActors: () =>
+            {
+                captureObserved?.Invoke();
+                return liveActors ?? [];
+            },
+            localPlayerName: () =>
+            {
+                captureObserved?.Invoke();
+                return "Player Name";
+            },
+            playerSexHint: () =>
+            {
+                captureObserved?.Invoke();
+                return playerSex;
+            },
+            runOnFrameworkThreadAsync: runOnFrameworkThreadAsync);
     }
 
     /// <summary>
@@ -185,5 +307,25 @@ public class DialogueInterlocutorMetadataResolverTests
             Provenance = "QuestSheetDerived",
             ConfidenceTier = 2,
         };
+    }
+
+    /// <summary>
+    ///     Locates the repository root for production wiring contract checks.
+    /// </summary>
+    /// <returns>The repository root directory.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Echoglossian.sln")))
+            {
+                return current;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
     }
 }

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -45,11 +45,10 @@ public class DialogueInterlocutorMetadataResolverTests
     [Fact]
     public void Resolver_ProductionCapture_UsesFrameworkThreadMarshal()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "DialogueInterlocutorMetadataResolver.cs"));
+            "DialogueInterlocutorMetadataResolver.cs");
 
         Assert.Contains("FrameworkInterface.RunOnFrameworkThread(", source, StringComparison.Ordinal);
     }
@@ -61,11 +60,10 @@ public class DialogueInterlocutorMetadataResolverTests
     [Fact]
     public void Resolver_QuestProgressBoundary_UsesCapturedSequenceForManagedResolution()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "DialogueInterlocutorMetadataResolver.cs"));
+            "DialogueInterlocutorMetadataResolver.cs");
 
         Assert.Contains("new QuestProgressCapture(", source, StringComparison.Ordinal);
         Assert.Contains("this.captureQuestSequence(", source, StringComparison.Ordinal);
@@ -140,11 +138,10 @@ public class DialogueInterlocutorMetadataResolverTests
     [Fact]
     public void AddonHandlerWiring_PreservesPersistedMetadataIdentity()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "AddonHandlerWiring.cs"));
+            "AddonHandlerWiring.cs");
 
         Assert.Contains("metadata.Provenance", source, StringComparison.Ordinal);
         Assert.Contains("metadata.ConfidenceTier", source, StringComparison.Ordinal);
@@ -300,11 +297,10 @@ public class DialogueInterlocutorMetadataResolverTests
     [Fact]
     public void CaptureLiveActors_NumericCustomizeSex_NormalizesToGenderHints()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var source = ReadContractSource(
             "NativeUI",
             "Helpers",
-            "DialogueInterlocutorMetadataResolver.cs"));
+            "DialogueInterlocutorMetadataResolver.cs");
 
         Assert.Contains("\"0\" => \"male\"", source, StringComparison.Ordinal);
         Assert.Contains("\"1\" => \"female\"", source, StringComparison.Ordinal);
@@ -467,5 +463,35 @@ public class DialogueInterlocutorMetadataResolverTests
         }
 
         throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    /// <summary>
+    ///     Reads contract source text with normalized line endings so
+    ///     multi-line assertions are checkout-format agnostic.
+    /// </summary>
+    /// <param name="relativePathSegments">The repository-relative path segments.</param>
+    /// <returns>The normalized source text.</returns>
+    private static string ReadContractSource(params string[] relativePathSegments)
+    {
+        var path = FindRepositoryRoot().FullName;
+        foreach (var relativePathSegment in relativePathSegments)
+        {
+            path = Path.Combine(path, relativePathSegment);
+        }
+
+        return NormalizeLineEndings(File.ReadAllText(path));
+    }
+
+    /// <summary>
+    ///     Normalizes mixed checkout line endings to line-feed-only text for
+    ///     substring contract assertions.
+    /// </summary>
+    /// <param name="source">The source text to normalize.</param>
+    /// <returns>The normalized source text.</returns>
+    private static string NormalizeLineEndings(string source)
+    {
+        return source
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal);
     }
 }

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -128,7 +128,7 @@ public class DialogueInterlocutorMetadataResolverTests
 
         Assert.NotNull(result);
         Assert.Equal(1, captureSchedulerCalls);
-        Assert.Equal(5, nativeCaptureReadCalls);
+        Assert.Equal(6, nativeCaptureReadCalls);
         Assert.Equal(2, questTraversalCalls);
         Assert.Equal(1, databaseLookupCalls);
     }
@@ -248,6 +248,52 @@ public class DialogueInterlocutorMetadataResolverTests
     }
 
     /// <summary>
+    ///     Ensures a matching current target takes precedence over ambiguous
+    ///     object-table actors when persisted speaker metadata is available.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_PersistedSpeakerWithMatchingTarget_ReturnsTargetSpeakerHints()
+    {
+        var resolver = this.CreateResolver(
+            liveActors:
+            [
+                new("Oriel", 1045123, "male", "hyur", "midlander"),
+                new("Oriel", 1045124, "male", "hyur", "midlander"),
+            ],
+            targetActor: new("Oriel", 1045125, "female", "elezen", "wildwood"));
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(DialogueInterlocutorResolutionTier.QuestSheetPlusLiveFusion, result.ResolutionTier);
+        Assert.Equal("female", result.SpeakerGenderHint);
+        Assert.Equal("elezen", result.SpeakerRaceHint);
+        Assert.Equal("wildwood", result.SpeakerBodyTypeHint);
+        Assert.Equal((uint)1045125, result.SpeakerActor!.DataId);
+    }
+
+    /// <summary>
+    ///     Ensures a matching current target supplies visible-speaker fallback
+    ///     metadata when persisted dialogue metadata is unavailable.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_VisibleSpeakerWithMatchingTarget_ReturnsTargetSpeakerFallback()
+    {
+        var resolver = this.CreateResolver(
+            returnPersistedMetadata: false,
+            targetActor: new("Oriel", 1045125, "female", "elezen", "wildwood"));
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(DialogueInterlocutorResolutionTier.LiveActorVisibleSpeakerFallback, result.ResolutionTier);
+        Assert.Equal("female", result.SpeakerGenderHint);
+        Assert.Equal("elezen", result.SpeakerRaceHint);
+        Assert.Equal("wildwood", result.SpeakerBodyTypeHint);
+        Assert.Equal((uint)1045125, result.SpeakerActor!.DataId);
+    }
+
+    /// <summary>
     ///     Ensures native actor customize-sex values retain their semantic
     ///     gender when the visible-speaker fallback captures live actors.
     /// </summary>
@@ -279,6 +325,7 @@ public class DialogueInterlocutorMetadataResolverTests
     private DialogueInterlocutorMetadataResolver CreateResolver(
         QuestDialogueMetadata? metadata = null,
         IReadOnlyList<LiveDialogueActorSnapshot>? liveActors = null,
+        LiveDialogueActorSnapshot? targetActor = null,
         bool returnPersistedMetadata = true,
         string? playerSex = null,
         Action? nativeCaptureObserved = null,
@@ -339,6 +386,11 @@ public class DialogueInterlocutorMetadataResolverTests
             {
                 nativeCaptureObserved?.Invoke();
                 return liveActors ?? [];
+            },
+            captureTargetActor: () =>
+            {
+                nativeCaptureObserved?.Invoke();
+                return targetActor;
             },
             localPlayerName: () =>
             {

--- a/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
+++ b/Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs
@@ -40,10 +40,10 @@ public class DialogueInterlocutorMetadataResolverTests
     public async Task ResolveAsync_PersistedAddresseeWithMatchingLoadedActor_ReturnsQuestSheetPlusLiveFusion()
     {
         var resolver = this.CreateResolver(
-            liveActors: new Dictionary<string, LiveDialogueActorSnapshot>(StringComparer.Ordinal)
-            {
-                ["Radovan"] = new("Radovan", 1045123, "male", "hyur", "midlander"),
-            });
+            liveActors:
+            [
+                new("Radovan", 1045123, "male", "hyur", "midlander"),
+            ]);
 
         var result = await resolver.ResolveAsync(this.CreateRequest());
 
@@ -53,6 +53,28 @@ public class DialogueInterlocutorMetadataResolverTests
         Assert.Equal("hyur", result.AddresseeRaceHint);
         Assert.Equal("midlander", result.AddresseeBodyTypeHint);
         Assert.Equal((uint)1045123, result.AddresseeActor!.DataId);
+    }
+
+    /// <summary>
+    ///     Ensures an ambiguous loaded actor name cannot upgrade persisted quest
+    ///     metadata to live fusion.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_DuplicateNamedLiveActors_LeavesResultQuestSheetDerivedExact()
+    {
+        LiveDialogueActorSnapshot[] liveActors =
+        [
+            new("Radovan", 1045123, "male", "hyur", "midlander"),
+            new("Radovan", 1045124, "female", "elezen", "wildwood"),
+        ];
+        var resolver = this.CreateResolver(liveActors: liveActors);
+
+        var result = await resolver.ResolveAsync(this.CreateRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal(DialogueInterlocutorResolutionTier.QuestSheetDerivedExact, result.ResolutionTier);
+        Assert.Null(result.AddresseeActor);
+        Assert.Null(result.AddresseeGenderHint);
     }
 
     /// <summary>
@@ -86,7 +108,7 @@ public class DialogueInterlocutorMetadataResolverTests
     /// <returns>A configured resolver.</returns>
     private DialogueInterlocutorMetadataResolver CreateResolver(
         QuestDialogueMetadata? metadata = null,
-        IReadOnlyDictionary<string, LiveDialogueActorSnapshot>? liveActors = null,
+        IReadOnlyList<LiveDialogueActorSnapshot>? liveActors = null,
         string? playerSex = null)
     {
         var snapshot = new QuestProgressSnapshot(
@@ -116,7 +138,7 @@ public class DialogueInterlocutorMetadataResolverTests
                     lookup.SourceTextHash);
                 return Task.FromResult<QuestDialogueMetadata?>(expectedMetadata);
             },
-            captureLiveActors: () => liveActors ?? new Dictionary<string, LiveDialogueActorSnapshot>(),
+            captureLiveActors: () => liveActors ?? [],
             localPlayerName: () => "Player Name",
             playerSexHint: () => playerSex);
     }

--- a/Echoglossian.Tests/DialogueTranslationSessionStoreTests.cs
+++ b/Echoglossian.Tests/DialogueTranslationSessionStoreTests.cs
@@ -197,7 +197,7 @@ public class DialogueTranslationSessionStoreTests
         "npc",
         "male",
         "quest-sheet",
-        "exact");
+        2);
 
     var hintedContext = DialogueTranslationSessionStore.BuildContext(
         "Talk",

--- a/Echoglossian.Tests/DialogueTranslationSessionStoreTests.cs
+++ b/Echoglossian.Tests/DialogueTranslationSessionStoreTests.cs
@@ -180,4 +180,48 @@ public class DialogueTranslationSessionStoreTests
     Assert.Equal(1, snapshot.RetainedTurnCount);
     Assert.Equal(observedAtUtc, snapshot.LastObservedAtUtc);
   }
+
+  /// <summary>
+  ///     Ensures interlocutor hints apply only to the returned current request
+  ///     and do not become part of retained prior-turn history.
+  /// </summary>
+  [Fact]
+  public void BuildContext_WithInterlocutorHints_ShouldApplyThemOnlyToCurrentRequest()
+  {
+    DialogueTranslationSessionStore.Clear();
+    var observedAtUtc = new DateTime(2026, 05, 12, 15, 20, 0, DateTimeKind.Utc);
+    var hints = new DialogueInterlocutorHints(
+        "npc",
+        "female",
+        "Alphinaud",
+        "npc",
+        "male",
+        "quest-sheet",
+        "exact");
+
+    var hintedContext = DialogueTranslationSessionStore.BuildContext(
+        "Talk",
+        "krile-session",
+        "Krile",
+        "Stay close.",
+        3,
+        TimeSpan.FromSeconds(30),
+        observedAtUtc,
+        hints);
+    var context = DialogueTranslationSessionStore.BuildContext(
+        "Talk",
+        "krile-session",
+        "Krile",
+        "We move now.",
+        3,
+        TimeSpan.FromSeconds(30),
+        observedAtUtc.AddSeconds(1));
+
+    Assert.Equal("female", hintedContext.SpeakerGenderHint);
+    Assert.Equal("Alphinaud", hintedContext.AddresseeHint);
+    Assert.Null(context.SpeakerGenderHint);
+    Assert.Null(context.AddresseeHint);
+    var priorTurn = Assert.Single(context.PriorTurns);
+    Assert.Equal("Stay close.", priorTurn.SourceText);
+  }
 }

--- a/Echoglossian.Tests/LlmCapabilityErrorClassifierTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityErrorClassifierTests.cs
@@ -1,0 +1,85 @@
+// <copyright file="LlmCapabilityErrorClassifierTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators.Capabilities;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers bounded classification of provider capability failures.
+/// </summary>
+public sealed class LlmCapabilityErrorClassifierTests
+{
+    /// <summary>
+    ///     Ensures an explicit unsupported parameter response is safe to
+    ///     promote.
+    /// </summary>
+    [Fact]
+    public void TryClassify_WithExplicitUnsupportedParameter400_ReturnsPromotableClassification()
+    {
+        var classification = LlmCapabilityErrorClassifier.TryClassify(
+            new LlmCapabilityScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra"),
+            LlmCapabilityParameterName.Temperature,
+            400,
+            "{ \"error\": { \"code\": \"unsupported_parameter\", \"message\": \"Unsupported parameter: temperature. api_key=secret\" } }");
+
+        classification.ObservationRecorded.Should().BeTrue();
+        classification.RulePromoted.Should().BeTrue();
+        classification.FailureKind.Should().Be("unsupported-parameter");
+        classification.MessageExcerpt.Should().Be("Provider rejected parameter 'temperature'.");
+        classification.MessageExcerpt.Should().NotContain("secret");
+    }
+
+    /// <summary>
+    ///     Ensures ambiguous client errors are retained only as sanitized
+    ///     observations.
+    /// </summary>
+    [Fact]
+    public void TryClassify_WithAmbiguous400_ReturnsObservationOnlyClassification()
+    {
+        var classification = LlmCapabilityErrorClassifier.TryClassify(
+            new LlmCapabilityScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra"),
+            LlmCapabilityParameterName.Temperature,
+            400,
+            "{ \"error\": { \"message\": \"Request could not be processed.\" } }");
+
+        classification.ObservationRecorded.Should().BeTrue();
+        classification.RulePromoted.Should().BeFalse();
+        classification.FailureKind.Should().Be("ambiguous-client-error");
+    }
+
+    /// <summary>
+    ///     Ensures non-client failures are not retained as capability feedback.
+    /// </summary>
+    [Fact]
+    public void TryClassify_WithNon400Failure_ReturnsNoObservation()
+    {
+        var classification = LlmCapabilityErrorClassifier.TryClassify(
+            new LlmCapabilityScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra"),
+            LlmCapabilityParameterName.Temperature,
+            429,
+            "rate limited");
+
+        classification.ObservationRecorded.Should().BeFalse();
+        classification.RulePromoted.Should().BeFalse();
+        classification.FailureKind.Should().Be("unclassified");
+    }
+}

--- a/Echoglossian.Tests/LlmCapabilityPersistenceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPersistenceTests.cs
@@ -65,6 +65,9 @@ public class LlmCapabilityPersistenceTests
             LlmCapabilityCacheManager.GetRuleDefinitions()
                 .Should()
                 .ContainSingle(rule => rule.MatchValue == "gpt-5.6-terra");
+            LlmCapabilityCacheManager.GetRuleDefinitions()
+                .Should()
+                .NotBeOfType<List<LlmCapabilityRuleDefinition>>();
 
             using (var context = new EchoglossianDbContext(configDir))
             {

--- a/Echoglossian.Tests/LlmCapabilityPersistenceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPersistenceTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="LlmCapabilityPersistenceTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Cache;
+using Echoglossian.DBHelpers;
+using Echoglossian.EFCoreSqlite;
+using Echoglossian.EFCoreSqlite.Models;
+using Echoglossian.Translators.Capabilities;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers persistence and in-memory hydration of LLM capability overlays.
+/// </summary>
+public class LlmCapabilityPersistenceTests
+{
+    /// <summary>
+    ///     Ensures an exact-model capability rule survives persistence and is
+    ///     available through the DB-free runtime cache.
+    /// </summary>
+    [Fact]
+    public void UpsertRule_ThenReload_PreservesExactModelLookup()
+    {
+        var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDir);
+
+        try
+        {
+            LlmCapabilityPersistenceHelper.UpsertRules(
+                configDir,
+                [
+                    LlmModelCapabilityRule.CreateExactModel(
+                        "ChatGPT",
+                        "OpenAI",
+                        "https://api.openai.com/v1",
+                        "gpt-5.6-terra",
+                        LlmCapabilityParameterName.Temperature,
+                        LlmCapabilitySupportState.Unsupported,
+                        omitWhenDefaultOnly: true,
+                        source: "Observed400",
+                        reason: "provider rejected non-default temperature"),
+                ]);
+            LlmCapabilityPersistenceHelper.RecordObservation(
+                configDir,
+                new LlmModelCapabilityObservation
+                {
+                    Engine = "ChatGPT",
+                    ProviderScope = "OpenAI",
+                    EndpointScope = "https://api.openai.com/v1",
+                    ModelId = "gpt-5.6-terra",
+                    ParameterName = "Temperature",
+                    StatusCode = 400,
+                    ProviderErrorCode = "unsupported_parameter",
+                    MessageExcerpt = "temperature is unsupported",
+                });
+
+            LlmCapabilityCacheManager.Initialize(configDir);
+
+            LlmCapabilityCacheManager.GetRuleDefinitions()
+                .Should()
+                .ContainSingle(rule => rule.MatchValue == "gpt-5.6-terra");
+
+            using (var context = new EchoglossianDbContext(configDir))
+            {
+                context.LlmModelCapabilityObservations.Should().ContainSingle();
+            }
+        }
+        finally
+        {
+            LlmCapabilityCacheManager.Clear();
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            Directory.Delete(configDir, recursive: true);
+        }
+    }
+}

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -23,6 +23,27 @@ namespace Echoglossian.Tests;
 public sealed class LlmCapabilityPolicyServiceTests
 {
     /// <summary>
+    ///     Ensures every OpenAI-compatible and Anthropic translator routes
+    ///     outbound temperature through the shared capability policy.
+    /// </summary>
+    /// <param name="translatorPath">The translator source path relative to the repository root.</param>
+    [Theory]
+    [InlineData("Translators/ChatGPTTranslator.cs")]
+    [InlineData("Translators/ClaudeTranslator.cs")]
+    [InlineData("Translators/DeepSeekTranslator.cs")]
+    [InlineData("Translators/LmStudioTranslator.cs")]
+    [InlineData("Translators/OpenRouterTranslator.cs")]
+    public void OpenAiFamilyAndClaudeTranslators_ResolveTemperatureThroughSharedCapabilityPolicy(
+        string translatorPath)
+    {
+        var repositoryRoot = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        var source = File.ReadAllText(Path.Combine(repositoryRoot, translatorPath));
+
+        source.Should().Contain("LlmCapabilityPolicyService.TryResolveTemperature(");
+    }
+
+    /// <summary>
     ///     Ensures scope creation normalizes provider, endpoint, and model
     ///     identity before resolution.
     /// </summary>

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -90,11 +90,11 @@ public sealed class LlmCapabilityPolicyServiceTests
     }
 
     /// <summary>
-    ///     Ensures structured ChatGPT requests omit reasoning effort when the
-    ///     effective capability policy marks it unsupported.
+    ///     Ensures structured ChatGPT requests explicitly disable reasoning
+    ///     effort when the effective capability policy marks it unsupported.
     /// </summary>
     [Fact]
-    public void ChatGptTranslator_WhenReasoningEffortIsUnsupported_OmitsStructuredOption()
+    public void ChatGptTranslator_WhenReasoningEffortIsUnsupported_SendsExplicitStructuredDisable()
     {
         var translator = new ChatGPTTranslator(
             new NoOpPluginLog(),
@@ -112,10 +112,58 @@ public sealed class LlmCapabilityPolicyServiceTests
 
         var applied = translator.ApplyStructuredReasoningEffortPolicy(options);
 
-        applied.Should().BeFalse();
+        applied.Should().BeTrue();
 #pragma warning disable OPENAI001
-        options.ReasoningEffortLevel.Should().BeNull();
+        options.ReasoningEffortLevel.Should().Be(ChatReasoningEffortLevel.None);
 #pragma warning restore OPENAI001
+    }
+
+    /// <summary>
+    ///     Ensures OpenAI-compatible structured dialogue requests describe the
+    ///     actual request shape before dispatch and the validated result after
+    ///     completion.
+    /// </summary>
+    [Fact]
+    public async Task OpenRouterTranslator_StructuredDialogue_LogsRequestShapeAndSuccess()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var translator = new OpenRouterTranslator(
+            pluginLog,
+            new Config
+            {
+                OpenRouterApiKey = "test-key",
+                OpenRouterBaseUrl = "https://openrouter.example/v1",
+                OpenRouterModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(new StructuredDialogueResponseHandler())
+            {
+                BaseAddress = new Uri("https://openrouter.example/v1/"),
+            });
+
+        var translated = await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext(
+                "Talk",
+                "quest-1",
+                "Krile",
+                [],
+                SpeakerGenderHint: "female"));
+
+        translated.Should().Be("Fique perto.");
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-start", StringComparison.Ordinal) &&
+                message.Contains("route=chat-completions", StringComparison.Ordinal) &&
+                message.Contains("endpointScope=https://openrouter.example/v1", StringComparison.Ordinal) &&
+                message.Contains("glossaryApplied=false", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-success", StringComparison.Ordinal) &&
+                message.Contains("route=chat-completions", StringComparison.Ordinal) &&
+                message.Contains("translatedLength=12", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -168,7 +216,7 @@ public sealed class LlmCapabilityPolicyServiceTests
     ///     model that returned the structured tool-calling error.
     /// </summary>
     [Fact]
-    public void LearnFromProviderFailure_WithReasoningEffort400_RecordsExactModelFeedback()
+    public void LearnFromProviderFailure_WithReasoningEffort400_PromotesExactModelFeedback()
     {
         this.WithTemporaryConfigurationDirectory(_ =>
         {
@@ -185,12 +233,17 @@ public sealed class LlmCapabilityPolicyServiceTests
                 "Function tools with reasoning_effort are not supported for gpt-5.6-terra in v1/chat/completions");
 
             result.ObservationRecorded.Should().BeTrue();
-            result.RulePromoted.Should().BeFalse();
+            result.RulePromoted.Should().BeTrue();
 
             using var context = new EchoglossianDbContext(_);
             context.LlmModelCapabilityObservations.Should().ContainSingle(
                 observation => observation.ModelId == "gpt-5.6-terra" &&
                     observation.ParameterName == LlmCapabilityParameterName.ReasoningEffort.ToString());
+            context.LlmModelCapabilityRules.Should().ContainSingle(
+                rule => rule.MatchType == LlmCapabilityRuleMatchType.ExactModel.ToString() &&
+                    rule.MatchValue == "gpt-5.6-terra" &&
+                    rule.ParameterName == LlmCapabilityParameterName.ReasoningEffort.ToString() &&
+                    rule.SupportState == LlmCapabilitySupportState.Unsupported.ToString());
         });
     }
 
@@ -404,6 +457,31 @@ public sealed class LlmCapabilityPolicyServiceTests
             Echoglossian.ConfigDirectory = originalConfigDirectory;
             SqliteConnection.ClearAllPools();
             Directory.Delete(configDir, recursive: true);
+        }
+    }
+
+    private void ReplaceHttpClient(OpenRouterTranslator translator, HttpClient httpClient)
+    {
+        typeof(OpenRouterTranslator)
+            .GetField("httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(translator, httpClient);
+    }
+
+    private sealed class StructuredDialogueResponseHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            const string ResponseBody = """
+                {"choices":[{"message":{"content":"{\"text_translated\":\"Fique perto.\"}"}}]}
+                """;
+
+            return Task.FromResult(
+                new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ResponseBody),
+                });
         }
     }
 

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -5,12 +5,19 @@
 
 using Echoglossian.Cache;
 using Echoglossian.EFCoreSqlite;
+using Echoglossian.Translators;
 using Echoglossian.Translators.Capabilities;
+
+using Echoglossian.Tests.TestDoubles;
 
 using FluentAssertions;
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+
+using Newtonsoft.Json;
+
+using OpenAI.Chat;
 
 using Xunit;
 
@@ -23,24 +30,63 @@ namespace Echoglossian.Tests;
 public sealed class LlmCapabilityPolicyServiceTests
 {
     /// <summary>
-    ///     Ensures every OpenAI-compatible and Anthropic translator routes
-    ///     outbound temperature through the shared capability policy.
+    ///     Ensures unknown capability scopes omit temperature from both plain
+    ///     and structured OpenAI-compatible request payloads.
     /// </summary>
-    /// <param name="translatorPath">The translator source path relative to the repository root.</param>
-    [Theory]
-    [InlineData("Translators/ChatGPTTranslator.cs")]
-    [InlineData("Translators/ClaudeTranslator.cs")]
-    [InlineData("Translators/DeepSeekTranslator.cs")]
-    [InlineData("Translators/LmStudioTranslator.cs")]
-    [InlineData("Translators/OpenRouterTranslator.cs")]
-    public void OpenAiFamilyAndClaudeTranslators_ResolveTemperatureThroughSharedCapabilityPolicy(
-        string translatorPath)
+    [Fact]
+    public void TryAddTemperature_WhenCapabilityIsUnknown_OmitsPlainAndStructuredPayloadFields()
     {
-        var repositoryRoot = Path.GetFullPath(
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
-        var source = File.ReadAllText(Path.Combine(repositoryRoot, translatorPath));
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.OpenRouter,
+            "OpenRouter",
+            "https://openrouter.ai/api/v1",
+            "unknown-model");
+        var plainPayload = new Dictionary<string, object>
+        {
+            ["model"] = "unknown-model",
+            ["messages"] = Array.Empty<object>(),
+        };
+        var structuredPayload = new Dictionary<string, object>
+        {
+            ["model"] = "unknown-model",
+            ["messages"] = Array.Empty<object>(),
+            ["tools"] = Array.Empty<object>(),
+        };
 
-        source.Should().Contain("LlmCapabilityPolicyService.TryResolveTemperature(");
+        LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+            plainPayload,
+            scope,
+            0.7f).Should().BeFalse();
+        LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+            structuredPayload,
+            scope,
+            0.7f).Should().BeFalse();
+
+        JsonConvert.SerializeObject(plainPayload).Should().NotContain("temperature");
+        JsonConvert.SerializeObject(structuredPayload).Should().NotContain("temperature");
+    }
+
+    /// <summary>
+    ///     Ensures the official OpenAI default-only model leaves the SDK
+    ///     completion option unset.
+    /// </summary>
+    [Fact]
+    public void ChatGptTranslator_WhenTemperatureIsDefaultOnly_LeavesCompletionOptionUnset()
+    {
+        var translator = new ChatGPTTranslator(
+            new NoOpPluginLog(),
+            new Config
+            {
+                ChatGptApiKey = "test-key",
+                ChatGPTBaseUrl = "https://api.openai.com/v1",
+                OpenAILlmModel = "gpt-5.6-terra",
+                ChatGptTemperature = 0.7f,
+            });
+        var options = new ChatCompletionOptions();
+
+        translator.ApplyTemperaturePolicy(options);
+
+        options.Temperature.Should().BeNull();
     }
 
     /// <summary>

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -90,6 +90,54 @@ public sealed class LlmCapabilityPolicyServiceTests
     }
 
     /// <summary>
+    ///     Ensures structured ChatGPT tool requests explicitly disable
+    ///     reasoning effort and learn an exact-model capability rejection.
+    /// </summary>
+    [Fact]
+    public void ChatGptTranslator_StructuredToolRequest_DisablesAndLearnsReasoningEffort()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "Translators",
+            "ChatGPTTranslator.cs"));
+
+        source.Should().Contain("ReasoningEffortLevel = ChatReasoningEffortLevel.None");
+        source.Should().Contain("this.LearnReasoningEffortFailure(ex);");
+        source.Should().Contain("LlmCapabilityParameterName.ReasoningEffort");
+    }
+
+    /// <summary>
+    ///     Ensures a reasoning-effort rejection is promoted only for the exact
+    ///     model that returned the structured tool-calling error.
+    /// </summary>
+    [Fact]
+    public void LearnFromProviderFailure_WithReasoningEffort400_RecordsExactModelFeedback()
+    {
+        this.WithTemporaryConfigurationDirectory(_ =>
+        {
+            var scope = new LlmCapabilityScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra");
+
+            var result = LlmCapabilityPolicyService.LearnFromProviderFailure(
+                scope,
+                LlmCapabilityParameterName.ReasoningEffort,
+                400,
+                "Function tools with reasoning_effort are not supported for gpt-5.6-terra in v1/chat/completions");
+
+            result.ObservationRecorded.Should().BeTrue();
+            result.RulePromoted.Should().BeFalse();
+
+            using var context = new EchoglossianDbContext(_);
+            context.LlmModelCapabilityObservations.Should().ContainSingle(
+                observation => observation.ModelId == "gpt-5.6-terra" &&
+                    observation.ParameterName == LlmCapabilityParameterName.ReasoningEffort.ToString());
+        });
+    }
+
+    /// <summary>
     ///     Ensures scope creation normalizes provider, endpoint, and model
     ///     identity before resolution.
     /// </summary>
@@ -300,5 +348,25 @@ public sealed class LlmCapabilityPolicyServiceTests
             SqliteConnection.ClearAllPools();
             Directory.Delete(configDir, recursive: true);
         }
+    }
+
+    /// <summary>
+    ///     Locates the repository root for production wiring contract checks.
+    /// </summary>
+    /// <returns>The repository root directory.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Echoglossian.sln")))
+            {
+                return current;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
     }
 }

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="LlmCapabilityPolicyServiceTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Cache;
+using Echoglossian.EFCoreSqlite;
+using Echoglossian.Translators.Capabilities;
+
+using FluentAssertions;
+
+using Microsoft.Data.Sqlite;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers shared runtime policy resolution and persisted capability
+///     learning.
+/// </summary>
+public sealed class LlmCapabilityPolicyServiceTests
+{
+    /// <summary>
+    ///     Ensures scope creation normalizes provider, endpoint, and model
+    ///     identity before resolution.
+    /// </summary>
+    [Fact]
+    public void CreateScope_NormalizesLookupIdentity()
+    {
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.ChatGPT,
+            " OpenAI ",
+            " https://api.openai.com/v1/ ",
+            " gpt-5.6-terra ");
+
+        scope.ProviderScope.Should().Be("OpenAI");
+        scope.EndpointScope.Should().Be("https://api.openai.com/v1");
+        scope.ModelId.Should().Be("gpt-5.6-terra");
+    }
+
+    /// <summary>
+    ///     Ensures unsupported temperature is omitted from the outbound
+    ///     provider payload.
+    /// </summary>
+    [Fact]
+    public void TryResolveTemperature_WithUnsupportedDecision_OmitsPayloadValue()
+    {
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.ChatGPT,
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.6-terra");
+
+        var resolved = LlmCapabilityPolicyService.TryResolveTemperature(
+            scope,
+            0.7f,
+            out var sanitizedValue,
+            out var decision);
+
+        resolved.Should().BeFalse();
+        sanitizedValue.Should().Be(default);
+        decision.SupportState.Should().Be(LlmCapabilitySupportState.Unsupported);
+    }
+
+    /// <summary>
+    ///     Ensures a clearly classified provider rejection is persisted and
+    ///     promoted for the exact model only.
+    /// </summary>
+    [Fact]
+    public void LearnFromProviderFailure_WithClassifiedTemperature400_PromotesExactModelOnly()
+    {
+        this.WithTemporaryConfigurationDirectory(configDir =>
+        {
+            var scope = new LlmCapabilityScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra");
+
+            var result = LlmCapabilityPolicyService.LearnFromProviderFailure(
+                scope,
+                LlmCapabilityParameterName.Temperature,
+                400,
+                "{ \"error\": { \"message\": \"Unsupported value: 'temperature' does not support 0.7 with this model.\" } }");
+
+            result.ObservationRecorded.Should().BeTrue();
+            result.RulePromoted.Should().BeTrue();
+            result.FailureKind.Should().Be("unsupported-parameter");
+            LlmCapabilityCacheManager.GetRuleDefinitions().Should().ContainSingle(
+                rule => rule.MatchType == LlmCapabilityRuleMatchType.ExactModel &&
+                    rule.MatchValue == "gpt-5.6-terra" &&
+                    rule.ParameterName == LlmCapabilityParameterName.Temperature);
+
+            using var context = new EchoglossianDbContext(configDir);
+            context.LlmModelCapabilityRules.Should().ContainSingle(
+                rule => rule.MatchType == LlmCapabilityRuleMatchType.ExactModel.ToString() &&
+                    rule.MatchValue == "gpt-5.6-terra");
+            context.LlmModelCapabilityRules.Should().NotContain(
+                rule => rule.MatchType == LlmCapabilityRuleMatchType.FamilyPrefix.ToString());
+        });
+    }
+
+    /// <summary>
+    ///     Ensures discovered models inherit known family policy into
+    ///     exact-model persisted overlays.
+    /// </summary>
+    [Fact]
+    public void PromoteDiscoveredModels_WithStaticFamilyRule_PersistsExactModelOverlay()
+    {
+        this.WithTemporaryConfigurationDirectory(configDir =>
+        {
+            LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                ["gpt-5.6-terra"],
+                DateTime.UtcNow);
+
+            using var context = new EchoglossianDbContext(configDir);
+            context.LlmModelCapabilityRules.Should().ContainSingle(rule =>
+                rule.MatchType == LlmCapabilityRuleMatchType.ExactModel.ToString() &&
+                rule.MatchValue == "gpt-5.6-terra" &&
+                rule.ParameterName == LlmCapabilityParameterName.Temperature.ToString() &&
+                rule.SupportState == LlmCapabilitySupportState.Unsupported.ToString());
+        });
+    }
+
+    /// <summary>
+    ///     Runs an action with an isolated persisted capability database.
+    /// </summary>
+    /// <param name="action">The action that exercises the policy service.</param>
+    private void WithTemporaryConfigurationDirectory(Action<string> action)
+    {
+        var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var originalConfigDirectory = Echoglossian.ConfigDirectory;
+        Directory.CreateDirectory(configDir);
+        Echoglossian.ConfigDirectory = configDir;
+        LlmCapabilityCacheManager.Clear();
+
+        try
+        {
+            action(configDir);
+        }
+        finally
+        {
+            LlmCapabilityCacheManager.Clear();
+            Echoglossian.ConfigDirectory = originalConfigDirectory;
+            SqliteConnection.ClearAllPools();
+            Directory.Delete(configDir, recursive: true);
+        }
+    }
+}

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -7,6 +7,7 @@ using Echoglossian.Cache;
 using Echoglossian.EFCoreSqlite;
 using Echoglossian.Translators;
 using Echoglossian.Translators.Capabilities;
+using Echoglossian.Translators.Helpers;
 
 using Echoglossian.Tests.TestDoubles;
 
@@ -135,7 +136,9 @@ public sealed class LlmCapabilityPolicyServiceTests
                 OpenRouterBaseUrl = "https://openrouter.example/v1",
                 OpenRouterModel = "test-model",
             });
-        var responseHandler = new StructuredDialogueResponseHandler();
+        var responseHandler = new StructuredDialogueResponseHandler(
+            isStructuredStartLogged: () => pluginLog.DebugMessages.Any(
+                message => message.Contains("structured-start", StringComparison.Ordinal)));
         this.ReplaceHttpClient(
             translator,
             new HttpClient(responseHandler)
@@ -159,6 +162,7 @@ public sealed class LlmCapabilityPolicyServiceTests
         responseHandler.RequestUri.Should().Be("https://openrouter.example/v1/chat/completions");
         responseHandler.RequestBody.Should().Contain("\"model\":\"test-model\"");
         responseHandler.RequestBody.Should().Contain("\"tool_choice\"");
+        responseHandler.StructuredStartWasLoggedAtDispatch.Should().BeTrue();
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("route=chat-completions", StringComparison.Ordinal) &&
@@ -211,6 +215,93 @@ public sealed class LlmCapabilityPolicyServiceTests
                 message.Contains("route=chat-completions", StringComparison.Ordinal) &&
                 message.Contains("glossaryApplied=false", StringComparison.Ordinal) &&
                 message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Ensures the default OpenAI structured path records its explicit
+    ///     gpt-5.6 parameter decisions without changing provider policy.
+    /// </summary>
+    [Fact]
+    public void ChatGptTranslator_StructuredDefaultRules_UseExplicitCapabilityDecisionTokens()
+    {
+        var translator = new ChatGPTTranslator(
+            new NoOpPluginLog(),
+            new Config
+            {
+                ChatGptApiKey = "test-key",
+                ChatGPTBaseUrl = "https://api.openai.com/v1",
+                OpenAILlmModel = "gpt-5.6-terra",
+                ChatGptTemperature = 0.7f,
+            });
+        var options = new ChatCompletionOptions();
+
+        translator.ApplyTemperaturePolicy(options).Should().BeFalse();
+        translator.ApplyStructuredReasoningEffortPolicy(options).Should().BeTrue();
+        var snapshot = LlmCapabilityPolicyService.GetSnapshot(
+            LlmCapabilityPolicyService.CreateScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra"));
+
+        StructuredDialogueCapabilityDecisionLogFormatter.Format(
+            LlmCapabilityParameterName.Temperature,
+            snapshot.GetDecision(LlmCapabilityParameterName.Temperature),
+            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly)
+            .Should().Be("temperature=omitted(default-only)");
+        StructuredDialogueCapabilityDecisionLogFormatter.Format(
+            LlmCapabilityParameterName.ReasoningEffort,
+            snapshot.GetDecision(LlmCapabilityParameterName.ReasoningEffort),
+            StructuredDialogueCapabilityEmissionMode.ExplicitDisable)
+            .Should().Be("reasoning_effort=explicit-none(unsupported)");
+    }
+
+    /// <summary>
+    ///     Ensures the DeepSeek structured HTTP path emits the same start and
+    ///     success shape as the other OpenAI-compatible translators.
+    /// </summary>
+    [Fact]
+    public async Task DeepSeekTranslator_StructuredDialogue_LogsRequestShapeAndSuccess()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var responseHandler = new StructuredDialogueResponseHandler(
+            isStructuredStartLogged: () => pluginLog.DebugMessages.Any(
+                message => message.Contains("structured-start", StringComparison.Ordinal)));
+        var translator = new DeepSeekTranslator(
+            pluginLog,
+            new Config
+            {
+                DeepSeekTranslatorApiKey = new string('k', 25),
+                DeepSeekBaseUrl = "https://deepseek.example/v1",
+                DeepSeekModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(responseHandler)
+            {
+                BaseAddress = new Uri("https://deepseek.example/v1/"),
+            });
+
+        var translated = await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        translated.Should().Be("Fique perto.");
+        responseHandler.RequestMethod.Should().Be(HttpMethod.Post);
+        responseHandler.RequestUri.Should().Be("https://deepseek.example/v1/chat/completions");
+        responseHandler.RequestBody.Should().Contain("\"tool_choice\"");
+        responseHandler.StructuredStartWasLoggedAtDispatch.Should().BeTrue();
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-start", StringComparison.Ordinal) &&
+                message.Contains("provider=DeepSeek", StringComparison.Ordinal) &&
+                message.Contains("route=chat-completions", StringComparison.Ordinal) &&
+                message.Contains("requestJsonLength=", StringComparison.Ordinal));
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-success", StringComparison.Ordinal) &&
+                message.Contains("provider=DeepSeek", StringComparison.Ordinal) &&
+                message.Contains("translatedLength=12", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -514,17 +605,28 @@ public sealed class LlmCapabilityPolicyServiceTests
             .SetValue(translator, httpClient);
     }
 
+    private void ReplaceHttpClient(DeepSeekTranslator translator, HttpClient httpClient)
+    {
+        typeof(DeepSeekTranslator)
+            .GetField("httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(translator, httpClient);
+    }
+
     private sealed class StructuredDialogueResponseHandler : HttpMessageHandler
     {
         private const string DefaultResponseBody = """
             {"choices":[{"message":{"content":"{\"text_translated\":\"Fique perto.\"}"}}]}
             """;
 
+        private readonly Func<bool>? isStructuredStartLogged;
         private readonly string responseBody;
 
-        public StructuredDialogueResponseHandler(string? responseBody = null)
+        public StructuredDialogueResponseHandler(
+            string? responseBody = null,
+            Func<bool>? isStructuredStartLogged = null)
         {
             this.responseBody = responseBody ?? DefaultResponseBody;
+            this.isStructuredStartLogged = isStructuredStartLogged;
         }
 
         public string RequestBody { get; private set; } = string.Empty;
@@ -532,6 +634,8 @@ public sealed class LlmCapabilityPolicyServiceTests
         public string? RequestUri { get; private set; }
 
         public HttpMethod? RequestMethod { get; private set; }
+
+        public bool StructuredStartWasLoggedAtDispatch { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -542,6 +646,7 @@ public sealed class LlmCapabilityPolicyServiceTests
             this.RequestBody = request.Content?.ReadAsStringAsync(cancellationToken)
                 .GetAwaiter()
                 .GetResult() ?? string.Empty;
+            this.StructuredStartWasLoggedAtDispatch = this.isStructuredStartLogged?.Invoke() ?? false;
 
             return Task.FromResult(
                 new HttpResponseMessage(System.Net.HttpStatusCode.OK)

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -90,20 +90,77 @@ public sealed class LlmCapabilityPolicyServiceTests
     }
 
     /// <summary>
-    ///     Ensures structured ChatGPT tool requests explicitly disable
-    ///     reasoning effort and learn an exact-model capability rejection.
+    ///     Ensures structured ChatGPT requests omit reasoning effort when the
+    ///     effective capability policy marks it unsupported.
     /// </summary>
     [Fact]
-    public void ChatGptTranslator_StructuredToolRequest_DisablesAndLearnsReasoningEffort()
+    public void ChatGptTranslator_WhenReasoningEffortIsUnsupported_OmitsStructuredOption()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
-            "Translators",
-            "ChatGPTTranslator.cs"));
+        var translator = new ChatGPTTranslator(
+            new NoOpPluginLog(),
+            new Config
+            {
+                ChatGptApiKey = "test-key",
+                ChatGPTBaseUrl = "https://api.openai.com/v1",
+                OpenAILlmModel = "gpt-5.6-terra",
+            });
+        var options = new ChatCompletionOptions();
 
-        source.Should().Contain("ReasoningEffortLevel = ChatReasoningEffortLevel.None");
-        source.Should().Contain("this.LearnReasoningEffortFailure(ex);");
-        source.Should().Contain("LlmCapabilityParameterName.ReasoningEffort");
+#pragma warning disable OPENAI001
+        options.ReasoningEffortLevel = ChatReasoningEffortLevel.Low;
+#pragma warning restore OPENAI001
+
+        var applied = translator.ApplyStructuredReasoningEffortPolicy(options);
+
+        applied.Should().BeFalse();
+#pragma warning disable OPENAI001
+        options.ReasoningEffortLevel.Should().BeNull();
+#pragma warning restore OPENAI001
+    }
+
+    /// <summary>
+    ///     Ensures structured ChatGPT requests retain a configured reasoning
+    ///     effort only when the effective capability policy supports it.
+    /// </summary>
+    [Fact]
+    public void ChatGptTranslator_WhenReasoningEffortIsSupported_RetainsStructuredOption()
+    {
+        LlmCapabilityCacheManager.Clear();
+        try
+        {
+            LlmCapabilityCacheManager.PublishRule(
+                LlmCapabilityRuleDefinition.ExactModel(
+                    Echoglossian.TransEngines.ChatGPT.ToString(),
+                    "OpenAI",
+                    "https://api.openai.com/v1",
+                    "test-model",
+                    LlmCapabilityParameterName.ReasoningEffort,
+                    LlmCapabilitySupportState.Supported));
+            var translator = new ChatGPTTranslator(
+                new NoOpPluginLog(),
+                new Config
+                {
+                    ChatGptApiKey = "test-key",
+                    ChatGPTBaseUrl = "https://api.openai.com/v1",
+                    OpenAILlmModel = "test-model",
+                });
+            var options = new ChatCompletionOptions();
+
+#pragma warning disable OPENAI001
+            options.ReasoningEffortLevel = ChatReasoningEffortLevel.Low;
+#pragma warning restore OPENAI001
+
+            var applied = translator.ApplyStructuredReasoningEffortPolicy(options);
+
+            applied.Should().BeTrue();
+#pragma warning disable OPENAI001
+            options.ReasoningEffortLevel.Should().Be(ChatReasoningEffortLevel.Low);
+#pragma warning restore OPENAI001
+        }
+        finally
+        {
+            LlmCapabilityCacheManager.Clear();
+        }
     }
 
     /// <summary>

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -209,12 +209,13 @@ public sealed class LlmCapabilityPolicyServiceTests
             new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
 
         pluginLog.DebugMessages.Should().ContainSingle(
-            message => message.Contains("structured dialogue fallback", StringComparison.Ordinal) &&
+            message => message.Contains("structured-fallback", StringComparison.Ordinal) &&
                 message.Contains("stage=validation", StringComparison.Ordinal) &&
                 message.Contains("endpointScope=https://openrouter.example/v1", StringComparison.Ordinal) &&
                 message.Contains("route=chat-completions", StringComparison.Ordinal) &&
                 message.Contains("glossaryApplied=false", StringComparison.Ordinal) &&
-                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
+                message.Contains("excerpt={}", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -339,13 +340,13 @@ public sealed class LlmCapabilityPolicyServiceTests
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("provider=Gemini", StringComparison.Ordinal) &&
-                message.Contains("route=models-test-model-generatecontent", StringComparison.Ordinal) &&
+                message.Contains("route=v1beta-models-test-model-generatecontent", StringComparison.Ordinal) &&
                 message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
                 message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-success", StringComparison.Ordinal) &&
                 message.Contains("provider=Gemini", StringComparison.Ordinal) &&
-                message.Contains("route=models-test-model-generatecontent", StringComparison.Ordinal));
+                message.Contains("route=v1beta-models-test-model-generatecontent", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -431,7 +432,7 @@ public sealed class LlmCapabilityPolicyServiceTests
             new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
 
         pluginLog.DebugMessages.Should().ContainSingle(
-            message => message.Contains("structured dialogue fallback", StringComparison.Ordinal) &&
+            message => message.Contains("structured-fallback", StringComparison.Ordinal) &&
                 message.Contains("provider=Anthropic", StringComparison.Ordinal) &&
                 message.Contains("route=v1-messages", StringComparison.Ordinal) &&
                 message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
@@ -575,6 +576,33 @@ public sealed class LlmCapabilityPolicyServiceTests
         {
             LlmCapabilityCacheManager.Clear();
         }
+    }
+
+    /// <summary>
+    ///     Ensures production DeepSeek and LM Studio base addresses preserve
+    ///     their configured API-version segment for relative request routes.
+    /// </summary>
+    [Fact]
+    public void OpenAiCompatibleTranslators_WhenBaseUrlLacksTrailingSlash_PreserveVersionSegment()
+    {
+        var deepSeekTranslator = new DeepSeekTranslator(
+            new NoOpPluginLog(),
+            new Config
+            {
+                DeepSeekTranslatorApiKey = new string('k', 25),
+                DeepSeekBaseUrl = "https://deepseek.example/v1",
+            });
+        var lmStudioTranslator = new LmStudioTranslator(
+            new NoOpPluginLog(),
+            new Config
+            {
+                LmStudioBaseUrl = "http://lmstudio.example/v1",
+            });
+
+        this.GetHttpClient(deepSeekTranslator).BaseAddress.Should().Be(
+            new Uri("https://deepseek.example/v1/"));
+        this.GetHttpClient(lmStudioTranslator).BaseAddress.Should().Be(
+            new Uri("http://lmstudio.example/v1/"));
     }
 
     /// <summary>
@@ -838,6 +866,14 @@ public sealed class LlmCapabilityPolicyServiceTests
         typeof(DeepSeekTranslator)
             .GetField("httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(translator, httpClient);
+    }
+
+    private HttpClient GetHttpClient<TTranslator>(TTranslator translator)
+        where TTranslator : class
+    {
+        return (HttpClient)typeof(TTranslator)
+            .GetField("httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(translator)!;
     }
 
     private void ReplaceHttpClient<TTranslator>(TTranslator translator, HttpClient httpClient)

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -256,6 +256,28 @@ public sealed class LlmCapabilityPolicyServiceTests
     }
 
     /// <summary>
+    ///     Ensures Gemini 3 discoveries inherit the committed family policy
+    ///     into an exact-model overlay.
+    /// </summary>
+    [Fact]
+    public void PromoteDiscoveredModels_WithGemini3Model_CreatesExactRuleFromFamilyDefault()
+    {
+        this.WithTemporaryConfigurationDirectory(_ =>
+        {
+            LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                Echoglossian.TransEngines.Gemini,
+                "Gemini",
+                "https://generativelanguage.googleapis.com",
+                ["gemini-3-pro"],
+                new DateTime(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc));
+
+            LlmCapabilityCacheManager.GetRuleDefinitions()
+                .Should()
+                .Contain(rule => rule.MatchValue == "gemini-3-pro");
+        });
+    }
+
+    /// <summary>
     ///     Runs an action with an isolated persisted capability database.
     /// </summary>
     /// <param name="action">The action that exercises the policy service.</param>

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -10,6 +10,7 @@ using Echoglossian.Translators.Capabilities;
 using FluentAssertions;
 
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 
 using Xunit;
 
@@ -98,6 +99,67 @@ public sealed class LlmCapabilityPolicyServiceTests
                     rule.MatchValue == "gpt-5.6-terra");
             context.LlmModelCapabilityRules.Should().NotContain(
                 rule => rule.MatchType == LlmCapabilityRuleMatchType.FamilyPrefix.ToString());
+        });
+    }
+
+    /// <summary>
+    ///     Ensures learning does not persist an observation or rule when the
+    ///     provider did not identify the active model.
+    /// </summary>
+    [Fact]
+    public void LearnFromProviderFailure_WithBlankModelId_DoesNotPersistCapabilityFeedback()
+    {
+        this.WithTemporaryConfigurationDirectory(configDir =>
+        {
+            var result = LlmCapabilityPolicyService.LearnFromProviderFailure(
+                new LlmCapabilityScope(
+                    Echoglossian.TransEngines.ChatGPT,
+                    "OpenAI",
+                    "https://api.openai.com/v1",
+                    " "),
+                LlmCapabilityParameterName.Temperature,
+                400,
+                "{ \"error\": { \"message\": \"Unsupported parameter: temperature.\" } }");
+
+            result.ObservationRecorded.Should().BeFalse();
+            result.RulePromoted.Should().BeFalse();
+            LlmCapabilityCacheManager.GetRuleDefinitions().Should().BeEmpty();
+
+            using var context = new EchoglossianDbContext(configDir);
+            context.Database.Migrate();
+            context.LlmModelCapabilityObservations.Should().BeEmpty();
+            context.LlmModelCapabilityRules.Should().BeEmpty();
+        });
+    }
+
+    /// <summary>
+    ///     Ensures recurring ambiguous provider failures do not grow the
+    ///     persisted observation table.
+    /// </summary>
+    [Fact]
+    public void LearnFromProviderFailure_WithRepeatedAmbiguous400_DeduplicatesObservation()
+    {
+        this.WithTemporaryConfigurationDirectory(configDir =>
+        {
+            var scope = new LlmCapabilityScope(
+                Echoglossian.TransEngines.ChatGPT,
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra");
+
+            LlmCapabilityPolicyService.LearnFromProviderFailure(
+                scope,
+                LlmCapabilityParameterName.Temperature,
+                400,
+                "{ \"error\": { \"message\": \"Request could not be processed.\" } }");
+            LlmCapabilityPolicyService.LearnFromProviderFailure(
+                scope,
+                LlmCapabilityParameterName.Temperature,
+                400,
+                "{ \"error\": { \"message\": \"Request could not be processed.\" } }");
+
+            using var context = new EchoglossianDbContext(configDir);
+            context.LlmModelCapabilityObservations.Should().ContainSingle();
         });
     }
 

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -135,9 +135,10 @@ public sealed class LlmCapabilityPolicyServiceTests
                 OpenRouterBaseUrl = "https://openrouter.example/v1",
                 OpenRouterModel = "test-model",
             });
+        var responseHandler = new StructuredDialogueResponseHandler();
         this.ReplaceHttpClient(
             translator,
-            new HttpClient(new StructuredDialogueResponseHandler())
+            new HttpClient(responseHandler)
             {
                 BaseAddress = new Uri("https://openrouter.example/v1/"),
             });
@@ -154,16 +155,62 @@ public sealed class LlmCapabilityPolicyServiceTests
                 SpeakerGenderHint: "female"));
 
         translated.Should().Be("Fique perto.");
+        responseHandler.RequestMethod.Should().Be(HttpMethod.Post);
+        responseHandler.RequestUri.Should().Be("https://openrouter.example/v1/chat/completions");
+        responseHandler.RequestBody.Should().Contain("\"model\":\"test-model\"");
+        responseHandler.RequestBody.Should().Contain("\"tool_choice\"");
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("route=chat-completions", StringComparison.Ordinal) &&
                 message.Contains("endpointScope=https://openrouter.example/v1", StringComparison.Ordinal) &&
                 message.Contains("glossaryApplied=false", StringComparison.Ordinal) &&
-                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
+                message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-success", StringComparison.Ordinal) &&
                 message.Contains("route=chat-completions", StringComparison.Ordinal) &&
                 message.Contains("translatedLength=12", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Ensures a rejected structured OpenAI-compatible response retains
+    ///     enough request-shape detail to diagnose the plain-text fallback.
+    /// </summary>
+    [Fact]
+    public async Task OpenRouterTranslator_WhenStructuredResponseIsRejected_LogsFallbackRequestShape()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var translator = new OpenRouterTranslator(
+            pluginLog,
+            new Config
+            {
+                OpenRouterApiKey = "test-key",
+                OpenRouterBaseUrl = "https://openrouter.example/v1",
+                OpenRouterModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(new StructuredDialogueResponseHandler(
+                """
+                {"choices":[{"message":{"content":"{}"}}]}
+                """))
+            {
+                BaseAddress = new Uri("https://openrouter.example/v1/"),
+            });
+
+        await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured dialogue fallback", StringComparison.Ordinal) &&
+                message.Contains("stage=validation", StringComparison.Ordinal) &&
+                message.Contains("endpointScope=https://openrouter.example/v1", StringComparison.Ordinal) &&
+                message.Contains("route=chat-completions", StringComparison.Ordinal) &&
+                message.Contains("glossaryApplied=false", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -469,18 +516,37 @@ public sealed class LlmCapabilityPolicyServiceTests
 
     private sealed class StructuredDialogueResponseHandler : HttpMessageHandler
     {
+        private const string DefaultResponseBody = """
+            {"choices":[{"message":{"content":"{\"text_translated\":\"Fique perto.\"}"}}]}
+            """;
+
+        private readonly string responseBody;
+
+        public StructuredDialogueResponseHandler(string? responseBody = null)
+        {
+            this.responseBody = responseBody ?? DefaultResponseBody;
+        }
+
+        public string RequestBody { get; private set; } = string.Empty;
+
+        public string? RequestUri { get; private set; }
+
+        public HttpMethod? RequestMethod { get; private set; }
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            const string ResponseBody = """
-                {"choices":[{"message":{"content":"{\"text_translated\":\"Fique perto.\"}"}}]}
-                """;
+            this.RequestMethod = request.Method;
+            this.RequestUri = request.RequestUri?.ToString();
+            this.RequestBody = request.Content?.ReadAsStringAsync(cancellationToken)
+                .GetAwaiter()
+                .GetResult() ?? string.Empty;
 
             return Task.FromResult(
                 new HttpResponseMessage(System.Net.HttpStatusCode.OK)
                 {
-                    Content = new StringContent(ResponseBody),
+                    Content = new StringContent(this.responseBody),
                 });
         }
     }

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -340,6 +340,7 @@ public sealed class LlmCapabilityPolicyServiceTests
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("provider=Gemini", StringComparison.Ordinal) &&
                 message.Contains("route=models-test-model-generatecontent", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
                 message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-success", StringComparison.Ordinal) &&
@@ -389,11 +390,51 @@ public sealed class LlmCapabilityPolicyServiceTests
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("provider=Anthropic", StringComparison.Ordinal) &&
                 message.Contains("route=v1-messages", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
                 message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-success", StringComparison.Ordinal) &&
                 message.Contains("provider=Anthropic", StringComparison.Ordinal) &&
                 message.Contains("route=v1-messages", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Ensures Claude fallback diagnostics retain the scope-derived
+    ///     Anthropic provider identity and active capability decisions.
+    /// </summary>
+    [Fact]
+    public async Task ClaudeTranslator_WhenStructuredResponseIsRejected_LogsScopeProviderAndDecision()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var translator = new ClaudeTranslator(
+            pluginLog,
+            new Config
+            {
+                ClaudeApiKey = "test-key",
+                ClaudeBaseUrl = "https://claude.example",
+                ClaudeModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(new StructuredDialogueResponseHandler(
+                """
+                {"content":[]}
+                """))
+            {
+                BaseAddress = new Uri("https://claude.example/"),
+            });
+
+        await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured dialogue fallback", StringComparison.Ordinal) &&
+                message.Contains("provider=Anthropic", StringComparison.Ordinal) &&
+                message.Contains("route=v1-messages", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -437,6 +478,7 @@ public sealed class LlmCapabilityPolicyServiceTests
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("provider=Ollama", StringComparison.Ordinal) &&
                 message.Contains("route=api-generate", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
                 message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-success", StringComparison.Ordinal) &&
@@ -482,6 +524,7 @@ public sealed class LlmCapabilityPolicyServiceTests
             message => message.Contains("structured-start", StringComparison.Ordinal) &&
                 message.Contains("provider=LmStudio", StringComparison.Ordinal) &&
                 message.Contains("route=chat-completions", StringComparison.Ordinal) &&
+                message.Contains("capabilityDecisions=temperature=omitted(unknown)", StringComparison.Ordinal) &&
                 message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
         pluginLog.DebugMessages.Should().ContainSingle(
             message => message.Contains("structured-success", StringComparison.Ordinal) &&

--- a/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
@@ -305,6 +305,191 @@ public sealed class LlmCapabilityPolicyServiceTests
     }
 
     /// <summary>
+    ///     Ensures Gemini records the actual generative-language route around
+    ///     structured dialogue dispatch and validation.
+    /// </summary>
+    [Fact]
+    public async Task GeminiTranslator_StructuredDialogue_LogsRequestShapeAndSuccess()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var responseHandler = new StructuredDialogueResponseHandler(
+            """
+            {"candidates":[{"content":{"parts":[{"text":"{\"text_translated\":\"Fique perto.\"}"}]}}]}
+            """,
+            () => pluginLog.DebugMessages.Any(
+                message => message.Contains("structured-start", StringComparison.Ordinal)));
+        var translator = new GeminiTranslator(
+            pluginLog,
+            new Config
+            {
+                GeminiTranslatorApiKey = new string('k', 25),
+                GeminiModel = "test-model",
+            });
+        this.ReplaceHttpClient(translator, new HttpClient(responseHandler));
+
+        var translated = await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        translated.Should().Be("Fique perto.");
+        responseHandler.RequestUri.Should().Contain("v1beta/models/test-model:generateContent");
+        responseHandler.StructuredStartWasLoggedAtDispatch.Should().BeTrue();
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-start", StringComparison.Ordinal) &&
+                message.Contains("provider=Gemini", StringComparison.Ordinal) &&
+                message.Contains("route=models-test-model-generatecontent", StringComparison.Ordinal) &&
+                message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-success", StringComparison.Ordinal) &&
+                message.Contains("provider=Gemini", StringComparison.Ordinal) &&
+                message.Contains("route=models-test-model-generatecontent", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Ensures Claude records its Messages API request shape around
+    ///     structured tool output validation.
+    /// </summary>
+    [Fact]
+    public async Task ClaudeTranslator_StructuredDialogue_LogsRequestShapeAndSuccess()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var responseHandler = new StructuredDialogueResponseHandler(
+            """
+            {"content":[{"type":"tool_use","name":"submit_dialogue_translation","input":{"text_translated":"Fique perto."}}]}
+            """,
+            () => pluginLog.DebugMessages.Any(
+                message => message.Contains("structured-start", StringComparison.Ordinal)));
+        var translator = new ClaudeTranslator(
+            pluginLog,
+            new Config
+            {
+                ClaudeApiKey = "test-key",
+                ClaudeBaseUrl = "https://claude.example",
+                ClaudeModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(responseHandler)
+            {
+                BaseAddress = new Uri("https://claude.example/"),
+            });
+
+        var translated = await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        translated.Should().Be("Fique perto.");
+        responseHandler.RequestUri.Should().Be("https://claude.example/v1/messages");
+        responseHandler.StructuredStartWasLoggedAtDispatch.Should().BeTrue();
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-start", StringComparison.Ordinal) &&
+                message.Contains("provider=Anthropic", StringComparison.Ordinal) &&
+                message.Contains("route=v1-messages", StringComparison.Ordinal) &&
+                message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-success", StringComparison.Ordinal) &&
+                message.Contains("provider=Anthropic", StringComparison.Ordinal) &&
+                message.Contains("route=v1-messages", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Ensures Ollama records the generate endpoint used by its structured
+    ///     JSON-schema request.
+    /// </summary>
+    [Fact]
+    public async Task OllamaTranslator_StructuredDialogue_LogsRequestShapeAndSuccess()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var responseHandler = new StructuredDialogueResponseHandler(
+            """
+            {"response":"{\"text_translated\":\"Fique perto.\"}"}
+            """,
+            () => pluginLog.DebugMessages.Any(
+                message => message.Contains("structured-start", StringComparison.Ordinal)));
+        var translator = new OllamaTranslator(
+            pluginLog,
+            new Config
+            {
+                OllamaUrl = "http://ollama.example",
+                OllamaModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(responseHandler)
+            {
+                BaseAddress = new Uri("http://ollama.example/"),
+            });
+
+        var translated = await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        translated.Should().Be("Fique perto.");
+        responseHandler.RequestUri.Should().Be("http://ollama.example/api/generate");
+        responseHandler.StructuredStartWasLoggedAtDispatch.Should().BeTrue();
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-start", StringComparison.Ordinal) &&
+                message.Contains("provider=Ollama", StringComparison.Ordinal) &&
+                message.Contains("route=api-generate", StringComparison.Ordinal) &&
+                message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-success", StringComparison.Ordinal) &&
+                message.Contains("provider=Ollama", StringComparison.Ordinal) &&
+                message.Contains("route=api-generate", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Ensures LM Studio records its OpenAI-compatible chat-completions
+    ///     route around structured dialogue dispatch and validation.
+    /// </summary>
+    [Fact]
+    public async Task LmStudioTranslator_StructuredDialogue_LogsRequestShapeAndSuccess()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var responseHandler = new StructuredDialogueResponseHandler(
+            isStructuredStartLogged: () => pluginLog.DebugMessages.Any(
+                message => message.Contains("structured-start", StringComparison.Ordinal)));
+        var translator = new LmStudioTranslator(
+            pluginLog,
+            new Config
+            {
+                LmStudioBaseUrl = "http://lmstudio.example/v1",
+                LmStudioModel = "test-model",
+            });
+        this.ReplaceHttpClient(
+            translator,
+            new HttpClient(responseHandler)
+            {
+                BaseAddress = new Uri("http://lmstudio.example/v1/"),
+            });
+
+        var translated = await translator.TranslateAsync(
+            "Stay close.",
+            "English",
+            "Portuguese",
+            new DialogueTranslationContext("Talk", "quest-1", "Krile", []));
+
+        translated.Should().Be("Fique perto.");
+        responseHandler.RequestUri.Should().Be("http://lmstudio.example/v1/chat/completions");
+        responseHandler.StructuredStartWasLoggedAtDispatch.Should().BeTrue();
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-start", StringComparison.Ordinal) &&
+                message.Contains("provider=LmStudio", StringComparison.Ordinal) &&
+                message.Contains("route=chat-completions", StringComparison.Ordinal) &&
+                message.Contains($"requestJsonLength={responseHandler.RequestBody.Length}", StringComparison.Ordinal));
+        pluginLog.DebugMessages.Should().ContainSingle(
+            message => message.Contains("structured-success", StringComparison.Ordinal) &&
+                message.Contains("provider=LmStudio", StringComparison.Ordinal) &&
+                message.Contains("route=chat-completions", StringComparison.Ordinal));
+    }
+
+    /// <summary>
     ///     Ensures structured ChatGPT requests retain a configured reasoning
     ///     effort only when the effective capability policy supports it.
     /// </summary>
@@ -608,6 +793,14 @@ public sealed class LlmCapabilityPolicyServiceTests
     private void ReplaceHttpClient(DeepSeekTranslator translator, HttpClient httpClient)
     {
         typeof(DeepSeekTranslator)
+            .GetField("httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(translator, httpClient);
+    }
+
+    private void ReplaceHttpClient<TTranslator>(TTranslator translator, HttpClient httpClient)
+        where TTranslator : class
+    {
+        typeof(TTranslator)
             .GetField("httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(translator, httpClient);
     }

--- a/Echoglossian.Tests/LlmCapabilityResolverTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityResolverTests.cs
@@ -241,7 +241,7 @@ public class LlmCapabilityResolverTests
         Echoglossian.TransEngines.Gemini,
         "Gemini",
         "https://generativelanguage.googleapis.com",
-        "gemini-3-pro");
+        "gemini-4-pro");
 
     var snapshot = LlmCapabilityResolver.Resolve(
         scope,

--- a/Echoglossian.Tests/LlmCapabilityResolverTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityResolverTests.cs
@@ -112,6 +112,126 @@ public class LlmCapabilityResolverTests
   }
 
   /// <summary>
+  ///     Ensures a narrower matching family-prefix rule takes precedence over
+  ///     a broader family rule.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithNestedFamilyPrefixes_PrefersLongerPrefix()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-4.1-mini");
+    var broaderRule = LlmCapabilityRuleDefinition.FamilyPrefix(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Unsupported,
+        source: "LiveRefresh",
+        reason: "broader family does not support temperature");
+    var narrowerRule = LlmCapabilityRuleDefinition.FamilyPrefix(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-4.1-",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Supported,
+        source: "LiveRefresh",
+        reason: "narrower family supports temperature");
+
+    var snapshot = LlmCapabilityResolver.Resolve(
+        scope,
+        [broaderRule, narrowerRule]);
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Supported);
+  }
+
+  /// <summary>
+  ///     Ensures conflicting supported ranges with no common value resolve to
+  ///     an unknown decision instead of an invalid supported range.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithDisjointSupportedRanges_ReturnsUnknownDecision()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-4.1-mini");
+    var lowerRangeRule = LlmCapabilityRuleDefinition.ExactModel(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-4.1-mini",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Supported,
+        minValue: 0f,
+        maxValue: 0.2f,
+        source: "LiveRefresh",
+        reason: "first observed range");
+    var upperRangeRule = LlmCapabilityRuleDefinition.ExactModel(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-4.1-mini",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Supported,
+        minValue: 0.8f,
+        maxValue: 1f,
+        source: "Observed400",
+        reason: "second observed range");
+
+    var decision = LlmCapabilityResolver.Resolve(
+            scope,
+            [lowerRangeRule, upperRangeRule])
+        .GetDecision(LlmCapabilityParameterName.Temperature);
+
+    decision.SupportState.Should().Be(LlmCapabilitySupportState.Unknown);
+    decision.MinValue.Should().BeNull();
+    decision.MaxValue.Should().BeNull();
+  }
+
+  /// <summary>
+  ///     Ensures an unsupported model-match type cannot be interpreted as a
+  ///     family-prefix rule.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithUnsupportedMatchType_ReturnsUnknown()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-4.1-mini");
+    var invalidRule = new LlmCapabilityRuleDefinition(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        (LlmCapabilityRuleMatchType)99,
+        "gpt-",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Supported,
+        null,
+        null,
+        false,
+        "LiveRefresh",
+        "invalid match type");
+
+    var snapshot = LlmCapabilityResolver.Resolve(scope, [invalidRule]);
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Unknown);
+  }
+
+  /// <summary>
   ///     Ensures unmatched provider capabilities remain unknown.
   /// </summary>
   [Fact]

--- a/Echoglossian.Tests/LlmCapabilityResolverTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityResolverTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="LlmCapabilityResolverTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators.Capabilities;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers conservative resolution of static and overlay LLM capabilities.
+/// </summary>
+public class LlmCapabilityResolverTests
+{
+  /// <summary>
+  ///     Ensures an exact-model overlay takes precedence over a matching
+  ///     family-prefix static rule.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithExactAndFamilyRules_PrefersExactRule()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+    var exactRule = LlmCapabilityRuleDefinition.ExactModel(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Supported,
+        source: "LiveRefresh",
+        reason: "provider metadata confirmed support");
+
+    var snapshot = LlmCapabilityResolver.Resolve(scope, [exactRule]);
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Supported);
+  }
+
+  /// <summary>
+  ///     Ensures the static family-prefix rule disables temperature for
+  ///     matching OpenAI reasoning models.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithMatchingFamilyRule_ReturnsUnsupported()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+
+    var snapshot = LlmCapabilityResolver.Resolve(
+        scope,
+        Array.Empty<LlmCapabilityRuleDefinition>());
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Unsupported);
+  }
+
+  /// <summary>
+  ///     Ensures unsupported support wins when equally specific overlay rules
+  ///     disagree.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithAmbiguousOverlayRules_PrefersUnsupported()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+    var supportedRule = LlmCapabilityRuleDefinition.ExactModel(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Supported,
+        source: "LiveRefresh",
+        reason: "provider metadata confirmed support");
+    var unsupportedRule = LlmCapabilityRuleDefinition.ExactModel(
+        "ChatGPT",
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra",
+        LlmCapabilityParameterName.Temperature,
+        LlmCapabilitySupportState.Unsupported,
+        omitWhenDefaultOnly: true,
+        source: "Observed400",
+        reason: "provider rejected non-default temperature");
+
+    var snapshot = LlmCapabilityResolver.Resolve(
+        scope,
+        [supportedRule, unsupportedRule]);
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Unsupported);
+  }
+
+  /// <summary>
+  ///     Ensures unmatched provider capabilities remain unknown.
+  /// </summary>
+  [Fact]
+  public void Resolve_WithUnknownSupport_RemainsConservative()
+  {
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.Gemini,
+        "Gemini",
+        "https://generativelanguage.googleapis.com",
+        "gemini-3-pro");
+
+    var snapshot = LlmCapabilityResolver.Resolve(
+        scope,
+        Array.Empty<LlmCapabilityRuleDefinition>());
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Unknown);
+  }
+}

--- a/Echoglossian.Tests/LlmCapabilityUiHelperTests.cs
+++ b/Echoglossian.Tests/LlmCapabilityUiHelperTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="LlmCapabilityUiHelperTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Cache;
+using Echoglossian.PluginUI.EngineConfigUI;
+using Echoglossian.Properties;
+using Echoglossian.Translators.Capabilities;
+
+using FluentAssertions;
+
+using System.Globalization;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers policy-driven temperature slider state for LLM engine UI.
+/// </summary>
+public sealed class LlmCapabilityUiHelperTests
+{
+    /// <summary>
+    ///     Ensures default-only temperature decisions disable the control and
+    ///     explain the provider restriction.
+    /// </summary>
+    [Fact]
+    public void GetTemperatureSliderState_WithDefaultOnlyDecision_DisablesControlAndExplainsWhy()
+    {
+        var originalCulture = Resources.Culture;
+        Resources.Culture = CultureInfo.GetCultureInfo("en-US");
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.ChatGPT,
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.6-terra");
+
+        try
+        {
+            var state = LlmCapabilityUiHelper.GetTemperatureSliderState(
+                scope,
+                0.1f,
+                1.0f);
+
+            state.IsEnabled.Should().BeFalse();
+            state.TooltipText.Should().Contain("default-only");
+        }
+        finally
+        {
+            Resources.Culture = originalCulture;
+        }
+    }
+
+    /// <summary>
+    ///     Ensures unknown temperature capability remains disabled instead of
+    ///     implying that the configured value will be sent.
+    /// </summary>
+    [Fact]
+    public void GetTemperatureSliderState_WithUnknownDecision_DisablesControlAndExplainsWhy()
+    {
+        var originalCulture = Resources.Culture;
+        Resources.Culture = CultureInfo.GetCultureInfo("en-US");
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.OpenRouter,
+            "OpenRouter",
+            "https://openrouter.ai/api/v1",
+            "unknown-model");
+
+        try
+        {
+            var state = LlmCapabilityUiHelper.GetTemperatureSliderState(
+                scope,
+                0.1f,
+                1.0f);
+
+            state.IsEnabled.Should().BeFalse();
+            state.MinValue.Should().Be(0.1f);
+            state.MaxValue.Should().Be(1.0f);
+            state.TooltipText.Should().Contain("unknown");
+        }
+        finally
+        {
+            Resources.Culture = originalCulture;
+        }
+    }
+
+    /// <summary>
+    ///     Ensures supported overlay ranges replace the engine fallback
+    ///     slider range.
+    /// </summary>
+    [Fact]
+    public void GetTemperatureSliderState_WithSupportedOverlay_UsesResolvedRange()
+    {
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.OpenRouter,
+            "OpenRouter",
+            "https://openrouter.ai/api/v1",
+            "range-model");
+        LlmCapabilityCacheManager.Clear();
+        LlmCapabilityCacheManager.PublishRule(
+            LlmCapabilityRuleDefinition.ExactModel(
+                "OpenRouter",
+                "OpenRouter",
+                "https://openrouter.ai/api/v1",
+                "range-model",
+                LlmCapabilityParameterName.Temperature,
+                LlmCapabilitySupportState.Supported,
+                minValue: 0.2f,
+                maxValue: 0.8f,
+                reason: "Provider metadata confirmed the temperature range."));
+
+        try
+        {
+            var state = LlmCapabilityUiHelper.GetTemperatureSliderState(
+                scope,
+                0.1f,
+                1.0f);
+
+            state.IsEnabled.Should().BeTrue();
+            state.MinValue.Should().Be(0.2f);
+            state.MaxValue.Should().Be(0.8f);
+            state.TooltipText.Should().BeEmpty();
+        }
+        finally
+        {
+            LlmCapabilityCacheManager.Clear();
+        }
+    }
+}

--- a/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
+++ b/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
@@ -454,6 +454,200 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     }
 
     /// <summary>
+    ///     Ensures the managed BattleTalk capture callback returns while database
+    ///     lookup remains suspended and publishes only after lookup completes.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_SuspendedDatabaseLookup_DoesNotBlockCaptureCallback()
+    {
+        using var lookupStarted = new ManualResetEventSlim();
+        using var releaseLookupPrefix = new ManualResetEventSlim();
+        using var captureReturned = new ManualResetEventSlim();
+        var lookupCompletion = new TaskCompletionSource<BattleTalkMessage?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var overlayPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var overlayUpdates = 0;
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            () =>
+            {
+                overlayUpdates++;
+                overlayPublished.TrySetResult(true);
+            },
+            findBattleTalkMessageAsync: async (_, cancellationToken) =>
+            {
+                lookupStarted.Set();
+                releaseLookupPrefix.Wait();
+                return await lookupCompletion.Task.WaitAsync(cancellationToken);
+            });
+        var english = new SourceClientLanguage("en", "en");
+        var captureAccepted = false;
+        var captureThread = new Thread(
+            () =>
+            {
+                captureAccepted = handler.TryQueueTranslation(
+                    "Alphinaud",
+                    "Understood.",
+                    english);
+                captureReturned.Set();
+            });
+
+        handler.InvalidateStateForSource(english);
+
+        try
+        {
+            captureThread.Start();
+
+            Assert.True(lookupStarted.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(captureReturned.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(captureAccepted);
+        }
+        finally
+        {
+            releaseLookupPrefix.Set();
+            captureThread.Join(TimeSpan.FromSeconds(1));
+        }
+
+        Assert.False(lookupCompletion.Task.IsCompleted);
+        Assert.True(handler.IsTranslationInFlight);
+        Assert.Equal(0, overlayUpdates);
+        Assert.False(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out _,
+            out _,
+            out _));
+
+        lookupCompletion.TrySetResult(CreateStoredBattleTalkMessage(
+            "Alphinaud",
+            "Understood.",
+            "Entendido."));
+        await overlayPublished.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(handler.IsTranslationInFlight);
+        Assert.Equal(1, overlayUpdates);
+        Assert.True(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out var translatedText,
+            out _,
+            out _));
+        Assert.Equal("Entendido.", translatedText);
+    }
+
+    /// <summary>
+    ///     Ensures a suspended BattleTalk database result for line A cannot
+    ///     publish over the newer managed state captured for line B.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_StaleDatabaseResult_CannotReplaceNewerManagedState()
+    {
+        var lookupStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lookupCompletion = new TaskCompletionSource<BattleTalkMessage?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var overlayUpdates = 0;
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            () => overlayUpdates++,
+            findBattleTalkMessageAsync: async (_, cancellationToken) =>
+            {
+                lookupStarted.TrySetResult(true);
+                return await lookupCompletion.Task.WaitAsync(cancellationToken);
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Line A",
+            english,
+            out var lineARequestId,
+            out var lineAOperation));
+        var lineAResolution = handler.ResolveTranslationAsync(
+            "Alphinaud",
+            "Line A",
+            lineARequestId,
+            english,
+            lineAOperation,
+            lineAOperation.CancellationToken);
+        await lookupStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Line B",
+            english,
+            out _,
+            out _));
+
+        lookupCompletion.TrySetResult(CreateStoredBattleTalkMessage(
+            "Alphinaud",
+            "Line A",
+            "Linha A"));
+        await lineAResolution;
+
+        Assert.True(handler.IsTranslationInFlight);
+        Assert.Equal(0, overlayUpdates);
+        Assert.False(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out _,
+            out _,
+            out _));
+    }
+
+    /// <summary>
+    ///     Ensures a BattleTalk speaker-name translation failure does not discard
+    ///     the translated dialogue body.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_SpeakerTranslationFailure_PublishesTranslatedBody()
+    {
+        var configuration = new Config
+        {
+            TranslateBattleTalk = true,
+            BattleTalkTranslationDisplayMode =
+                JournalTranslationDisplayMode.TooltipTranslation,
+            TranslateBattleTalkNpcNames = true,
+            Lang = 81,
+        };
+        BattleTalkMessage? insertedMessage = null;
+        var overlayPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(new BodySuccessSpeakerFailureTranslator()),
+            () => overlayPublished.TrySetResult(true),
+            configuration,
+            insertBattleTalkMessageAsync: (message, _) =>
+            {
+                insertedMessage = message;
+                return Task.FromResult(string.Empty);
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Understood.",
+            english));
+
+        await overlayPublished.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.NotNull(insertedMessage);
+        Assert.Equal("Entendido.", insertedMessage.TranslatedBattleTalkMessage);
+        Assert.Equal(string.Empty, insertedMessage.TranslatedSenderName);
+        Assert.True(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out var translatedName,
+            out var translatedText,
+            out _,
+            out _));
+        Assert.Equal(string.Empty, translatedName);
+        Assert.Equal("Entendido.", translatedText);
+    }
+
+    /// <summary>
     ///     Creates a Talk handler with native-free publication delegates.
     /// </summary>
     /// <param name="translationService">The translation service.</param>
@@ -518,21 +712,65 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     }
 
     /// <summary>
-    ///     Creates a BattleTalk handler for session-key assertions.
+    ///     Creates a BattleTalk handler with native-free publication delegates.
     /// </summary>
     /// <param name="translationService">The translation service.</param>
+    /// <param name="updateOverlay">The overlay publication callback.</param>
+    /// <param name="configuration">The optional handler configuration.</param>
+    /// <param name="insertBattleTalkMessageAsync">The persistence callback.</param>
+    /// <param name="findBattleTalkMessageAsync">The asynchronous lookup callback.</param>
     /// <returns>The configured handler.</returns>
     private static BattleTalkHandler CreateBattleTalkHandler(
-        TranslationService translationService)
+        TranslationService translationService,
+        Action? updateOverlay = null,
+        Config? configuration = null,
+        Func<BattleTalkMessage, CancellationToken, Task<string>>?
+            insertBattleTalkMessageAsync = null,
+        Func<BattleTalkMessage, CancellationToken, Task<BattleTalkMessage?>>?
+            findBattleTalkMessageAsync = null)
     {
         return new BattleTalkHandler(
-            new Config(),
+            configuration ?? new Config
+            {
+                TranslateBattleTalk = true,
+                BattleTalkTranslationDisplayMode =
+                    JournalTranslationDisplayMode.TooltipTranslation,
+                Lang = 81,
+            },
             translationService,
-            static _ => null,
-            static _ => Task.FromResult(string.Empty),
-            static (_, _, _) => { },
+            findBattleTalkMessageAsync ??
+            (static (_, _) => Task.FromResult<BattleTalkMessage?>(null)),
+            insertBattleTalkMessageAsync ??
+            (static (_, _) => Task.FromResult(string.Empty)),
+            (_, _, _) => updateOverlay?.Invoke(),
             static () => { },
             static text => text);
+    }
+
+    /// <summary>
+    ///     Creates one stored BattleTalk translation for async lookup tests.
+    /// </summary>
+    /// <param name="originalName">The original speaker name.</param>
+    /// <param name="originalText">The original dialogue text.</param>
+    /// <param name="translatedText">The translated dialogue text.</param>
+    /// <returns>The stored BattleTalk row.</returns>
+    private static BattleTalkMessage CreateStoredBattleTalkMessage(
+        string originalName,
+        string originalText,
+        string translatedText)
+    {
+        return new BattleTalkMessage(
+            originalName,
+            originalText,
+            "en",
+            "en",
+            string.Empty,
+            translatedText,
+            "pt-BR",
+            (int)PluginEntry.TransEngines.Google,
+            rtlLangTranslationImageData: null,
+            DateTime.UtcNow,
+            DateTime.UtcNow);
     }
 
     /// <summary>
@@ -594,6 +832,33 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         {
             this.requestStarted.TrySetResult(true);
             return this.completion.Task;
+        }
+    }
+
+    /// <summary>
+    ///     Translates dialogue text while failing speaker-name translation.
+    /// </summary>
+    private sealed class BodySuccessSpeakerFailureTranslator : ITranslator
+    {
+        /// <inheritdoc />
+        public string? Translate(
+            string text,
+            string sourceLanguage,
+            string targetLanguage)
+        {
+            return null;
+        }
+
+        /// <inheritdoc />
+        public Task<string?> TranslateAsync(
+            string text,
+            string sourceLanguage,
+            string targetLanguage)
+        {
+            return text == "Alphinaud"
+                ? Task.FromException<string?>(
+                    new InvalidOperationException("Speaker translation failed."))
+                : Task.FromResult<string?>("Entendido.");
         }
     }
 }

--- a/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
+++ b/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
@@ -295,14 +295,30 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     }
 
     /// <summary>
+    ///     Ensures unloading a Talk handler before any source capture safely
+    ///     disposes its owned operations.
+    /// </summary>
+    [Fact]
+    public void TalkHandler_FreshUnload_DoesNotThrow()
+    {
+        var handler = CreateTalkHandler(
+            CreateTranslationService(new ControlledTranslator()));
+
+        var unloadException = Record.Exception(handler.OnPluginUnload);
+
+        Assert.Null(unloadException);
+    }
+
+    /// <summary>
     ///     Ensures the managed Talk capture callback returns while database
     ///     lookup remains suspended and publishes only after lookup completes.
     /// </summary>
     [Fact]
     public async Task TalkHandler_SuspendedDatabaseLookup_DoesNotBlockCaptureCallback()
     {
-        var lookupStarted = new TaskCompletionSource<bool>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var lookupStarted = new ManualResetEventSlim();
+        using var releaseLookupPrefix = new ManualResetEventSlim();
+        using var captureReturned = new ManualResetEventSlim();
         var lookupCompletion = new TaskCompletionSource<TalkMessage?>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var overlayPublished = new TaskCompletionSource<bool>(
@@ -317,18 +333,37 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             },
             findTalkMessageAsync: async (_, cancellationToken) =>
             {
-                lookupStarted.TrySetResult(true);
+                lookupStarted.Set();
+                releaseLookupPrefix.Wait();
                 return await lookupCompletion.Task.WaitAsync(cancellationToken);
             });
         var english = new SourceClientLanguage("en", "en");
+        var captureAccepted = false;
+        var captureThread = new Thread(
+            () =>
+            {
+                captureAccepted = handler.TryQueueTranslation(
+                    "Alphinaud",
+                    "Understood.",
+                    english);
+                captureReturned.Set();
+            });
 
         handler.InvalidateStateForSource(english);
 
-        Assert.True(handler.TryQueueTranslation(
-            "Alphinaud",
-            "Understood.",
-            english));
-        await lookupStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        try
+        {
+            captureThread.Start();
+
+            Assert.True(lookupStarted.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(captureReturned.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(captureAccepted);
+        }
+        finally
+        {
+            releaseLookupPrefix.Set();
+            captureThread.Join(TimeSpan.FromSeconds(1));
+        }
 
         Assert.False(lookupCompletion.Task.IsCompleted);
         Assert.True(handler.IsTranslationInFlight);

--- a/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
+++ b/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
@@ -454,6 +454,100 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     }
 
     /// <summary>
+    ///     Ensures the first fresh Talk line forwards resolved interlocutor
+    ///     hints to a context-aware translator without requiring prior turns.
+    /// </summary>
+    [Fact]
+    public async Task TalkHandler_FirstFreshLine_PassesInterlocutorHintsToContextAwareTranslator()
+    {
+        var translator = new ContextAwareRecordingTranslator();
+        using var handler = CreateTalkHandler(
+            CreateTranslationService(translator),
+            resolveInterlocutorHintsAsync: static (_, _, _, _) =>
+                Task.FromResult(CreateInterlocutorHints()));
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+
+        var context = await translator.WaitForDialogueContextAsync();
+
+        Assert.Empty(context.PriorTurns);
+        Assert.Equal("Alphinaud", context.AddresseeHint);
+        Assert.Equal("male", context.AddresseeGenderHint);
+    }
+
+    /// <summary>
+    ///     Ensures a retired Talk source generation cancels the pending
+    ///     interlocutor-hint resolution before it can call the translator.
+    /// </summary>
+    [Fact]
+    public async Task TalkHandler_RetiredScope_CancelsPendingInterlocutorHintResolution()
+    {
+        var resolutionStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = CreateTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            resolveInterlocutorHintsAsync: async (_, _, _, cancellationToken) =>
+            {
+                resolutionStarted.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                    when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult(true);
+                    throw;
+                }
+
+                return CreateInterlocutorHints();
+            });
+        var english = new SourceClientLanguage("en", "en");
+        var german = new SourceClientLanguage("de", "de");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+        await resolutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        handler.InvalidateStateForSource(german);
+
+        Assert.True(await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    /// <summary>
+    ///     Ensures a reusable Talk database row bypasses interlocutor-hint
+    ///     resolution entirely.
+    /// </summary>
+    [Fact]
+    public async Task TalkHandler_ReusedDatabaseTranslation_DoesNotResolveInterlocutorHints()
+    {
+        var resolverCalls = 0;
+        var overlayPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = CreateTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            () => overlayPublished.TrySetResult(true),
+            findTalkMessageAsync: static (_, _) => Task.FromResult<TalkMessage?>(
+                CreateStoredTalkMessage("Krile", "Stay close.", "Fique perto.")),
+            resolveInterlocutorHintsAsync: (_, _, _, _) =>
+            {
+                resolverCalls++;
+                return Task.FromResult(CreateInterlocutorHints());
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+        await overlayPublished.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(0, resolverCalls);
+    }
+
+    /// <summary>
     ///     Ensures the managed BattleTalk capture callback returns while database
     ///     lookup remains suspended and publishes only after lookup completes.
     /// </summary>
@@ -595,6 +689,63 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             out _,
             out _,
             out _));
+    }
+
+    /// <summary>
+    ///     Ensures the first fresh BattleTalk line forwards resolved
+    ///     interlocutor hints to a context-aware translator without requiring
+    ///     prior turns.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_FirstFreshLine_PassesInterlocutorHintsToContextAwareTranslator()
+    {
+        var translator = new ContextAwareRecordingTranslator();
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(translator),
+            resolveInterlocutorHintsAsync: static (_, _, _, _) =>
+                Task.FromResult(CreateInterlocutorHints()));
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+
+        var context = await translator.WaitForDialogueContextAsync();
+
+        Assert.Empty(context.PriorTurns);
+        Assert.Equal("Alphinaud", context.AddresseeHint);
+        Assert.Equal("male", context.AddresseeGenderHint);
+    }
+
+    /// <summary>
+    ///     Ensures a reusable BattleTalk database row bypasses
+    ///     interlocutor-hint resolution entirely.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_ReusedDatabaseTranslation_DoesNotResolveInterlocutorHints()
+    {
+        var resolverCalls = 0;
+        var overlayPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            () => overlayPublished.TrySetResult(true),
+            findBattleTalkMessageAsync: static (_, _) =>
+                Task.FromResult<BattleTalkMessage?>(CreateStoredBattleTalkMessage(
+                    "Krile",
+                    "Stay close.",
+                    "Fique perto.")),
+            resolveInterlocutorHintsAsync: (_, _, _, _) =>
+            {
+                resolverCalls++;
+                return Task.FromResult(CreateInterlocutorHints());
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+        await overlayPublished.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(0, resolverCalls);
     }
 
     /// <summary>
@@ -823,7 +974,9 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         Func<TalkMessage, CancellationToken, Task<string>>?
             insertTalkMessageWithCancellationAsync = null,
         Func<TalkMessage, CancellationToken, Task<TalkMessage?>>?
-            findTalkMessageAsync = null)
+            findTalkMessageAsync = null,
+        Func<string, string, SourceClientLanguage, CancellationToken,
+            Task<DialogueInterlocutorHints>>? resolveInterlocutorHintsAsync = null)
     {
         return new TalkHandler(
             configuration ?? new Config
@@ -842,6 +995,8 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             (_, _, _) => updateOverlay?.Invoke(),
             clearOverlay ?? (static () => { }),
             static text => text,
+            resolveInterlocutorHintsAsync ??
+            (static (_, _, _, _) => Task.FromResult(default(DialogueInterlocutorHints))),
             restoreNativeMutation: static () => { });
     }
 
@@ -887,7 +1042,9 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         Func<BattleTalkMessage, CancellationToken, Task<string>>?
             insertBattleTalkMessageAsync = null,
         Func<BattleTalkMessage, CancellationToken, Task<BattleTalkMessage?>>?
-            findBattleTalkMessageAsync = null)
+            findBattleTalkMessageAsync = null,
+        Func<string, string, SourceClientLanguage, CancellationToken,
+            Task<DialogueInterlocutorHints>>? resolveInterlocutorHintsAsync = null)
     {
         return new BattleTalkHandler(
             configuration ?? new Config
@@ -904,7 +1061,9 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             (static (_, _) => Task.FromResult(string.Empty)),
             (_, _, _) => updateOverlay?.Invoke(),
             static () => { },
-            static text => text);
+            static text => text,
+            resolveInterlocutorHintsAsync ??
+            (static (_, _, _, _) => Task.FromResult(default(DialogueInterlocutorHints))));
     }
 
     /// <summary>
@@ -945,6 +1104,22 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             static text => text,
             translator,
             translationEngine: (int)PluginEntry.TransEngines.Google);
+    }
+
+    /// <summary>
+    ///     Creates the fixed fresh-line hints used by handler context tests.
+    /// </summary>
+    /// <returns>The resolved interlocutor hints.</returns>
+    private static DialogueInterlocutorHints CreateInterlocutorHints()
+    {
+        return new DialogueInterlocutorHints(
+            "npc",
+            "female",
+            "Alphinaud",
+            "npc",
+            "male",
+            "QuestSheetDerived",
+            "2");
     }
 
     /// <summary>
@@ -992,6 +1167,56 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         {
             this.requestStarted.TrySetResult(true);
             return this.completion.Task;
+        }
+    }
+
+    /// <summary>
+    ///     Records the dialogue context passed to the context-aware translation
+    ///     contract for a fresh line.
+    /// </summary>
+    private sealed class ContextAwareRecordingTranslator :
+        ITranslator,
+        IDialogueContextAwareTranslator
+    {
+        private readonly TaskCompletionSource<DialogueTranslationContext> context = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <inheritdoc />
+        public string? Translate(
+            string text,
+            string sourceLanguage,
+            string targetLanguage)
+        {
+            return null;
+        }
+
+        /// <inheritdoc />
+        public Task<string?> TranslateAsync(
+            string text,
+            string sourceLanguage,
+            string targetLanguage)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        /// <inheritdoc />
+        public Task<string?> TranslateAsync(
+            string text,
+            string sourceLanguage,
+            string targetLanguage,
+            DialogueTranslationContext dialogueContext)
+        {
+            this.context.TrySetResult(dialogueContext);
+            return Task.FromResult<string?>("Fique perto.");
+        }
+
+        /// <summary>
+        ///     Waits for the first context-aware dialogue translation request.
+        /// </summary>
+        /// <returns>The captured dialogue context.</returns>
+        public Task<DialogueTranslationContext> WaitForDialogueContextAsync()
+        {
+            return this.context.Task;
         }
     }
 

--- a/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
+++ b/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
@@ -29,6 +29,7 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     /// </summary>
     public NativeDialogueHandlerLifecycleTests()
     {
+        DialogueTranslationSessionStore.Clear();
         this.originalLanguageInt = PluginEntry.LanguageInt;
         this.originalLanguages = PluginEntry.LangDict;
         PluginEntry.LanguageInt = 81;
@@ -52,6 +53,7 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
+        DialogueTranslationSessionStore.Clear();
         PluginEntry.LanguageInt = this.originalLanguageInt;
         PluginEntry.LangDict = this.originalLanguages;
     }
@@ -478,6 +480,31 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     }
 
     /// <summary>
+    ///     Ensures auxiliary Talk metadata failures fall back to an empty hint
+    ///     set without aborting the normal dialogue translation.
+    /// </summary>
+    [Fact]
+    public async Task TalkHandler_InterlocutorResolverFailure_ContinuesWithoutHints()
+    {
+        var translator = new ContextAwareRecordingTranslator();
+        using var handler = CreateTalkHandler(
+            CreateTranslationService(translator),
+            resolveInterlocutorHintsAsync: static (_, _, _, _) =>
+                Task.FromException<DialogueInterlocutorHints>(
+                    new InvalidOperationException("Metadata lookup failed.")));
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+
+        var context = await translator.WaitForDialogueContextAsync()
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Null(context.AddresseeHint);
+        Assert.Null(context.MetadataProvenance);
+    }
+
+    /// <summary>
     ///     Ensures a retired Talk source generation cancels the pending
     ///     interlocutor-hint resolution before it can call the translator.
     /// </summary>
@@ -714,6 +741,31 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         Assert.Empty(context.PriorTurns);
         Assert.Equal("Alphinaud", context.AddresseeHint);
         Assert.Equal("male", context.AddresseeGenderHint);
+    }
+
+    /// <summary>
+    ///     Ensures auxiliary BattleTalk metadata failures fall back to an empty
+    ///     hint set without aborting the normal dialogue translation.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_InterlocutorResolverFailure_ContinuesWithoutHints()
+    {
+        var translator = new ContextAwareRecordingTranslator();
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(translator),
+            resolveInterlocutorHintsAsync: static (_, _, _, _) =>
+                Task.FromException<DialogueInterlocutorHints>(
+                    new InvalidOperationException("Metadata lookup failed.")));
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation("Krile", "Stay close.", english));
+
+        var context = await translator.WaitForDialogueContextAsync()
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Null(context.AddresseeHint);
+        Assert.Null(context.MetadataProvenance);
     }
 
     /// <summary>
@@ -1119,7 +1171,7 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             "npc",
             "male",
             "QuestSheetDerived",
-            "2");
+            2);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
+++ b/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
@@ -598,6 +598,166 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
     }
 
     /// <summary>
+    ///     Ensures a BattleTalk callback completing after source invalidation
+    ///     cannot republish stale overlay output.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_StaleAsyncCallback_CannotRepublish()
+    {
+        var translator = new ControlledTranslator();
+        var overlayUpdates = 0;
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(translator),
+            () => overlayUpdates++);
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Understood.",
+            english,
+            out var requestId,
+            out var sourceOperation));
+        var resolution = handler.ResolveTranslationAsync(
+            "Alphinaud",
+            "Understood.",
+            requestId,
+            english,
+            sourceOperation,
+            sourceOperation.CancellationToken);
+        await translator.WaitForRequestAsync();
+
+        handler.InvalidateStateForSource(
+            new SourceClientLanguage("de", "de"));
+        translator.Complete("Entendido.");
+        await resolution;
+
+        Assert.Equal(0, overlayUpdates);
+    }
+
+    /// <summary>
+    ///     Ensures a BattleTalk completion captured under one target and
+    ///     policy does not persist or publish after the same source rebuilds
+    ///     under another full operation scope.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task BattleTalkHandler_TargetAndPolicyChange_RejectsInFlightCompletion()
+    {
+        var translator = new ControlledTranslator();
+        var configuration = new Config
+        {
+            TranslateBattleTalk = true,
+            BattleTalkTranslationDisplayMode =
+                JournalTranslationDisplayMode.TooltipTranslation,
+            Lang = 81,
+            ChosenTransEngine = 0,
+            TranslateAlreadyTranslatedTexts = false,
+        };
+        BattleTalkMessage? persistedMessage = null;
+        var overlayUpdates = 0;
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(translator),
+            () => overlayUpdates++,
+            configuration,
+            insertBattleTalkMessageAsync: (message, _) =>
+            {
+                persistedMessage = message;
+                return Task.FromResult(string.Empty);
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Understood.",
+            english,
+            out var requestId,
+            out var sourceOperation));
+        var resolution = handler.ResolveTranslationAsync(
+            "Alphinaud",
+            "Understood.",
+            requestId,
+            english,
+            sourceOperation,
+            sourceOperation.CancellationToken);
+        await translator.WaitForRequestAsync();
+
+        configuration.Lang = 82;
+        configuration.ChosenTransEngine = 8;
+        configuration.TranslateAlreadyTranslatedTexts = true;
+        handler.InvalidateStateForSource(english);
+        translator.Complete("Entendido.");
+        await resolution;
+
+        Assert.Null(persistedMessage);
+        Assert.Equal(0, overlayUpdates);
+        Assert.False(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out _,
+            out _,
+            out _));
+    }
+
+    /// <summary>
+    ///     Ensures source retirement cancels an in-progress BattleTalk write
+    ///     so a result cannot commit after its captured scope has changed.
+    /// </summary>
+    [Fact]
+    public async Task BattleTalkHandler_RetiredScope_CancelsPendingPersistence()
+    {
+        var translator = new ControlledTranslator();
+        var persistenceStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = CreateBattleTalkHandler(
+            CreateTranslationService(translator),
+            insertBattleTalkMessageAsync: async (_, cancellationToken) =>
+            {
+                persistenceStarted.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                    when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult(true);
+                    throw;
+                }
+
+                return string.Empty;
+            });
+        var english = new SourceClientLanguage("en", "en");
+        var german = new SourceClientLanguage("de", "de");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Understood.",
+            english,
+            out var requestId,
+            out var sourceOperation));
+        var resolution = handler.ResolveTranslationAsync(
+            "Alphinaud",
+            "Understood.",
+            requestId,
+            english,
+            sourceOperation,
+            sourceOperation.CancellationToken);
+        await translator.WaitForRequestAsync();
+        translator.Complete("Entendido.");
+        await persistenceStarted.Task;
+
+        handler.InvalidateStateForSource(german);
+        await resolution;
+
+        Assert.True(await cancellationObserved.Task);
+    }
+
+    /// <summary>
     ///     Ensures a BattleTalk speaker-name translation failure does not discard
     ///     the translated dialogue body.
     /// </summary>

--- a/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
+++ b/Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs
@@ -107,7 +107,8 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             "Understood.",
             requestId,
             english,
-            sourceOperation);
+            sourceOperation,
+            sourceOperation.CancellationToken);
         await translator.WaitForRequestAsync();
         translator.Complete("Entendido.");
         await resolution;
@@ -158,7 +159,8 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             "Understood.",
             requestId,
             english,
-            sourceOperation);
+            sourceOperation,
+            sourceOperation.CancellationToken);
         await translator.WaitForRequestAsync();
 
         handler.InvalidateStateForSource(
@@ -214,7 +216,8 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             "Understood.",
             requestId,
             english,
-            sourceOperation);
+            sourceOperation,
+            sourceOperation.CancellationToken);
         await translator.WaitForRequestAsync();
 
         configuration.Lang = 82;
@@ -279,7 +282,8 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
             "Understood.",
             requestId,
             english,
-            sourceOperation);
+            sourceOperation,
+            sourceOperation.CancellationToken);
         await translator.WaitForRequestAsync();
         translator.Complete("Entendido.");
         await persistenceStarted.Task;
@@ -288,6 +292,130 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         await resolution;
 
         Assert.True(await cancellationObserved.Task);
+    }
+
+    /// <summary>
+    ///     Ensures the managed Talk capture callback returns while database
+    ///     lookup remains suspended and publishes only after lookup completes.
+    /// </summary>
+    [Fact]
+    public async Task TalkHandler_SuspendedDatabaseLookup_DoesNotBlockCaptureCallback()
+    {
+        var lookupStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lookupCompletion = new TaskCompletionSource<TalkMessage?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var overlayPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var overlayUpdates = 0;
+        using var handler = CreateTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            () =>
+            {
+                overlayUpdates++;
+                overlayPublished.TrySetResult(true);
+            },
+            findTalkMessageAsync: async (_, cancellationToken) =>
+            {
+                lookupStarted.TrySetResult(true);
+                return await lookupCompletion.Task.WaitAsync(cancellationToken);
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Understood.",
+            english));
+        await lookupStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(lookupCompletion.Task.IsCompleted);
+        Assert.True(handler.IsTranslationInFlight);
+        Assert.Equal(0, overlayUpdates);
+        Assert.False(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out _,
+            out _,
+            out _));
+
+        lookupCompletion.TrySetResult(CreateStoredTalkMessage(
+            "Alphinaud",
+            "Understood.",
+            "Entendido."));
+        await overlayPublished.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(handler.IsTranslationInFlight);
+        Assert.Equal(1, overlayUpdates);
+        Assert.True(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out var translatedText,
+            out _,
+            out _));
+        Assert.Equal("Entendido.", translatedText);
+    }
+
+    /// <summary>
+    ///     Ensures a suspended database result for line A cannot publish over
+    ///     the newer managed state captured for line B.
+    /// </summary>
+    [Fact]
+    public async Task TalkHandler_StaleDatabaseResult_CannotReplaceNewerManagedState()
+    {
+        var lookupStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lookupCompletion = new TaskCompletionSource<TalkMessage?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var overlayUpdates = 0;
+        using var handler = CreateTalkHandler(
+            CreateTranslationService(new ControlledTranslator()),
+            () => overlayUpdates++,
+            findTalkMessageAsync: async (_, cancellationToken) =>
+            {
+                lookupStarted.TrySetResult(true);
+                return await lookupCompletion.Task.WaitAsync(cancellationToken);
+            });
+        var english = new SourceClientLanguage("en", "en");
+
+        handler.InvalidateStateForSource(english);
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Line A",
+            english,
+            out var lineARequestId,
+            out var lineAOperation));
+        var lineAResolution = handler.ResolveTranslationAsync(
+            "Alphinaud",
+            "Line A",
+            lineARequestId,
+            english,
+            lineAOperation,
+            lineAOperation.CancellationToken);
+        await lookupStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.True(handler.TryQueueTranslation(
+            "Alphinaud",
+            "Line B",
+            english,
+            out _,
+            out _));
+
+        lookupCompletion.TrySetResult(CreateStoredTalkMessage(
+            "Alphinaud",
+            "Line A",
+            "Linha A"));
+        await lineAResolution;
+
+        Assert.True(handler.IsTranslationInFlight);
+        Assert.Equal(0, overlayUpdates);
+        Assert.False(handler.TryGetCurrentResolvedTranslation(
+            english,
+            out _,
+            out _,
+            out _,
+            out _));
     }
 
     /// <summary>
@@ -304,27 +432,10 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
         Config? configuration = null,
         Func<TalkMessage, Task<string>>? insertTalkMessageAsync = null,
         Func<TalkMessage, CancellationToken, Task<string>>?
-            insertTalkMessageWithCancellationAsync = null)
+            insertTalkMessageWithCancellationAsync = null,
+        Func<TalkMessage, CancellationToken, Task<TalkMessage?>>?
+            findTalkMessageAsync = null)
     {
-        if (insertTalkMessageWithCancellationAsync != null)
-        {
-            return new TalkHandler(
-                configuration ?? new Config
-                {
-                    TranslateTalk = true,
-                    TalkTranslationDisplayMode =
-                        JournalTranslationDisplayMode.TooltipTranslation,
-                    Lang = 81,
-                },
-                translationService,
-                static _ => null,
-                insertTalkMessageWithCancellationAsync,
-                (_, _, _) => updateOverlay?.Invoke(),
-                clearOverlay ?? (static () => { }),
-                static text => text,
-                restoreNativeMutation: static () => { });
-        }
-
         return new TalkHandler(
             configuration ?? new Config
             {
@@ -334,12 +445,41 @@ public sealed class NativeDialogueHandlerLifecycleTests : IDisposable
                 Lang = 81,
             },
             translationService,
-            static _ => null,
-            insertTalkMessageAsync ?? (static _ => Task.FromResult(string.Empty)),
+            findTalkMessageAsync ??
+            (static (_, _) => Task.FromResult<TalkMessage?>(null)),
+            insertTalkMessageWithCancellationAsync ??
+            ((message, _) => insertTalkMessageAsync?.Invoke(message) ??
+                             Task.FromResult(string.Empty)),
             (_, _, _) => updateOverlay?.Invoke(),
             clearOverlay ?? (static () => { }),
             static text => text,
             restoreNativeMutation: static () => { });
+    }
+
+    /// <summary>
+    ///     Creates one stored Talk translation for async lookup tests.
+    /// </summary>
+    /// <param name="originalName">The original speaker name.</param>
+    /// <param name="originalText">The original dialogue text.</param>
+    /// <param name="translatedText">The translated dialogue text.</param>
+    /// <returns>The stored Talk row.</returns>
+    private static TalkMessage CreateStoredTalkMessage(
+        string originalName,
+        string originalText,
+        string translatedText)
+    {
+        return new TalkMessage(
+            originalName,
+            originalText,
+            "en",
+            "en",
+            string.Empty,
+            translatedText,
+            "pt-BR",
+            (int)PluginEntry.TransEngines.Google,
+            rtlLangTranslationImageData: null,
+            DateTime.UtcNow,
+            DateTime.UtcNow);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/OpenAIModelManagerTests.cs
+++ b/Echoglossian.Tests/OpenAIModelManagerTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using Echoglossian.Cache;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.OpenAI;
 using FluentAssertions;
 using Xunit;
@@ -15,6 +17,40 @@ namespace Echoglossian.Tests;
 /// </summary>
 public class OpenAIModelManagerTests
 {
+    /// <summary>
+    ///     Ensures successful model discovery promotes known family defaults
+    ///     to exact-model capability overlays.
+    /// </summary>
+    [Fact]
+    public void ApplyRefreshSuccess_WithKnownFamilyModel_PromotesExactModelOverlay()
+    {
+        this.WithTemporaryConfigurationDirectory(_ =>
+        {
+            OpenAIModelManager.ResetAllForTesting();
+
+            OpenAIModelManager.ApplyRefreshSuccess(
+                "OpenAI",
+                new DateTime(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc),
+                "OpenAI",
+                "https://api.openai.com/v1",
+                [
+                    new LlmTextModel(
+                        "gpt-5.6-terra",
+                        "GPT-5.6 Terra",
+                        true,
+                        false,
+                        false,
+                        false,
+                        false,
+                        "OpenAI"),
+                ]);
+
+            LlmCapabilityCacheManager.GetRuleDefinitions()
+                .Should()
+                .Contain(rule => rule.MatchValue == "gpt-5.6-terra");
+        });
+    }
+
     /// <summary>
     ///     Ensures official OpenAI and custom OpenAI-compatible model lists do
     ///     not overwrite each other inside the shared manager.
@@ -122,5 +158,30 @@ public class OpenAIModelManagerTests
         OpenAIModelManager.GetCurrentModelList("OpenAI-Compatible")
             .Should()
             .BeEquivalentTo(OpenAITextModelDefaults.PredefinedModels);
+    }
+
+    /// <summary>
+    ///     Runs an action with an isolated persisted capability database.
+    /// </summary>
+    /// <param name="action">The action that exercises the model manager.</param>
+    private void WithTemporaryConfigurationDirectory(Action<string> action)
+    {
+        var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var originalConfigDirectory = Echoglossian.ConfigDirectory;
+        Directory.CreateDirectory(configDir);
+        Echoglossian.ConfigDirectory = configDir;
+        LlmCapabilityCacheManager.Clear();
+
+        try
+        {
+            action(configDir);
+        }
+        finally
+        {
+            LlmCapabilityCacheManager.Clear();
+            Echoglossian.ConfigDirectory = originalConfigDirectory;
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            Directory.Delete(configDir, recursive: true);
+        }
     }
 }

--- a/Echoglossian.Tests/OwnedAsyncOperationSetTests.cs
+++ b/Echoglossian.Tests/OwnedAsyncOperationSetTests.cs
@@ -33,12 +33,54 @@ public class OwnedAsyncOperationSetTests
     }
 
     /// <summary>
+    ///     Ensures synchronous work before an operation's first await cannot
+    ///     block the thread that submits the operation.
+    /// </summary>
+    [Fact]
+    public void Run_SynchronousOperationPrefix_DoesNotBlockCaller()
+    {
+        using var operationStarted = new ManualResetEventSlim();
+        using var releaseOperation = new ManualResetEventSlim();
+        using var runReturned = new ManualResetEventSlim();
+        using var operations = new OwnedAsyncOperationSet();
+        var accepted = false;
+        var callerThread = new Thread(
+            () =>
+            {
+                accepted = operations.Run(
+                    _ =>
+                    {
+                        operationStarted.Set();
+                        releaseOperation.Wait();
+                        return Task.CompletedTask;
+                    });
+                runReturned.Set();
+            });
+
+        try
+        {
+            callerThread.Start();
+
+            Assert.True(operationStarted.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(runReturned.Wait(TimeSpan.FromSeconds(1)));
+            Assert.True(accepted);
+        }
+        finally
+        {
+            releaseOperation.Set();
+            callerThread.Join(TimeSpan.FromSeconds(1));
+        }
+    }
+
+    /// <summary>
     ///     Ensures disposal cancels the token supplied to active operations.
     /// </summary>
     /// <returns>A task that completes when cancellation is observed.</returns>
     [Fact]
     public async Task Dispose_CancelsActiveOperationToken()
     {
+        var operationStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var cancellationObserved = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var operations = new OwnedAsyncOperationSet();
@@ -49,10 +91,44 @@ public class OwnedAsyncOperationSetTests
                 {
                     using var registration = cancellationToken.Register(
                         () => cancellationObserved.TrySetResult(true));
+                    operationStarted.TrySetResult(true);
                     await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 }));
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
 
         operations.Dispose();
+
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    ///     Ensures cancellation supplied by an operation's source owner reaches
+    ///     the token passed to the queued operation.
+    /// </summary>
+    /// <returns>A task that completes when external cancellation is observed.</returns>
+    [Fact]
+    public async Task Run_ExternalCancellation_CancelsOperationToken()
+    {
+        var operationStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var externalTokenSource = new CancellationTokenSource();
+        using var operations = new OwnedAsyncOperationSet();
+
+        Assert.True(
+            operations.Run(
+                async cancellationToken =>
+                {
+                    using var registration = cancellationToken.Register(
+                        () => cancellationObserved.TrySetResult(true));
+                    operationStarted.TrySetResult(true);
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                },
+                externalTokenSource.Token));
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        externalTokenSource.Cancel();
 
         await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
     }
@@ -68,6 +144,8 @@ public class OwnedAsyncOperationSetTests
         var observedExceptions = new List<Exception>();
         var exceptionObserved = new TaskCompletionSource<Exception>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var registrationReady = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         using var operations = new OwnedAsyncOperationSet(
             exception =>
             {
@@ -81,8 +159,10 @@ public class OwnedAsyncOperationSetTests
                 {
                     cancellationToken.Register(
                         static () => throw new InvalidOperationException("callback boom"));
+                    registrationReady.TrySetResult(true);
                     return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 }));
+        await registrationReady.Task.WaitAsync(TimeSpan.FromSeconds(1));
 
         var disposeException = Record.Exception(operations.Dispose);
 

--- a/Echoglossian.Tests/OwnedAsyncOperationSetTests.cs
+++ b/Echoglossian.Tests/OwnedAsyncOperationSetTests.cs
@@ -58,6 +58,47 @@ public class OwnedAsyncOperationSetTests
     }
 
     /// <summary>
+    ///     Ensures a failing cancellation callback does not escape disposal
+    ///     and is reported through the injected error observer.
+    /// </summary>
+    /// <returns>A task that completes when the callback failure is observed.</returns>
+    [Fact]
+    public async Task Dispose_CancellationCallbackFails_ReportsErrorWithoutThrowing()
+    {
+        var observedExceptions = new List<Exception>();
+        var exceptionObserved = new TaskCompletionSource<Exception>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var operations = new OwnedAsyncOperationSet(
+            exception =>
+            {
+                observedExceptions.Add(exception);
+                exceptionObserved.TrySetResult(exception);
+            });
+
+        Assert.True(
+            operations.Run(
+                cancellationToken =>
+                {
+                    cancellationToken.Register(
+                        static () => throw new InvalidOperationException("callback boom"));
+                    return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }));
+
+        var disposeException = Record.Exception(operations.Dispose);
+
+        Assert.Null(disposeException);
+
+        var observedException = await exceptionObserved.Task.WaitAsync(
+            TimeSpan.FromSeconds(1));
+
+        var cancellationException = Assert.IsType<AggregateException>(observedException);
+        var callbackException = Assert.IsType<InvalidOperationException>(
+            Assert.Single(cancellationException.Flatten().InnerExceptions));
+        Assert.Equal("callback boom", callbackException.Message);
+        Assert.Single(observedExceptions);
+    }
+
+    /// <summary>
     ///     Ensures a faulted operation is reported once rather than escaping as
     ///     an unobserved task exception.
     /// </summary>

--- a/Echoglossian.Tests/OwnedAsyncOperationSetTests.cs
+++ b/Echoglossian.Tests/OwnedAsyncOperationSetTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="OwnedAsyncOperationSetTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.NativeUI.Helpers;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers ownership, cancellation, and error observation for background
+///     native UI operations.
+/// </summary>
+public class OwnedAsyncOperationSetTests
+{
+    /// <summary>
+    ///     Ensures starting a suspended operation does not wait for its
+    ///     completion on the caller's thread.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsBeforeSuspendedOperationCompletes()
+    {
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var operations = new OwnedAsyncOperationSet();
+
+        var accepted = operations.Run(_ => completion.Task);
+
+        Assert.True(accepted);
+        Assert.False(completion.Task.IsCompleted);
+    }
+
+    /// <summary>
+    ///     Ensures disposal cancels the token supplied to active operations.
+    /// </summary>
+    /// <returns>A task that completes when cancellation is observed.</returns>
+    [Fact]
+    public async Task Dispose_CancelsActiveOperationToken()
+    {
+        var cancellationObserved = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var operations = new OwnedAsyncOperationSet();
+
+        Assert.True(
+            operations.Run(
+                async cancellationToken =>
+                {
+                    using var registration = cancellationToken.Register(
+                        () => cancellationObserved.TrySetResult(true));
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }));
+
+        operations.Dispose();
+
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    ///     Ensures a faulted operation is reported once rather than escaping as
+    ///     an unobserved task exception.
+    /// </summary>
+    /// <returns>A task that completes when the unexpected exception is observed.</returns>
+    [Fact]
+    public async Task Run_UnexpectedException_InvokesErrorObserverOnce()
+    {
+        var observedExceptions = new List<Exception>();
+        var exceptionObserved = new TaskCompletionSource<Exception>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var operations = new OwnedAsyncOperationSet(
+            exception =>
+            {
+                observedExceptions.Add(exception);
+                exceptionObserved.TrySetResult(exception);
+            });
+
+        Assert.True(
+            operations.Run(
+                _ => Task.FromException(new InvalidOperationException("boom"))));
+
+        var observedException = await exceptionObserved.Task.WaitAsync(
+            TimeSpan.FromSeconds(1));
+
+        Assert.IsType<InvalidOperationException>(observedException);
+        Assert.Equal("boom", observedException.Message);
+        Assert.Single(observedExceptions);
+    }
+
+    /// <summary>
+    ///     Ensures disposal prevents the set from accepting further work.
+    /// </summary>
+    [Fact]
+    public void Run_AfterDispose_RejectsOperation()
+    {
+        using var operations = new OwnedAsyncOperationSet();
+        operations.Dispose();
+
+        var accepted = operations.Run(_ => Task.CompletedTask);
+
+        Assert.False(accepted);
+    }
+}

--- a/Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using System.Reflection;
+
 using Xunit;
 
 namespace Echoglossian.Tests;
@@ -113,6 +115,76 @@ public class QuestDialogueMetadataDerivationTests
             QuestContentHash.ComputeLine("key", "text"),
             QuestContentHash.ComputeLine("key", "text"));
         Assert.Matches("^[0-9a-f]{16}$", first.SourceTextHash);
+    }
+
+    /// <summary>
+    /// Ensures cancellation is observed while filtering source-ordered quest
+    /// dialogue rows.
+    /// </summary>
+    [Fact]
+    public void ReadDialogueEntries_CancelledTraversal_ThrowsOperationCanceledException()
+    {
+        var method = typeof(QuestDialogueMetadataDerivation).GetMethod(
+            "ReadDialogueEntries",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            types:
+            [
+                typeof(QuestProgressSnapshot),
+                typeof(IReadOnlyList<QuestDialogueSheetEntry>),
+                typeof(CancellationToken),
+            ],
+            modifiers: null);
+        Assert.NotNull(method);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(
+            null,
+            [this.CreateSnapshot(), Array.Empty<QuestDialogueSheetEntry>(), cancellationTokenSource.Token]));
+
+        Assert.IsType<OperationCanceledException>(exception.InnerException);
+    }
+
+    /// <summary>
+    /// Ensures cancellation is observed before metadata pairing traverses the
+    /// source-ordered dialogue rows.
+    /// </summary>
+    [Fact]
+    public void BuildEntries_CancelledTraversal_ThrowsOperationCanceledException()
+    {
+        var method = typeof(QuestDialogueMetadataDerivation).GetMethod(
+            "BuildEntries",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            types:
+            [
+                typeof(QuestProgressSnapshot),
+                typeof(IReadOnlyList<QuestDialogueSheetEntry>),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(DateTime),
+                typeof(CancellationToken),
+            ],
+            modifiers: null);
+        Assert.NotNull(method);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(
+            null,
+            [
+                this.CreateSnapshot(),
+                Array.Empty<QuestDialogueSheetEntry>(),
+                "en",
+                "2026.08.10.0000",
+                "v1",
+                DateTime.UnixEpoch,
+                cancellationTokenSource.Token,
+            ]));
+
+        Assert.IsType<OperationCanceledException>(exception.InnerException);
     }
 
     /// <summary>

--- a/Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs
@@ -13,32 +13,61 @@ namespace Echoglossian.Tests;
 public class QuestDialogueMetadataDerivationTests
 {
     /// <summary>
+    ///     Ensures the reader carries SEQ boundary state into retained rows so
+    ///     the builder preserves multi-sequence metadata without SEQ rows.
+    /// </summary>
+    [Fact]
+    public void ReadDialogueEntries_MultiSequenceRows_PreservesSequenceForBuildEntries()
+    {
+        var snapshot = this.CreateSnapshot();
+        QuestDialogueSheetEntry[] rawRows =
+        [
+            new("LucKbb111_03263_SEQ_00", "Phase zero", 0, 0),
+            new("LucKbb111_03263_NPC_NAME_000_000", "Oriel", 1, 0),
+            new("LucKbb111_03263_NPC_000_000", "Welcome, adventurer.", 2, 0),
+            new("LucKbb111_03263_SEQ_01", "Phase one", 3, 0),
+            new("LucKbb111_03263_NPC_NAME_001_000", "Radovan", 4, 0),
+            new("LucKbb111_03263_NPC_001_000", "Stay alert.", 5, 0),
+        ];
+
+        var dialogueEntries = QuestDialogueMetadataDerivation.ReadDialogueEntries(
+            snapshot,
+            rawRows);
+        var metadata = QuestDialogueMetadataDerivation.BuildEntries(
+            snapshot,
+            dialogueEntries,
+            sourceLanguageCode: "en",
+            gameVersion: "2026.08.10.0000",
+            derivationVersion: "v1",
+            DateTime.UnixEpoch);
+
+        Assert.DoesNotContain(
+            dialogueEntries,
+            entry => entry.RowKey.Contains("_SEQ_", StringComparison.Ordinal));
+        Assert.Equal((ushort)0, dialogueEntries[0].QuestSequence);
+        Assert.Equal((ushort)1, dialogueEntries[^1].QuestSequence);
+        Assert.Equal([0, 1], metadata.Select(entry => (int)entry.QuestSequence));
+    }
+
+    /// <summary>
     ///     Ensures paired NAME rows identify speakers, SEQ rows delimit turns,
     ///     and neighboring named turns produce deterministic addressee hints.
     /// </summary>
     [Fact]
     public void BuildEntries_PairedDialogueRows_DerivesDeterministicMetadata()
     {
-        var snapshot = new QuestProgressSnapshot(
-            QuestId: 68799,
-            QuestSequence: 0,
-            QuestName: "For Better or Worse",
-            QuestSheetName: "quest/032/LucKbb111_03263",
-            QuestSteps: [],
-            QuestSeqTexts: [],
-            QuestSystemTexts: [],
-            ContentHash: "quest-content-hash");
+        var snapshot = this.CreateSnapshot();
         var observedAtUtc = DateTime.UnixEpoch;
         QuestDialogueSheetEntry[] rows =
         [
-            new("LucKbb111_03263_SEQ_00", "Phase zero", 0),
-            new("LucKbb111_03263_NPC_NAME_000_000", "Oriel", 1),
-            new("LucKbb111_03263_NPC_000_000", "Welcome, adventurer.", 2),
-            new("LucKbb111_03263_NPC_NAME_000_001", "Radovan", 3),
-            new("LucKbb111_03263_NPC_000_001", "We should leave.", 4),
-            new("LucKbb111_03263_SEQ_01", "Phase one", 5),
-            new("LucKbb111_03263_NPC_NAME_001_000", "Oriel", 6),
-            new("LucKbb111_03263_NPC_001_000", "Stay alert.", 7),
+            new("LucKbb111_03263_SEQ_00", "Phase zero", 0, 0),
+            new("LucKbb111_03263_NPC_NAME_000_000", "Oriel", 1, 0),
+            new("LucKbb111_03263_NPC_000_000", "Welcome, adventurer.", 2, 0),
+            new("LucKbb111_03263_NPC_NAME_000_001", "Radovan", 3, 0),
+            new("LucKbb111_03263_NPC_000_001", "We should leave.", 4, 0),
+            new("LucKbb111_03263_SEQ_01", "Phase one", 5, 1),
+            new("LucKbb111_03263_NPC_NAME_001_000", "Oriel", 6, 1),
+            new("LucKbb111_03263_NPC_001_000", "Stay alert.", 7, 1),
         ];
 
         var metadata = QuestDialogueMetadataDerivation.BuildEntries(
@@ -84,5 +113,22 @@ public class QuestDialogueMetadataDerivationTests
             QuestContentHash.ComputeLine("key", "text"),
             QuestContentHash.ComputeLine("key", "text"));
         Assert.Matches("^[0-9a-f]{16}$", first.SourceTextHash);
+    }
+
+    /// <summary>
+    ///     Creates the shared quest snapshot fixture.
+    /// </summary>
+    /// <returns>The fixed quest progress snapshot.</returns>
+    private QuestProgressSnapshot CreateSnapshot()
+    {
+        return new QuestProgressSnapshot(
+            QuestId: 68799,
+            QuestSequence: 0,
+            QuestName: "For Better or Worse",
+            QuestSheetName: "quest/032/LucKbb111_03263",
+            QuestSteps: [],
+            QuestSeqTexts: [],
+            QuestSystemTexts: [],
+            ContentHash: "quest-content-hash");
     }
 }

--- a/Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="QuestDialogueMetadataDerivationTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers deterministic speaker and addressee derivation from quest dialogue rows.
+/// </summary>
+public class QuestDialogueMetadataDerivationTests
+{
+    /// <summary>
+    ///     Ensures paired NAME rows identify speakers, SEQ rows delimit turns,
+    ///     and neighboring named turns produce deterministic addressee hints.
+    /// </summary>
+    [Fact]
+    public void BuildEntries_PairedDialogueRows_DerivesDeterministicMetadata()
+    {
+        var snapshot = new QuestProgressSnapshot(
+            QuestId: 68799,
+            QuestSequence: 0,
+            QuestName: "For Better or Worse",
+            QuestSheetName: "quest/032/LucKbb111_03263",
+            QuestSteps: [],
+            QuestSeqTexts: [],
+            QuestSystemTexts: [],
+            ContentHash: "quest-content-hash");
+        var observedAtUtc = DateTime.UnixEpoch;
+        QuestDialogueSheetEntry[] rows =
+        [
+            new("LucKbb111_03263_SEQ_00", "Phase zero", 0),
+            new("LucKbb111_03263_NPC_NAME_000_000", "Oriel", 1),
+            new("LucKbb111_03263_NPC_000_000", "Welcome, adventurer.", 2),
+            new("LucKbb111_03263_NPC_NAME_000_001", "Radovan", 3),
+            new("LucKbb111_03263_NPC_000_001", "We should leave.", 4),
+            new("LucKbb111_03263_SEQ_01", "Phase one", 5),
+            new("LucKbb111_03263_NPC_NAME_001_000", "Oriel", 6),
+            new("LucKbb111_03263_NPC_001_000", "Stay alert.", 7),
+        ];
+
+        var metadata = QuestDialogueMetadataDerivation.BuildEntries(
+            snapshot,
+            rows,
+            sourceLanguageCode: "en",
+            gameVersion: "2026.08.10.0000",
+            derivationVersion: "v1",
+            observedAtUtc);
+
+        Assert.Equal(3, metadata.Count);
+
+        var first = metadata[0];
+        Assert.Equal((ushort)0, first.QuestSequence);
+        Assert.Equal("LucKbb111_03263_NPC_000_000", first.SourceRowKey);
+        Assert.Equal("Oriel", first.SpeakerHint);
+        Assert.Equal("npc", first.SpeakerRoleHint);
+        Assert.Equal("Radovan", first.AddresseeHint);
+        Assert.Equal("npc", first.AddresseeRoleHint);
+        Assert.Equal(2, first.ConfidenceTier);
+        Assert.Equal("QuestSheetDerived", first.Provenance);
+        Assert.Equal("LucKbb111_03263", first.QuestSheetId);
+        Assert.Equal(snapshot.QuestSheetName, first.QuestTextSheetName);
+        Assert.Equal(
+            QuestContentHash.ComputeLine(first.SourceRowKey, "Welcome, adventurer."),
+            first.SourceTextHash);
+        Assert.Equal(observedAtUtc, first.CreatedAtUtc);
+        Assert.Equal(observedAtUtc, first.UpdatedAtUtc);
+
+        var second = metadata[1];
+        Assert.Equal((ushort)0, second.QuestSequence);
+        Assert.Equal("Radovan", second.SpeakerHint);
+        Assert.Equal("Oriel", second.AddresseeHint);
+        Assert.Equal(1, second.ConfidenceTier);
+
+        var third = metadata[2];
+        Assert.Equal((ushort)1, third.QuestSequence);
+        Assert.Equal("Oriel", third.SpeakerHint);
+        Assert.Empty(third.AddresseeHint);
+        Assert.Equal(0, third.ConfidenceTier);
+
+        Assert.Equal(
+            QuestContentHash.ComputeLine("key", "text"),
+            QuestContentHash.ComputeLine("key", "text"));
+        Assert.Matches("^[0-9a-f]{16}$", first.SourceTextHash);
+    }
+}

--- a/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
@@ -164,11 +164,11 @@ public class QuestDialogueMetadataPersistenceTests
     }
 
     /// <summary>
-    /// Ensures cancellation delivered at the commit boundary rolls back a
-    /// guarded metadata transaction without exposing its rows.
+    /// Ensures an older metadata batch that completes after a newer batch
+    /// cannot replace the current exact-key result.
     /// </summary>
     [Fact]
-    public async Task UpsertQuestDialogueMetadataBatchAsync_CancelledAtCommitBoundary_RollsBackRows()
+    public async Task UpsertQuestDialogueMetadataBatchAsync_OlderBatchCompletesLast_PreservesNewerRow()
     {
         var configDir = CreateTempConfigDirectory();
         var previousConfigDirectory = PluginEntry.ConfigDirectory;
@@ -183,21 +183,26 @@ public class QuestDialogueMetadataPersistenceTests
                 await context.Database.MigrateAsync();
             }
 
-            using var cancellationSource = new CancellationTokenSource();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(
-                () => plugin.UpsertQuestDialogueMetadataBatchAsync(
-                    [CreateRow()],
-                    () =>
-                    {
-                        cancellationSource.Cancel();
-                        return true;
-                    },
-                    cancellationSource.Token));
+            var olderObservedAtUtc = DateTime.UnixEpoch.AddMinutes(1);
+            var newerObservedAtUtc = DateTime.UnixEpoch.AddMinutes(2);
+            await plugin.UpsertQuestDialogueMetadataBatchAsync(
+                [CreateRow(
+                    speakerHint: "Current speaker",
+                    observedAtUtc: newerObservedAtUtc)],
+                CancellationToken.None);
+            await plugin.UpsertQuestDialogueMetadataBatchAsync(
+                [CreateRow(
+                    speakerHint: "Stale speaker",
+                    observedAtUtc: olderObservedAtUtc)],
+                CancellationToken.None);
 
-            await using var verification = new EchoglossianDbContext(configDir);
-            Assert.Empty(await verification.QuestDialogueMetadata
-                .AsNoTracking()
-                .ToListAsync());
+            var persisted = await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(),
+                CancellationToken.None);
+
+            Assert.NotNull(persisted);
+            Assert.Equal("Current speaker", persisted.SpeakerHint);
+            Assert.Equal(newerObservedAtUtc, persisted.UpdatedAtUtc);
         }
         finally
         {
@@ -216,8 +221,10 @@ public class QuestDialogueMetadataPersistenceTests
         string sourceRowKey = "TEXT_QUEST_001_SEQ_001",
         string sourceTextHash = "hash-001",
         string derivationVersion = "v1",
-        string speakerHint = "Speaker v1")
+        string speakerHint = "Speaker v1",
+        DateTime? observedAtUtc = null)
     {
+        var rowObservedAtUtc = observedAtUtc ?? DateTime.UnixEpoch;
         return new QuestDialogueMetadata
         {
             QuestId = 100,
@@ -236,8 +243,8 @@ public class QuestDialogueMetadataPersistenceTests
             Provenance = "quest-text",
             ConfidenceTier = 2,
             DerivationVersion = derivationVersion,
-            CreatedAtUtc = DateTime.UnixEpoch,
-            UpdatedAtUtc = DateTime.UnixEpoch,
+            CreatedAtUtc = rowObservedAtUtc,
+            UpdatedAtUtc = rowObservedAtUtc,
         };
     }
 

--- a/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
@@ -164,6 +164,49 @@ public class QuestDialogueMetadataPersistenceTests
     }
 
     /// <summary>
+    /// Ensures cancellation delivered at the commit boundary rolls back a
+    /// guarded metadata transaction without exposing its rows.
+    /// </summary>
+    [Fact]
+    public async Task UpsertQuestDialogueMetadataBatchAsync_CancelledAtCommitBoundary_RollsBackRows()
+    {
+        var configDir = CreateTempConfigDirectory();
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        PluginEntry.ConfigDirectory = configDir + Path.DirectorySeparatorChar;
+        var plugin = (PluginEntry)RuntimeHelpers.GetUninitializedObject(
+            typeof(PluginEntry));
+
+        try
+        {
+            await using (var context = new EchoglossianDbContext(configDir))
+            {
+                await context.Database.MigrateAsync();
+            }
+
+            using var cancellationSource = new CancellationTokenSource();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => plugin.UpsertQuestDialogueMetadataBatchAsync(
+                    [CreateRow()],
+                    () =>
+                    {
+                        cancellationSource.Cancel();
+                        return true;
+                    },
+                    cancellationSource.Token));
+
+            await using var verification = new EchoglossianDbContext(configDir);
+            Assert.Empty(await verification.QuestDialogueMetadata
+                .AsNoTracking()
+                .ToListAsync());
+        }
+        finally
+        {
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
     ///     Creates one metadata row with the canonical exact-match values.
     /// </summary>
     private static QuestDialogueMetadata CreateRow(

--- a/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="QuestDialogueMetadataPersistenceTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.EFCoreSqlite;
+using Echoglossian.EFCoreSqlite.Models.Journal;
+using Microsoft.EntityFrameworkCore;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+using PluginEntry = Echoglossian.Echoglossian;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers exact-row persistence and reuse for quest dialogue metadata.
+/// </summary>
+public class QuestDialogueMetadataPersistenceTests
+{
+    /// <summary>
+    ///     Ensures exact-row lookup rejects every logical-key mismatch and an
+    ///     upsert replaces its existing logical row rather than duplicating it.
+    /// </summary>
+    [Fact]
+    public async Task QuestDialogueMetadata_UsesExactLogicalKeyAndReplacesExistingRow()
+    {
+        var configDir = CreateTempConfigDirectory();
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        PluginEntry.ConfigDirectory = configDir + Path.DirectorySeparatorChar;
+        var plugin = (PluginEntry)RuntimeHelpers.GetUninitializedObject(
+            typeof(PluginEntry));
+
+        try
+        {
+            await using (var context = new EchoglossianDbContext(configDir))
+            {
+                await context.Database.MigrateAsync();
+                await context.QuestDialogueMetadata.AddRangeAsync(
+                    CreateRow(),
+                    CreateRow(questSequence: 2),
+                    CreateRow(sourceLanguageCode: "ja"),
+                    CreateRow(gameVersion: "2026.08.10.0001"),
+                    CreateRow(sourceRowKey: "TEXT_QUEST_001_SEQ_002"),
+                    CreateRow(sourceTextHash: "hash-002"),
+                    CreateRow(derivationVersion: "v2", speakerHint: "Speaker v2"));
+                await context.SaveChangesAsync();
+            }
+
+            var lookup = CreateLookup();
+            var match = await plugin.FindQuestDialogueMetadataAsync(
+                lookup,
+                CancellationToken.None);
+
+            Assert.NotNull(match);
+            Assert.Equal("Speaker v1", match.SpeakerHint);
+            var derivationVersionMatch = await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(derivationVersion: "v2"),
+                CancellationToken.None);
+            Assert.NotNull(derivationVersionMatch);
+            Assert.Equal("Speaker v2", derivationVersionMatch.SpeakerHint);
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(questSequence: 99),
+                CancellationToken.None));
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(sourceLanguageCode: "fr"),
+                CancellationToken.None));
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(gameVersion: "2026.08.10.9999"),
+                CancellationToken.None));
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(sourceRowKey: "TEXT_QUEST_001_SEQ_999"),
+                CancellationToken.None));
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(sourceTextHash: "hash-999"),
+                CancellationToken.None));
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(derivationVersion: "v999"),
+                CancellationToken.None));
+            Assert.Null(await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(sourceRowKey: string.Empty),
+                CancellationToken.None));
+
+            await plugin.UpsertQuestDialogueMetadataBatchAsync(
+                [
+                    CreateRow(speakerHint: "Speaker updated"),
+                    CreateRow(derivationVersion: "v2", speakerHint: "Speaker v2 updated"),
+                ],
+                CancellationToken.None);
+
+            await using var verification = new EchoglossianDbContext(configDir);
+            var rows = await verification.QuestDialogueMetadata
+                .AsNoTracking()
+                .Where(row => row.QuestId == 100 &&
+                              row.QuestSequence == 1 &&
+                              row.SourceLanguageCode == "en" &&
+                              row.GameVersion == "2026.08.10.0000" &&
+                              row.SourceRowKey == "TEXT_QUEST_001_SEQ_001" &&
+                              row.SourceTextHash == "hash-001" &&
+                              row.DerivationVersion == "v1")
+                .ToListAsync();
+            var updated = Assert.Single(rows);
+            Assert.Equal("Speaker updated", updated.SpeakerHint);
+            Assert.Equal("v1", updated.DerivationVersion);
+            var updatedDerivationVersionMatch =
+                await plugin.FindQuestDialogueMetadataAsync(
+                    CreateLookup(derivationVersion: "v2"),
+                    CancellationToken.None);
+            Assert.NotNull(updatedDerivationVersionMatch);
+            Assert.Equal("Speaker v2 updated", updatedDerivationVersionMatch.SpeakerHint);
+        }
+        finally
+        {
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
+    ///     Creates one metadata row with the canonical exact-match values.
+    /// </summary>
+    private static QuestDialogueMetadata CreateRow(
+        ushort questSequence = 1,
+        string sourceLanguageCode = "en",
+        string gameVersion = "2026.08.10.0000",
+        string sourceRowKey = "TEXT_QUEST_001_SEQ_001",
+        string sourceTextHash = "hash-001",
+        string derivationVersion = "v1",
+        string speakerHint = "Speaker v1")
+    {
+        return new QuestDialogueMetadata
+        {
+            QuestId = 100,
+            QuestSequence = questSequence,
+            SourceLanguageCode = sourceLanguageCode,
+            GameVersion = gameVersion,
+            QuestSheetId = "001",
+            QuestTextSheetName = "quest/001/Quest001",
+            SourceRowKey = sourceRowKey,
+            SourceTextHash = sourceTextHash,
+            SourceTextPreview = "A precise quest dialogue line.",
+            SpeakerHint = speakerHint,
+            AddresseeHint = "Player",
+            SpeakerRoleHint = "Quest giver",
+            AddresseeRoleHint = "Adventurer",
+            Provenance = "quest-text",
+            ConfidenceTier = 2,
+            DerivationVersion = derivationVersion,
+            CreatedAtUtc = DateTime.UnixEpoch,
+            UpdatedAtUtc = DateTime.UnixEpoch,
+        };
+    }
+
+    /// <summary>
+    ///     Creates one exact-row lookup with the canonical values.
+    /// </summary>
+    private static QuestDialogueMetadataLookup CreateLookup(
+        ushort questSequence = 1,
+        string sourceLanguageCode = "en",
+        string gameVersion = "2026.08.10.0000",
+        string sourceRowKey = "TEXT_QUEST_001_SEQ_001",
+        string sourceTextHash = "hash-001",
+        string derivationVersion = "v1")
+    {
+        return new QuestDialogueMetadataLookup(
+            100,
+            questSequence,
+            sourceLanguageCode,
+            gameVersion,
+            sourceRowKey,
+            sourceTextHash,
+            derivationVersion);
+    }
+
+    /// <summary>
+    ///     Creates an isolated temporary configuration directory.
+    /// </summary>
+    /// <returns>The created configuration directory path.</returns>
+    private static string CreateTempConfigDirectory()
+    {
+        var configDir = Path.Combine(
+            Path.GetTempPath(),
+            "Echoglossian.Tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDir);
+        return configDir;
+    }
+
+    /// <summary>
+    ///     Deletes an isolated temporary directory when it is no longer used.
+    /// </summary>
+    /// <param name="path">The directory path to delete.</param>
+    private static void TryDeleteDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
@@ -212,6 +212,97 @@ public class QuestDialogueMetadataPersistenceTests
     }
 
     /// <summary>
+    /// Ensures duplicate logical keys in one batch select the row with the
+    /// newest update timestamp rather than the last input row.
+    /// </summary>
+    [Fact]
+    public async Task UpsertQuestDialogueMetadataBatchAsync_InBatchDuplicateKey_PreservesNewestRow()
+    {
+        var configDir = CreateTempConfigDirectory();
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        PluginEntry.ConfigDirectory = configDir + Path.DirectorySeparatorChar;
+        var plugin = (PluginEntry)RuntimeHelpers.GetUninitializedObject(typeof(PluginEntry));
+
+        try
+        {
+            await using (var context = new EchoglossianDbContext(configDir))
+            {
+                await context.Database.MigrateAsync();
+            }
+
+            var olderObservedAtUtc = DateTime.UnixEpoch.AddMinutes(1);
+            var newerObservedAtUtc = DateTime.UnixEpoch.AddMinutes(2);
+            await plugin.UpsertQuestDialogueMetadataBatchAsync(
+                [
+                    CreateRow(speakerHint: "Newest speaker", observedAtUtc: newerObservedAtUtc),
+                    CreateRow(speakerHint: "Older trailing speaker", observedAtUtc: olderObservedAtUtc),
+                ],
+                CancellationToken.None);
+
+            var persisted = await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(),
+                CancellationToken.None);
+
+            Assert.NotNull(persisted);
+            Assert.Equal("Newest speaker", persisted.SpeakerHint);
+            Assert.Equal(newerObservedAtUtc, persisted.UpdatedAtUtc);
+        }
+        finally
+        {
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
+    /// Ensures a conflict update retains the earliest creation timestamp while
+    /// accepting the newer exact-key row contents.
+    /// </summary>
+    [Fact]
+    public async Task UpsertQuestDialogueMetadataBatchAsync_ConflictUpdate_PreservesEarliestCreatedAtUtc()
+    {
+        var configDir = CreateTempConfigDirectory();
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        PluginEntry.ConfigDirectory = configDir + Path.DirectorySeparatorChar;
+        var plugin = (PluginEntry)RuntimeHelpers.GetUninitializedObject(typeof(PluginEntry));
+
+        try
+        {
+            await using (var context = new EchoglossianDbContext(configDir))
+            {
+                await context.Database.MigrateAsync();
+            }
+
+            var createdAtUtc = DateTime.UnixEpoch.AddMinutes(1);
+            await plugin.UpsertQuestDialogueMetadataBatchAsync(
+                [CreateRow(
+                    speakerHint: "Initial speaker",
+                    observedAtUtc: DateTime.UnixEpoch.AddMinutes(2),
+                    createdAtUtc: createdAtUtc)],
+                CancellationToken.None);
+            await plugin.UpsertQuestDialogueMetadataBatchAsync(
+                [CreateRow(
+                    speakerHint: "Updated speaker",
+                    observedAtUtc: DateTime.UnixEpoch.AddMinutes(3),
+                    createdAtUtc: DateTime.UnixEpoch.AddMinutes(2))],
+                CancellationToken.None);
+
+            var persisted = await plugin.FindQuestDialogueMetadataAsync(
+                CreateLookup(),
+                CancellationToken.None);
+
+            Assert.NotNull(persisted);
+            Assert.Equal("Updated speaker", persisted.SpeakerHint);
+            Assert.Equal(createdAtUtc, persisted.CreatedAtUtc);
+        }
+        finally
+        {
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
     ///     Creates one metadata row with the canonical exact-match values.
     /// </summary>
     private static QuestDialogueMetadata CreateRow(
@@ -222,7 +313,8 @@ public class QuestDialogueMetadataPersistenceTests
         string sourceTextHash = "hash-001",
         string derivationVersion = "v1",
         string speakerHint = "Speaker v1",
-        DateTime? observedAtUtc = null)
+        DateTime? observedAtUtc = null,
+        DateTime? createdAtUtc = null)
     {
         var rowObservedAtUtc = observedAtUtc ?? DateTime.UnixEpoch;
         return new QuestDialogueMetadata
@@ -243,7 +335,7 @@ public class QuestDialogueMetadataPersistenceTests
             Provenance = "quest-text",
             ConfidenceTier = 2,
             DerivationVersion = derivationVersion,
-            CreatedAtUtc = rowObservedAtUtc,
+            CreatedAtUtc = createdAtUtc ?? rowObservedAtUtc,
             UpdatedAtUtc = rowObservedAtUtc,
         };
     }

--- a/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
+++ b/Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs
@@ -19,6 +19,53 @@ namespace Echoglossian.Tests;
 public class QuestDialogueMetadataPersistenceTests
 {
     /// <summary>
+    ///     Ensures concurrent upserts for one exact row coalesce without a
+    ///     unique-index failure or duplicate persisted rows.
+    /// </summary>
+    [Fact]
+    public async Task UpsertQuestDialogueMetadataBatchAsync_ConcurrentSameKey_CoalescesIntoOneRow()
+    {
+        var configDir = CreateTempConfigDirectory();
+        var previousConfigDirectory = PluginEntry.ConfigDirectory;
+        PluginEntry.ConfigDirectory = configDir + Path.DirectorySeparatorChar;
+        var plugin = (PluginEntry)RuntimeHelpers.GetUninitializedObject(
+            typeof(PluginEntry));
+
+        try
+        {
+            await using (var context = new EchoglossianDbContext(configDir))
+            {
+                await context.Database.MigrateAsync();
+            }
+
+            await Task.WhenAll(
+                Enumerable.Range(0, 16)
+                    .Select(index => Task.Run(() =>
+                        plugin.UpsertQuestDialogueMetadataBatchAsync(
+                            [CreateRow(speakerHint: $"Speaker {index}")],
+                            CancellationToken.None))));
+
+            await using var verification = new EchoglossianDbContext(configDir);
+            var persisted = await verification.QuestDialogueMetadata
+                .AsNoTracking()
+                .Where(row => row.QuestId == 100 &&
+                              row.QuestSequence == 1 &&
+                              row.SourceLanguageCode == "en" &&
+                              row.GameVersion == "2026.08.10.0000" &&
+                              row.SourceRowKey == "TEXT_QUEST_001_SEQ_001" &&
+                              row.SourceTextHash == "hash-001" &&
+                              row.DerivationVersion == "v1")
+                .ToListAsync();
+            Assert.Single(persisted);
+        }
+        finally
+        {
+            PluginEntry.ConfigDirectory = previousConfigDirectory;
+            TryDeleteDirectory(configDir);
+        }
+    }
+
+    /// <summary>
     ///     Ensures exact-row lookup rejects every logical-key mismatch and an
     ///     upsert replaces its existing logical row rather than duplicating it.
     /// </summary>

--- a/Echoglossian.Tests/QuestTextEvaluationThreadingContractTests.cs
+++ b/Echoglossian.Tests/QuestTextEvaluationThreadingContractTests.cs
@@ -1,0 +1,75 @@
+// <copyright file="QuestTextEvaluationThreadingContractTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.IO;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Guards quest-sheet text evaluation paths against calling
+///     <c>ISeStringEvaluator</c> from worker threads.
+/// </summary>
+public sealed class QuestTextEvaluationThreadingContractTests
+{
+    /// <summary>
+    ///     Ensures quest progress sheet evaluation consults the framework-thread
+    ///     gate before invoking the SeString evaluator.
+    /// </summary>
+    [Fact]
+    public void QuestProgressResolver_EvaluateQuestText_GatesSeStringEvaluatorToFrameworkThread()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "QuestProgressResolver.cs"));
+
+        Assert.Contains(
+            "Echoglossian.FrameworkInterface?.IsInFrameworkUpdateThread != true",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Ensures dialogue metadata derivation consults the framework-thread
+    ///     gate before invoking the SeString evaluator.
+    /// </summary>
+    [Fact]
+    public void QuestDialogueMetadataDerivation_EvaluateQuestText_GatesSeStringEvaluatorToFrameworkThread()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "Helpers",
+            "QuestDialogueMetadataDerivation.cs"));
+
+        Assert.Contains(
+            "Echoglossian.FrameworkInterface?.IsInFrameworkUpdateThread != true",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Locates the repository root for source-level contract assertions.
+    /// </summary>
+    /// <returns>The repository root directory.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Echoglossian.sln")))
+            {
+                return current;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+}

--- a/Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs
+++ b/Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs
@@ -104,6 +104,30 @@ public sealed class RuntimeConfigurationRefreshContractTests
     }
 
     /// <summary>
+    ///     Ensures a translation runtime reset clears capability snapshots so a
+    ///     later configuration scope cannot reuse stale policy state.
+    /// </summary>
+    [Fact]
+    public void Translation_refresh_clears_llm_capability_runtime_cache()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "GeneralHelpers",
+            "RuntimeConfigurationRefresh.cs"));
+
+        var resetMethod = source.IndexOf(
+            "private void ResetRuntimeTranslationPresentationState()",
+            StringComparison.Ordinal);
+        var capabilityCacheClear = source.IndexOf(
+            "LlmCapabilityCacheManager.Clear();",
+            StringComparison.Ordinal);
+
+        Assert.True(resetMethod >= 0);
+        Assert.True(capabilityCacheClear > resetMethod);
+    }
+
+    /// <summary>
     ///     Finds the repository root from the current test directory.
     /// </summary>
     /// <returns>The repository root directory.</returns>

--- a/Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs
@@ -38,4 +38,50 @@ public class StructuredDialogueCapabilityDecisionLogFormatterTests
 
         token.Should().Be("reasoning_effort=explicit-none(unsupported)");
     }
+
+    /// <summary>
+    ///     Ensures incompatible support and emission combinations do not
+    ///     silently produce an incorrect capability decision token.
+    /// </summary>
+    [Fact]
+    public void Format_WhenEmissionModeIsIncompatibleWithSupportState_ShouldThrow()
+    {
+        var decision = new LlmCapabilityParameterDecision(
+            LlmCapabilitySupportState.Supported,
+            null,
+            null,
+            false,
+            "StaticDefault",
+            "Supported");
+
+        var action = () => StructuredDialogueCapabilityDecisionLogFormatter.Format(
+            LlmCapabilityParameterName.Temperature,
+            decision,
+            StructuredDialogueCapabilityEmissionMode.ExplicitDisable);
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    ///     Ensures unrecognized emission modes are rejected instead of being
+    ///     rendered as a misleading omission token.
+    /// </summary>
+    [Fact]
+    public void Format_WhenEmissionModeIsUnknown_ShouldThrow()
+    {
+        var decision = new LlmCapabilityParameterDecision(
+            LlmCapabilitySupportState.Unknown,
+            null,
+            null,
+            false,
+            "StaticDefault",
+            "Unknown");
+
+        var action = () => StructuredDialogueCapabilityDecisionLogFormatter.Format(
+            LlmCapabilityParameterName.Temperature,
+            decision,
+            (StructuredDialogueCapabilityEmissionMode)99);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
 }

--- a/Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs
@@ -1,0 +1,41 @@
+// <copyright file="StructuredDialogueCapabilityDecisionLogFormatterTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators.Capabilities;
+using Echoglossian.Translators.Helpers;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers tokens that expose resolved capability decisions in structured
+///     dialogue diagnostics.
+/// </summary>
+public class StructuredDialogueCapabilityDecisionLogFormatterTests
+{
+    /// <summary>
+    ///     Ensures an unsupported reasoning-effort parameter explicitly
+    ///     records its required null disable value.
+    /// </summary>
+    [Fact]
+    public void Format_WhenUnsupportedReasoningEffortUsesExplicitNone_ShouldEmitExplicitDisableToken()
+    {
+        string token = StructuredDialogueCapabilityDecisionLogFormatter.Format(
+            LlmCapabilityParameterName.ReasoningEffort,
+            new LlmCapabilityParameterDecision(
+                LlmCapabilitySupportState.Unsupported,
+                null,
+                null,
+                false,
+                "StaticDefault",
+                "Unsupported"),
+            StructuredDialogueCapabilityEmissionMode.ExplicitDisable);
+
+        token.Should().Be("reasoning_effort=explicit-none(unsupported)");
+    }
+}

--- a/Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs
@@ -40,6 +40,27 @@ public class StructuredDialogueCapabilityDecisionLogFormatterTests
     }
 
     /// <summary>
+    ///     Ensures a supported reasoning-effort option without a configured
+    ///     value is logged as an accurate omission instead of an unknown rule.
+    /// </summary>
+    [Fact]
+    public void Format_WhenSupportedReasoningEffortIsUnset_ShouldEmitSupportedOmissionToken()
+    {
+        string token = StructuredDialogueCapabilityDecisionLogFormatter.Format(
+            LlmCapabilityParameterName.ReasoningEffort,
+            new LlmCapabilityParameterDecision(
+                LlmCapabilitySupportState.Supported,
+                null,
+                null,
+                false,
+                "StaticDefault",
+                "Supported"),
+            StructuredDialogueCapabilityEmissionMode.OmittedSupported);
+
+        token.Should().Be("reasoning_effort=omitted(unconfigured)");
+    }
+
+    /// <summary>
     ///     Ensures incompatible support and emission combinations do not
     ///     silently produce an incorrect capability decision token.
     /// </summary>

--- a/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
@@ -200,24 +200,24 @@ public class StructuredDialogueDiagnosticsHelperTests
     }
 
     /// <summary>
-    ///     Ensures fallback reasons use the same bounded credential redaction
-    ///     as provider excerpts before they reach the diagnostic log.
+    ///     Ensures non-exception fallback reasons redact quoted JSON
+    ///     credentials before token normalization reaches the diagnostic log.
     /// </summary>
     [Fact]
-    public void FormatStructuredFallbackMessage_ShouldRedactFailureReasonAndUseRequiredMarker()
+    public void FormatStructuredFallbackMessage_ShouldRedactQuotedJsonSecretInNonExceptionReason()
     {
         string message = StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
             "Gemini",
             "gemini-2.5-flash",
             StructuredDialogueProviderCapability.JsonSchema,
-            "exception",
-            "Provider rejected password=correct-horse and {\"apiKey\":\"sk-secret-123\"} at ?key=gemini-secret",
+            "validation",
+            "Provider rejected password=correct-horse and {\"apiKey\":\"plain-secret\"} at ?key=gemini-secret",
             400);
 
         message.Should().Contain("structured-fallback");
-        message.Should().Contain("reason=provider-exception");
+        message.Should().Contain("reason=");
         message.Should().NotContain("correct-horse");
-        message.Should().NotContain("sk-secret-123");
+        message.Should().NotContain("plain-secret");
         message.Should().NotContain("gemini-secret");
     }
 

--- a/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="StructuredDialogueDiagnosticsHelperTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators;
+using Echoglossian.Translators.Capabilities;
+using Echoglossian.Translators.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers the shared structured dialogue diagnostics formatting helper.
+/// </summary>
+public class StructuredDialogueDiagnosticsHelperTests
+{
+    /// <summary>
+    ///     Ensures request diagnostics identify the effective route, glossary
+    ///     state, and capability decisions.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredStartMessage_ShouldIncludeRouteGlossaryAndCapabilityDecisionTokens()
+    {
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.ChatGPT,
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.6-terra");
+
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+            scope,
+            "chat/completions",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "Talk",
+            1,
+            2,
+            true,
+            false,
+            420,
+            640,
+            "Return only a JSON object...",
+            "All these bright lights...",
+            [
+                "temperature=omitted(default-only)",
+                "reasoning_effort=explicit-none(unsupported)",
+            ]);
+
+        message.Should().Contain("structured-start");
+        message.Should().Contain("endpointScope=https://api.openai.com/v1");
+        message.Should().Contain("route=chat-completions");
+        message.Should().Contain("glossaryCount=2");
+        message.Should().Contain("capabilityDecisions=temperature=omitted(default-only)|reasoning_effort=explicit-none(unsupported)");
+    }
+
+    /// <summary>
+    ///     Ensures response diagnostics retain useful output context without
+    ///     exposing a credential-like response token.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredSuccessMessage_ShouldIncludeSanitizedResponsePreview()
+    {
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.OpenRouter,
+            "OpenRouter",
+            "https://openrouter.ai/api/v1",
+            "openai/gpt-5-mini");
+
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+            scope,
+            "chat/completions",
+            StructuredDialogueProviderCapability.JsonSchema,
+            true,
+            218,
+            84,
+            "{\"textTranslated\":\"sk-secret should never leak\"}",
+            "Texto traduzido final");
+
+        message.Should().Contain("structured-success");
+        message.Should().Contain("glossaryApplied=true");
+        message.Should().Contain("rawPayloadLength=218");
+        message.Should().Contain("translatedLength=84");
+        message.Should().NotContain("sk-secret");
+    }
+
+    /// <summary>
+    ///     Ensures structured fallback diagnostics expose a normalized shape
+    ///     with provider, model, capability, stage, and HTTP status.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredFallbackMessage_ShouldIncludeNormalizedShape()
+    {
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+            "Gemini",
+            "gemini-2.5-flash",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "exception",
+            "Bad Request",
+            400);
+
+        message.Should().Contain("provider=Gemini");
+        message.Should().Contain("model=gemini-2.5-flash");
+        message.Should().Contain("capability=json-schema");
+        message.Should().Contain("stage=exception");
+        message.Should().Contain("reason=bad-request");
+        message.Should().Contain("status=400");
+    }
+
+    /// <summary>
+    ///     Ensures free-form excerpts are redacted and truncated before they
+    ///     reach runtime logs.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredFallbackMessage_ShouldRedactAndTruncateExcerpt()
+    {
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+            "Gemini",
+            "gemini-2.5-flash",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "exception",
+            "bad-request",
+            400,
+            "apiKey=sk-secret-1234567890 token=abc123 this-is-a-very-long-excerpt-that-should-be-truncated-before-it-reaches-the-log-line");
+
+        message.Should().Contain("excerpt=");
+        message.Should().NotContain("sk-secret-1234567890");
+        message.Should().NotContain("token=abc123");
+        message.Should().Contain("[redacted]");
+        message.Length.Should().BeLessThan(240);
+    }
+
+    /// <summary>
+    ///     Ensures fallback diagnostics preserve the effective endpoint, route,
+    ///     capability decisions, and glossary state.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredFallbackMessage_ShouldIncludeEffectiveRequestShape()
+    {
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+            "OpenAI",
+            "gpt-5.6-terra",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "request",
+            "unsupported-parameter",
+            400,
+            endpointScope: "https://api.openai.com/v1",
+            route: "chat/completions",
+            capabilityDecisionTokens: ["reasoning_effort=explicit-none(unsupported)"],
+            glossaryApplied: true);
+
+        message.Should().Contain("endpointScope=https://api.openai.com/v1");
+        message.Should().Contain("route=chat-completions");
+        message.Should().Contain("capabilityDecisions=reasoning_effort=explicit-none(unsupported)");
+        message.Should().Contain("glossaryApplied=true");
+    }
+}

--- a/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
@@ -6,6 +6,7 @@
 using Echoglossian.Translators;
 using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Helpers;
+using Echoglossian.Tests.TestDoubles;
 using FluentAssertions;
 using Xunit;
 
@@ -82,6 +83,97 @@ public class StructuredDialogueDiagnosticsHelperTests
         message.Should().Contain("rawPayloadLength=218");
         message.Should().Contain("translatedLength=84");
         message.Should().NotContain("sk-secret");
+    }
+
+    /// <summary>
+    ///     Ensures both header-style and JSON-style bearer credentials are
+    ///     redacted before a structured response preview is logged.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredSuccessMessage_ShouldRedactBearerCredentials()
+    {
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.ChatGPT,
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.6-terra");
+
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+            scope,
+            "chat/completions",
+            StructuredDialogueProviderCapability.JsonSchema,
+            false,
+            64,
+            8,
+            "Authorization: Bearer abc123; {\"authorization\":\"Bearer xyz456\"}",
+            "Traducao");
+
+        message.Should().Contain("[redacted]");
+        message.Should().NotContain("abc123");
+        message.Should().NotContain("xyz456");
+    }
+
+    /// <summary>
+    ///     Ensures endpoint diagnostics retain a readable endpoint while
+    ///     removing user information, query secrets, fragments, and newlines.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredStartMessage_ShouldSanitizeEndpointScope()
+    {
+        var scope = new LlmCapabilityScope(
+            Echoglossian.TransEngines.ChatGPT,
+            "OpenAI",
+            "https://user:password@api.openai.com/v1?api_key=secret#fragment\r\nforged=true",
+            "gpt-5.6-terra");
+
+        string startMessage = StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+            scope,
+            "chat/completions",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "Talk",
+            0,
+            0,
+            false,
+            false,
+            24,
+            null,
+            "Prompt",
+            "Source",
+            []);
+        string fallbackMessage = StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+            "OpenAI",
+            "gpt-5.6-terra",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "request",
+            "bad-request",
+            endpointScope: scope.EndpointScope);
+
+        startMessage.Should().Contain("endpointScope=https://api.openai.com/v1");
+        fallbackMessage.Should().Contain("endpointScope=https://api.openai.com/v1");
+        startMessage.Should().NotContain("user");
+        startMessage.Should().NotContain("password");
+        startMessage.Should().NotContain("secret");
+        startMessage.Should().NotContain("forged");
+        fallbackMessage.Should().NotContain("\r");
+        fallbackMessage.Should().NotContain("\n");
+    }
+
+    /// <summary>
+    ///     Ensures captured debug logs render their structured values for
+    ///     complete assertions in later provider tests.
+    /// </summary>
+    [Fact]
+    public void CapturingPluginLog_Debug_ShouldRenderMessageValues()
+    {
+        var pluginLog = new CapturingPluginLog();
+
+        pluginLog.Debug(
+            "route={Route}, status={Status}",
+            "chat/completions",
+            200);
+
+        pluginLog.DebugMessages.Should().ContainSingle()
+            .Which.Should().Be("route=\"chat/completions\", status=200");
     }
 
     /// <summary>

--- a/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs
@@ -195,8 +195,30 @@ public class StructuredDialogueDiagnosticsHelperTests
         message.Should().Contain("model=gemini-2.5-flash");
         message.Should().Contain("capability=json-schema");
         message.Should().Contain("stage=exception");
-        message.Should().Contain("reason=bad-request");
+        message.Should().Contain("reason=provider-exception");
         message.Should().Contain("status=400");
+    }
+
+    /// <summary>
+    ///     Ensures fallback reasons use the same bounded credential redaction
+    ///     as provider excerpts before they reach the diagnostic log.
+    /// </summary>
+    [Fact]
+    public void FormatStructuredFallbackMessage_ShouldRedactFailureReasonAndUseRequiredMarker()
+    {
+        string message = StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+            "Gemini",
+            "gemini-2.5-flash",
+            StructuredDialogueProviderCapability.JsonSchema,
+            "exception",
+            "Provider rejected password=correct-horse and {\"apiKey\":\"sk-secret-123\"} at ?key=gemini-secret",
+            400);
+
+        message.Should().Contain("structured-fallback");
+        message.Should().Contain("reason=provider-exception");
+        message.Should().NotContain("correct-horse");
+        message.Should().NotContain("sk-secret-123");
+        message.Should().NotContain("gemini-secret");
     }
 
     /// <summary>

--- a/Echoglossian.Tests/StructuredDialogueTranslationRequestBuilderTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueTranslationRequestBuilderTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using System.Text.Json;
+
 using Echoglossian.Translators;
 using Echoglossian.Translators.Helpers;
 using FluentAssertions;
@@ -123,7 +125,7 @@ public class StructuredDialogueTranslationRequestBuilderTests
         AddresseeRoleHint: "npc",
         AddresseeGenderHint: "male",
         MetadataProvenance: "quest-sheet",
-        MetadataConfidenceTier: "exact");
+        MetadataConfidenceTier: 2);
     DialogueTranslationContext emptyHintContext = new(
         "Talk",
         "krile-session",
@@ -150,7 +152,9 @@ public class StructuredDialogueTranslationRequestBuilderTests
     hintedRequest.Metadata.AddresseeRoleHint.Should().Be("npc");
     hintedRequest.Metadata.AddresseeGenderHint.Should().Be("male");
     hintedRequest.Metadata.MetadataProvenance.Should().Be("quest-sheet");
-    hintedRequest.Metadata.MetadataConfidenceTier.Should().Be("exact");
+    hintedRequest.Metadata.MetadataConfidenceTier.Should().Be(2);
+    JsonSerializer.Serialize(hintedRequest)
+        .Should().Contain("\"metadata_confidence_tier\":2");
     emptyHintRequest.Metadata.SpeakerGenderHint.Should().BeNull();
     emptyHintRequest.Metadata.AddresseeOriginal.Should().BeNull();
   }

--- a/Echoglossian.Tests/StructuredDialogueTranslationRequestBuilderTests.cs
+++ b/Echoglossian.Tests/StructuredDialogueTranslationRequestBuilderTests.cs
@@ -104,4 +104,54 @@ public class StructuredDialogueTranslationRequestBuilderTests
     request.Glossary.Should().BeEmpty();
     request.Metadata.SpeakerOriginal.Should().BeEmpty();
   }
+
+  /// <summary>
+  ///     Ensures resolved current-request interlocutor hints project into the
+  ///     structured metadata contract while empty hints remain absent.
+  /// </summary>
+  [Fact]
+  public void Build_WithInterlocutorHints_ShouldProjectStructuredMetadata()
+  {
+    DialogueTranslationContext hintedContext = new(
+        "Talk",
+        "krile-session",
+        "Krile",
+        [],
+        SpeakerRoleHint: "npc",
+        SpeakerGenderHint: "female",
+        AddresseeHint: "Alphinaud",
+        AddresseeRoleHint: "npc",
+        AddresseeGenderHint: "male",
+        MetadataProvenance: "quest-sheet",
+        MetadataConfidenceTier: "exact");
+    DialogueTranslationContext emptyHintContext = new(
+        "Talk",
+        "krile-session",
+        "Krile",
+        []);
+
+    StructuredDialogueTranslationRequest hintedRequest =
+        StructuredDialogueTranslationRequestBuilder.Build(
+            "We must press on.",
+            "ja-JP",
+            "en-US",
+            TranslationSurfaceGroup.Dialogue,
+            hintedContext);
+    StructuredDialogueTranslationRequest emptyHintRequest =
+        StructuredDialogueTranslationRequestBuilder.Build(
+            "We must press on.",
+            "ja-JP",
+            "en-US",
+            TranslationSurfaceGroup.Dialogue,
+            emptyHintContext);
+
+    hintedRequest.Metadata.SpeakerGenderHint.Should().Be("female");
+    hintedRequest.Metadata.AddresseeOriginal.Should().Be("Alphinaud");
+    hintedRequest.Metadata.AddresseeRoleHint.Should().Be("npc");
+    hintedRequest.Metadata.AddresseeGenderHint.Should().Be("male");
+    hintedRequest.Metadata.MetadataProvenance.Should().Be("quest-sheet");
+    hintedRequest.Metadata.MetadataConfidenceTier.Should().Be("exact");
+    emptyHintRequest.Metadata.SpeakerGenderHint.Should().BeNull();
+    emptyHintRequest.Metadata.AddresseeOriginal.Should().BeNull();
+  }
 }

--- a/Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs
+++ b/Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs
@@ -7,6 +7,7 @@ using Dalamud.Plugin.Services;
 
 using Serilog;
 using Serilog.Events;
+using System.Globalization;
 
 namespace Echoglossian.Tests.TestDoubles;
 
@@ -66,13 +67,13 @@ internal sealed class CapturingPluginLog : IPluginLog
     /// <inheritdoc/>
     public void Debug(string messageTemplate, params object[] values)
     {
-        this.debugMessages.Add(messageTemplate);
+        this.debugMessages.Add(this.Render(messageTemplate, values));
     }
 
     /// <inheritdoc/>
     public void Debug(Exception? exception, string messageTemplate, params object[] values)
     {
-        this.debugMessages.Add(messageTemplate);
+        this.debugMessages.Add(this.Render(messageTemplate, values));
     }
 
     /// <inheritdoc/>
@@ -83,4 +84,30 @@ internal sealed class CapturingPluginLog : IPluginLog
 
     /// <inheritdoc/>
     public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object[] values) { }
+
+    private string Render(string messageTemplate, object[] values)
+    {
+        if (values.Length == 0)
+        {
+            return messageTemplate;
+        }
+
+        if (this.Logger.BindMessageTemplate(
+                messageTemplate,
+                values,
+                out var parsedTemplate,
+                out var properties))
+        {
+            var propertyMap = properties.ToDictionary(
+                property => property.Name,
+                property => property.Value,
+                StringComparer.Ordinal);
+            return parsedTemplate.Render(propertyMap);
+        }
+
+        var renderedValues = string.Join(
+            ", ",
+            values.Select(value => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "<null>"));
+        return $"{messageTemplate} | values: {renderedValues}";
+    }
 }

--- a/Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs
+++ b/Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs
@@ -1,0 +1,86 @@
+// <copyright file="CapturingPluginLog.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Dalamud.Plugin.Services;
+
+using Serilog;
+using Serilog.Events;
+
+namespace Echoglossian.Tests.TestDoubles;
+
+/// <summary>
+///     Captures plugin logger messages for assertions without emitting runtime
+///     diagnostics during tests.
+/// </summary>
+internal sealed class CapturingPluginLog : IPluginLog
+{
+    private readonly List<string> debugMessages = [];
+
+    /// <summary>
+    ///     Gets captured debug messages.
+    /// </summary>
+    public IReadOnlyList<string> DebugMessages => this.debugMessages;
+
+    /// <summary>
+    ///     Gets the inert Serilog logger required by the interface.
+    /// </summary>
+    public ILogger Logger { get; } = new LoggerConfiguration().CreateLogger();
+
+    /// <summary>
+    ///     Gets or sets the minimum log level accepted by this logger.
+    /// </summary>
+    public LogEventLevel MinimumLogLevel { get; set; } = LogEventLevel.Verbose;
+
+    /// <inheritdoc/>
+    public void Fatal(string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Fatal(Exception? exception, string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Error(string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Error(Exception? exception, string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Warning(string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Warning(Exception? exception, string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Information(string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Information(Exception? exception, string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Info(string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Info(Exception? exception, string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Debug(string messageTemplate, params object[] values)
+    {
+        this.debugMessages.Add(messageTemplate);
+    }
+
+    /// <inheritdoc/>
+    public void Debug(Exception? exception, string messageTemplate, params object[] values)
+    {
+        this.debugMessages.Add(messageTemplate);
+    }
+
+    /// <inheritdoc/>
+    public void Verbose(string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Verbose(Exception? exception, string messageTemplate, params object[] values) { }
+
+    /// <inheritdoc/>
+    public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object[] values) { }
+}

--- a/Echoglossian.Tests/TranslationServiceDialogueGlossaryProtectionTests.cs
+++ b/Echoglossian.Tests/TranslationServiceDialogueGlossaryProtectionTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="TranslationServiceDialogueGlossaryProtectionTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Covers deterministic dialogue glossary enforcement in the shared
+///     translation-service pipeline.
+/// </summary>
+public class TranslationServiceDialogueGlossaryProtectionTests
+{
+    /// <summary>
+    ///     Ensures dialogue LLM requests protect glossary terms before the
+    ///     provider call and restore the configured targets after the provider
+    ///     returns the marker-bearing payload unchanged.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task TranslateAsync_DialogueGlossaryTerms_RestoreConfiguredTargets()
+    {
+        var glossaryPath = CreateGlossaryFile(
+            """
+            [
+              {
+                "source_text": "Triple Triad",
+                "target_text": "Triple Triad [GLOSSARY-OK]"
+              }
+            ]
+            """);
+
+        try
+        {
+            StructuredDialogueGlossaryStore.Clear();
+            StructuredDialogueGlossaryStore.Refresh(glossaryPath).Should().BeTrue();
+
+            var translator = new EchoDialogueTranslator();
+            var service = new TranslationService(
+                text => text,
+                translator,
+                translationEngine: 8);
+            var context = new DialogueTranslationContext(
+                "Talk",
+                "gold-saucer",
+                "Roland",
+                []);
+
+            var result = await service.TranslateAsync(
+                "Triple Triad is popular here.",
+                new SourceClientLanguage("en", "en"),
+                "pt-BR",
+                context,
+                TranslationSurfaceGroup.Dialogue);
+
+            result.Should().Be("Triple Triad [GLOSSARY-OK] is popular here.");
+            translator.ContextAwareInputs.Should().ContainSingle();
+            translator.ContextAwareInputs[0].Should().NotContain("Triple Triad");
+        }
+        finally
+        {
+            StructuredDialogueGlossaryStore.Clear();
+            File.Delete(glossaryPath);
+        }
+    }
+
+    /// <summary>
+    ///     Ensures a provider response that damages a required glossary marker
+    ///     follows the existing sanitized-source fallback path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task TranslateAsync_DialogueGlossaryMarkerDamage_FallsBackToSanitizedSource()
+    {
+        var glossaryPath = CreateGlossaryFile(
+            """
+            [
+              {
+                "source_text": "Triple Triad",
+                "target_text": "Triple Triad [GLOSSARY-OK]"
+              }
+            ]
+            """);
+
+        try
+        {
+            StructuredDialogueGlossaryStore.Clear();
+            StructuredDialogueGlossaryStore.Refresh(glossaryPath).Should().BeTrue();
+
+            var failureReasons = new List<string>();
+            var translator = new EchoDialogueTranslator
+            {
+                ResponseFactory = _ => "The provider ignored the required marker.",
+            };
+            var service = new TranslationService(
+                text => text,
+                translator,
+                translationEngine: 8,
+                recordTransientFailedTranslation: (text, source, target, engine, reason, ttl) =>
+                    failureReasons.Add(reason));
+            var context = new DialogueTranslationContext(
+                "Talk",
+                "gold-saucer",
+                "Roland",
+                []);
+
+            var result = await service.TranslateAsync(
+                "Triple Triad is popular here.",
+                new SourceClientLanguage("en", "en"),
+                "pt-BR",
+                context,
+                TranslationSurfaceGroup.Dialogue);
+
+            result.Should().Be("Triple Triad is popular here.");
+            failureReasons.Should().ContainSingle("missing-required-marker");
+        }
+        finally
+        {
+            StructuredDialogueGlossaryStore.Clear();
+            File.Delete(glossaryPath);
+        }
+    }
+
+    /// <summary>
+    ///     Writes one temporary structured dialogue glossary file for one test.
+    /// </summary>
+    /// <param name="json">The JSON payload to write.</param>
+    /// <returns>The temporary glossary file path.</returns>
+    private static string CreateGlossaryFile(string json)
+    {
+        var filePath = Path.Combine(
+            Path.GetTempPath(),
+            $"{nameof(TranslationServiceDialogueGlossaryProtectionTests)}-{Guid.NewGuid():N}.json");
+        File.WriteAllText(filePath, json);
+        return filePath;
+    }
+
+    /// <summary>
+    ///     Minimal dialogue-aware translator used to observe the protected text
+    ///     that reaches the provider boundary.
+    /// </summary>
+    private sealed class EchoDialogueTranslator : ITranslator, IDialogueContextAwareTranslator
+    {
+        /// <summary>
+        ///     Gets the protected dialogue inputs received by the context-aware
+        ///     translation path.
+        /// </summary>
+        public List<string> ContextAwareInputs { get; } = [];
+
+        /// <summary>
+        ///     Gets or sets the response factory used to emulate provider output.
+        /// </summary>
+        public Func<string, string> ResponseFactory { get; set; } = text => text;
+
+        /// <inheritdoc />
+        public string? Translate(string text, string sourceLanguage, string targetLanguage)
+        {
+            return text;
+        }
+
+        /// <inheritdoc />
+        public Task<string?> TranslateAsync(string text, string sourceLanguage, string targetLanguage)
+        {
+            return Task.FromResult<string?>(text);
+        }
+
+        /// <inheritdoc />
+        public Task<string?> TranslateAsync(
+            string text,
+            string sourceLanguage,
+            string targetLanguage,
+            DialogueTranslationContext dialogueContext)
+        {
+            this.ContextAwareInputs.Add(text);
+            return Task.FromResult<string?>(this.ResponseFactory(text));
+        }
+    }
+}

--- a/Echoglossian.Tests/TranslationServiceTests.cs
+++ b/Echoglossian.Tests/TranslationServiceTests.cs
@@ -525,6 +525,31 @@ public class TranslationServiceTests
     }
 
     /// <summary>
+    /// Ensures an already-cancelled request never starts provider translation
+    /// work.
+    /// </summary>
+    [Fact]
+    public async Task TranslateAsync_PreCancelledToken_DoesNotInvokeProvider()
+    {
+        var translator = new RecordingTranslator
+        {
+            AsyncResult = "provider-result",
+        };
+        var service = new TranslationService(text => text, translator);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.TranslateAsync(
+                "hello",
+                "en",
+                "pt",
+                cancellationTokenSource.Token));
+
+        Assert.Equal(0, translator.AsyncCalls);
+    }
+
+    /// <summary>
     ///     Verifies that cancellation completes before a pending provider result.
     /// </summary>
     /// <param name="translationTask">The in-flight translation task.</param>

--- a/Echoglossian.Tests/TranslationServiceTests.cs
+++ b/Echoglossian.Tests/TranslationServiceTests.cs
@@ -702,7 +702,7 @@ public class TranslationServiceTests
     /// </summary>
     /// <returns>A task representing the test.</returns>
     [Fact]
-    public async Task TranslateAsync_WithDialogueContext_UsesContextAwareTranslator()
+    public async Task TranslateAsync_WithFirstTurnDialogueContext_UsesContextAwareTranslator()
     {
         var translator = new ContextAwareRecordingTranslator
         {
@@ -716,12 +716,7 @@ public class TranslationServiceTests
             "Talk",
             "Krile|engine:8|target:pt-BR",
             "Krile",
-            [
-                new DialogueTranslationTurn(
-                    "Krile",
-                    "Pray return.",
-                    new DateTime(2026, 05, 12, 15, 20, 0, DateTimeKind.Utc)),
-            ]);
+            []);
 
         var result = await service.TranslateAsync(
             "We must press on.",
@@ -862,23 +857,35 @@ public class TranslationServiceTests
     }
 
     /// <summary>
-    ///     Ensures empty runtime-only dialogue context does not switch the
-    ///     translation service into the context-aware path.
+    ///     Ensures anonymous first-turn dialogue context still routes through
+    ///     the dialogue-aware translator contract.
     /// </summary>
     [Fact]
-    public void WillUseDialogueContext_RequiresPriorTurns()
+    public async Task TranslateAsync_WithAnonymousFirstTurnDialogueContext_UsesContextAwareTranslator()
     {
-        var translator = new ContextAwareRecordingTranslator();
+        var translator = new ContextAwareRecordingTranslator
+        {
+            AsyncResult = "translated-with-context",
+        };
         var service = new TranslationService(
             text => text,
             translator);
         var dialogueContext = new DialogueTranslationContext(
             "Talk",
             "Krile|engine:8|target:pt-BR",
-            "Krile",
+            string.Empty,
             []);
 
-        Assert.False(service.WillUseDialogueContext(dialogueContext));
+        var result = await service.TranslateAsync(
+            "We must press on.",
+            "English",
+            "pt-BR",
+            dialogueContext);
+
+        Assert.Equal("translated-with-context", result);
+        Assert.Equal(1, translator.ContextAwareAsyncCalls);
+        Assert.Equal(0, translator.AsyncCalls);
+        Assert.True(service.WillUseDialogueContext(dialogueContext));
     }
 
     /// <summary>

--- a/Echoglossian.Tests/TranslationServiceTests.cs
+++ b/Echoglossian.Tests/TranslationServiceTests.cs
@@ -522,7 +522,7 @@ public class TranslationServiceTests
         cancellationTokenSource.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            async () => await translationTask);
+            () => translationTask);
 
         translator.Complete("provider-result");
 

--- a/Echoglossian.Tests/TranslationServiceTests.cs
+++ b/Echoglossian.Tests/TranslationServiceTests.cs
@@ -502,6 +502,34 @@ public class TranslationServiceTests
     }
 
     /// <summary>
+    ///     Ensures cancellation stops waiting for an in-flight translator result.
+    /// </summary>
+    /// <returns>A task representing the test.</returns>
+    [Fact]
+    public async Task TranslateAsync_CancellationToken_CancelsBeforeProviderResult()
+    {
+        var translator = new PendingAsyncTranslator();
+        var service = new TranslationService(
+            text => text,
+            translator);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var translationTask = service.TranslateAsync(
+            "hello",
+            "en",
+            "pt",
+            cancellationTokenSource.Token);
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await translationTask);
+
+        translator.Complete("provider-result");
+
+        Assert.True(translationTask.IsCanceled);
+    }
+
+    /// <summary>
     ///     Ensures the service skips exact requests already known to fail for
     ///     the same source and target language pair plus engine.
     /// </summary>
@@ -1058,6 +1086,36 @@ public class TranslationServiceTests
             this.LastAsyncText = text;
             this.asyncSourceLanguages.Add(sourceLanguage);
             return Task.FromResult(this.AsyncResult);
+        }
+    }
+
+    /// <summary>
+    ///     Fake translator that leaves asynchronous requests pending until the
+    ///     test explicitly completes them.
+    /// </summary>
+    private sealed class PendingAsyncTranslator : ITranslator
+    {
+        private readonly TaskCompletionSource<string?> completionSource = new();
+
+        /// <summary>
+        ///     Completes the pending provider request.
+        /// </summary>
+        /// <param name="result">The provider result.</param>
+        public void Complete(string? result)
+        {
+            this.completionSource.SetResult(result);
+        }
+
+        /// <inheritdoc/>
+        public string? Translate(string text, string sourceLanguage, string targetLanguage)
+        {
+            throw new InvalidOperationException("Synchronous translation must not be used.");
+        }
+
+        /// <inheritdoc/>
+        public Task<string?> TranslateAsync(string text, string sourceLanguage, string targetLanguage)
+        {
+            return this.completionSource.Task;
         }
     }
 

--- a/Echoglossian.Tests/TranslationServiceTests.cs
+++ b/Echoglossian.Tests/TranslationServiceTests.cs
@@ -506,7 +506,7 @@ public class TranslationServiceTests
     /// </summary>
     /// <returns>A task representing the test.</returns>
     [Fact]
-    public async Task TranslateAsync_CancellationToken_CancelsBeforeProviderResult()
+    public Task TranslateAsync_CancellationToken_CancelsBeforeProviderResult()
     {
         var translator = new PendingAsyncTranslator();
         var service = new TranslationService(
@@ -521,8 +521,21 @@ public class TranslationServiceTests
             cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
 
+        return this.AssertCanceledTranslationAsync(translationTask, translator);
+    }
+
+    /// <summary>
+    ///     Verifies that cancellation completes before a pending provider result.
+    /// </summary>
+    /// <param name="translationTask">The in-flight translation task.</param>
+    /// <param name="translator">The pending translator that supplies the later result.</param>
+    /// <returns>A task representing the assertion.</returns>
+    private async Task AssertCanceledTranslationAsync(
+        Task<string> translationTask,
+        PendingAsyncTranslator translator)
+    {
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => translationTask);
+            () => translationTask).ConfigureAwait(false);
 
         translator.Complete("provider-result");
 

--- a/Echoglossian.Tests/TranslationServiceTests.cs
+++ b/Echoglossian.Tests/TranslationServiceTests.cs
@@ -955,6 +955,68 @@ public class TranslationServiceTests
     }
 
     /// <summary>
+    ///     Ensures dialogue-aware requests emit a non-sensitive context summary
+    ///     that exposes presence/absence of hints without logging names.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task TranslateAsync_DialogueContextRequest_LogsNonSensitiveContextSummary()
+    {
+        var pluginLog = new CapturingPluginLog();
+        var translator = new ContextAwareRecordingTranslator
+        {
+            AsyncResult = "dialogue-result",
+        };
+        var service = new TranslationService(
+            static text => text,
+            translator,
+            translationEngine: (int)Echoglossian.TransEngines.Gemini,
+            debugLog: message => pluginLog.Debug(message));
+        var dialogueContext = new DialogueTranslationContext(
+            "Talk",
+            "quest-1",
+            "Minfilia",
+            [
+                new DialogueTranslationTurn(
+                    "Thancred",
+                    "We move now.",
+                    DateTime.UtcNow),
+            ],
+            SpeakerRoleHint: "npc",
+            SpeakerGenderHint: "female",
+            AddresseeHint: "Alphinaud",
+            AddresseeRoleHint: "npc",
+            AddresseeGenderHint: "male",
+            MetadataProvenance: "QuestSheetDerivedExact",
+            MetadataConfidenceTier: 2);
+
+        _ = await service.TranslateAsync(
+            "Current line",
+            new SourceClientLanguage("en", "en"),
+            "it",
+            dialogueContext,
+            TranslationSurfaceGroup.Dialogue,
+            originContext: "Talk/Text");
+
+        string message = Assert.Single(
+            pluginLog.DebugMessages,
+            line => line.StartsWith(
+                "[Talk/Text] TranslationService: dialogue context summary",
+                StringComparison.Ordinal));
+        Assert.Contains("dialogueContext=supplied", message, StringComparison.Ordinal);
+        Assert.Contains("metadata=populated", message, StringComparison.Ordinal);
+        Assert.Contains("speaker=true", message, StringComparison.Ordinal);
+        Assert.Contains("speakerGender=true", message, StringComparison.Ordinal);
+        Assert.Contains("addressee=true", message, StringComparison.Ordinal);
+        Assert.Contains("addresseeGender=true", message, StringComparison.Ordinal);
+        Assert.Contains("metadataProvenance=QuestSheetDerivedExact", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Minfilia", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Thancred", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Alphinaud", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("We move now.", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     ///     Ensures a known failed request keeps the sanitized original text
     ///     instead of collapsing to an empty string.
     /// </summary>

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -472,6 +472,8 @@ public partial class Echoglossian : IDalamudPlugin
 
   [PluginService] public static IObjectTable ObjectTableInterface { get; set; } = null!;
 
+  [PluginService] public static ITargetManager TargetManagerInterface { get; set; } = null!;
+
   [PluginService] public static IPlayerState PlayerStateInterface { get; set; } = null!;
 
   [PluginService]

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -585,6 +585,7 @@ public partial class Echoglossian : IDalamudPlugin
     QuestTodoProgressResolver.Clear();
     this.ClearAcceptedQuestPrefetchState();
     this.acceptedQuestPrefetchActionPump.Dispose();
+    this.acceptedQuestDialogueMetadataOperations.Dispose();
     this.ClearTraitDetailPrefetchState();
     this.ClearReferenceTextPrefetchState();
     this.ClearNamePlatePrefetchState();

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -586,6 +586,7 @@ public partial class Echoglossian : IDalamudPlugin
     this.ClearAcceptedQuestPrefetchState();
     this.acceptedQuestPrefetchActionPump.Dispose();
     this.acceptedQuestDialogueMetadataOperations.Dispose();
+    this.acceptedQuestDialogueMetadataGenerationCancellationSource.Dispose();
     this.ClearTraitDetailPrefetchState();
     this.ClearReferenceTextPrefetchState();
     this.ClearNamePlatePrefetchState();

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -471,6 +471,8 @@ public partial class Echoglossian : IDalamudPlugin
 
   [PluginService] public static IObjectTable ObjectTableInterface { get; set; } = null!;
 
+  [PluginService] public static IPlayerState PlayerStateInterface { get; set; } = null!;
+
   [PluginService]
   public static IChatGui ChatGuiInterface { get; set; } = null!;
 

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -403,6 +403,7 @@ public partial class Echoglossian : IDalamudPlugin
     NamePlateCacheManager.Preload(ConfigDirectory);
     StringArrayDataCacheManager.Preload(ConfigDirectory);
     TranslationFailureCacheManager.Preload(ConfigDirectory);
+    LlmCapabilityCacheManager.Initialize(ConfigDirectory);
     ActionTooltipCacheManager.Preload(ConfigDirectory);
     TraitCacheManager.Preload(ConfigDirectory);
     ReferenceTextCacheRegistry.PreloadAll(ConfigDirectory);
@@ -576,6 +577,7 @@ public partial class Echoglossian : IDalamudPlugin
       GameWindowCacheManager.Clear();
       NamePlateCacheManager.Clear();
       TranslationFailureCacheManager.Clear();
+      LlmCapabilityCacheManager.Clear();
       ActionTooltipCacheManager.Clear();
       TraitCacheManager.Clear();
       ReferenceTextCacheRegistry.ClearAll();

--- a/GeneralHelpers/RuntimeConfigurationRefresh.cs
+++ b/GeneralHelpers/RuntimeConfigurationRefresh.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.NativeUI.AddonHandlers.Common;
+using Echoglossian.Cache;
 
 using Newtonsoft.Json;
 
@@ -380,6 +381,7 @@ public partial class Echoglossian
   /// </summary>
   private void ResetRuntimeTranslationPresentationState()
   {
+    LlmCapabilityCacheManager.Clear();
     this.hoverTooltipManager.Clear();
     this.rtlTexturePresentationService.Clear();
     this.ClearOverlay(this.talkOverlay, clearText: true);

--- a/NativeUI/AddonHandlers/Common/DbFirstGameWindowAddonHandler.cs
+++ b/NativeUI/AddonHandlers/Common/DbFirstGameWindowAddonHandler.cs
@@ -4214,7 +4214,7 @@ internal sealed class SourcePublicationLifecycle
         Action invalidate)
     {
         var observedState = Volatile.Read(ref this.currentState);
-        if (observedState?.Scope == scope)
+        if (observedState is not null && observedState.Scope == scope)
         {
             return observedState.CreateOperation();
         }
@@ -4222,7 +4222,7 @@ internal sealed class SourcePublicationLifecycle
         lock (this.gate)
         {
             var currentState = this.currentState;
-            if (currentState?.Scope == scope)
+            if (currentState is not null && currentState.Scope == scope)
             {
                 return currentState.CreateOperation();
             }

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -12,7 +12,11 @@ namespace Echoglossian.NativeUI.AddonHandlers.Talk;
 ///     This includes live text capture from the visible addon, translation lookup,
 ///     async translation, overlay updates, and optional native text replacement.
 /// </summary>
-public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialogueRetranslationHandler
+public sealed class BattleTalkHandler :
+    IAddonTranslationHandler,
+    IVisibleDialogueRetranslationHandler,
+    IPluginUnloadAwareAddonHandler,
+    IDisposable
 {
   private static readonly TimeSpan DialogueSessionTtl = TimeSpan.FromSeconds(30);
   private const string BattleTalkAddonName = "_BattleTalk";
@@ -27,9 +31,13 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   private readonly Action clearOverlay;
   private readonly Config config;
   private readonly Dictionary<AddonEvent, List<LocalAddonHandlerDelegate>> eventHandlers = new();
-  private readonly Func<BattleTalkMessage, BattleTalkMessage?> findBattleTalkMessage;
+  private readonly Func<BattleTalkMessage, CancellationToken, Task<BattleTalkMessage?>>
+      findBattleTalkMessageAsync;
   private readonly Func<BattleTalkMessage, CancellationToken, Task<string>> insertBattleTalkMessageAsync;
   private readonly Func<string, string> normalizeReplacementText;
+  private readonly OwnedAsyncOperationSet ownedOperations = new(
+      exception => PluginRuntimeLog.Error(
+          $"[{BattleTalkAddonName}] Unexpected BattleTalk background operation error: {exception}"));
   private readonly SourcePublicationLifecycle sourceLifecycle = new();
   private readonly object stateGate = new();
   private readonly TranslationService translationService;
@@ -64,7 +72,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
   /// <param name="translationService">The translation service used by the plugin.</param>
-  /// <param name="findBattleTalkMessage">
+  /// <param name="findBattleTalkMessageAsync">
   ///     Delegate used to look up previously translated BattleTalk messages.
   /// </param>
   /// <param name="insertBattleTalkMessageAsync">
@@ -83,7 +91,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   public BattleTalkHandler(
       Config config,
       TranslationService translationService,
-      Func<BattleTalkMessage, BattleTalkMessage?> findBattleTalkMessage,
+      Func<BattleTalkMessage, CancellationToken, Task<BattleTalkMessage?>>
+          findBattleTalkMessageAsync,
       Func<BattleTalkMessage, Task<string>> insertBattleTalkMessageAsync,
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
@@ -91,7 +100,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
     : this(
         config,
         translationService,
-        findBattleTalkMessage,
+        findBattleTalkMessageAsync,
         (message, _) => insertBattleTalkMessageAsync(message),
         updateOverlay,
         clearOverlay,
@@ -105,7 +114,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
   /// <param name="translationService">The shared translation service.</param>
-  /// <param name="findBattleTalkMessage">The canonical BattleTalk lookup.</param>
+  /// <param name="findBattleTalkMessageAsync">The canonical asynchronous BattleTalk lookup.</param>
   /// <param name="insertBattleTalkMessageAsync">The cancellation-aware persistence delegate.</param>
   /// <param name="updateOverlay">The overlay publication callback.</param>
   /// <param name="clearOverlay">The overlay clear callback.</param>
@@ -113,7 +122,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   internal BattleTalkHandler(
       Config config,
       TranslationService translationService,
-      Func<BattleTalkMessage, BattleTalkMessage?> findBattleTalkMessage,
+      Func<BattleTalkMessage, CancellationToken, Task<BattleTalkMessage?>>
+          findBattleTalkMessageAsync,
       Func<BattleTalkMessage, CancellationToken, Task<string>> insertBattleTalkMessageAsync,
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
@@ -121,7 +131,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   {
     this.config = config;
     this.translationService = translationService;
-    this.findBattleTalkMessage = findBattleTalkMessage;
+    this.findBattleTalkMessageAsync = findBattleTalkMessageAsync;
     this.insertBattleTalkMessageAsync = insertBattleTalkMessageAsync;
     this.updateOverlay = updateOverlay;
     this.clearOverlay = clearOverlay;
@@ -152,6 +162,19 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
             handler(evt, args);
           }
         }));
+  }
+
+  /// <inheritdoc />
+  public void OnPluginUnload()
+  {
+    this.InvalidateStateForSource(null);
+    this.ownedOperations.Dispose();
+  }
+
+  /// <inheritdoc />
+  public void Dispose()
+  {
+    this.OnPluginUnload();
   }
 
   /// <inheritdoc />
@@ -219,6 +242,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
           operationScope.TargetLanguageCode,
           TranslationSurfaceGroup.Dialogue,
           translatorResolution,
+          sourceOperation.CancellationToken,
           originContext: "BattleTalk/Text").ConfigureAwait(false);
       var translatedName = this.ShouldTranslateBattleTalkNpcNames() &&
                            !originalName.IsNullOrEmpty()
@@ -228,6 +252,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
               operationScope.TargetLanguageCode,
               TranslationSurfaceGroup.Dialogue,
               translatorResolution,
+              sourceOperation.CancellationToken,
               originContext: "BattleTalk/Speaker").ConfigureAwait(false)
           : string.Empty;
       var dialogueTranslationEngine = operationScope.TranslationEngine
@@ -515,20 +540,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
       this.ShowPendingSwapOverlayIfNeeded(originalName, originalText);
     }
 
-    if (this.TryQueueTranslation(
-            originalName,
-            originalText,
-            sourceLanguage,
-            out var requestId,
-            out var sourceOperation))
-    {
-      Task.Run(() => this.ResolveTranslationAsync(
-          originalName,
-          originalText,
-          requestId,
-          sourceLanguage,
-          sourceOperation));
-    }
+    this.TryQueueTranslation(originalName, originalText, sourceLanguage);
   }
 
   /// <summary>
@@ -555,9 +567,11 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
       scheduledGeneration = ++this.hideResetGeneration;
     }
 
-    _ = Task.Run(async () =>
+    this.ownedOperations.Run(async operationToken =>
     {
-      await Task.Delay(HideResetDelayMilliseconds).ConfigureAwait(false);
+      await Task.Delay(
+          HideResetDelayMilliseconds,
+          operationToken).ConfigureAwait(false);
 
       lock (this.stateGate)
       {
@@ -607,7 +621,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   ///     The operation-captured source, or no value when source resolution
   ///     failed.
   /// </param>
-  private void InvalidateStateForSource(
+  internal void InvalidateStateForSource(
       SourceClientLanguage? sourceLanguage)
   {
     this.sourceLifecycle.TransitionTo(
@@ -974,16 +988,19 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   /// </param>
   /// <param name="sourceLanguage">The resolved source language.</param>
   /// <param name="sourceOperation">The source generation captured when queued.</param>
+  /// <param name="operationToken">The token owned by the queued operation.</param>
   /// <returns>A task that completes when the translation state has been updated.</returns>
-  private async Task ResolveTranslationAsync(
+  internal async Task ResolveTranslationAsync(
       string originalName,
       string originalText,
       int requestId,
       SourceClientLanguage sourceLanguage,
-      SourcePublicationOperation sourceOperation)
+      SourcePublicationOperation sourceOperation,
+      CancellationToken operationToken)
   {
     try
     {
+      operationToken.ThrowIfCancellationRequested();
       var operationScope = sourceOperation.Scope ??
                            this.CreateDialogueReuseScope(sourceLanguage);
       var translatorResolution = this.translationService
@@ -995,7 +1012,15 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
           originalText,
           sourceLanguage,
           operationScope);
-      var foundBattleTalkMessage = this.findBattleTalkMessage(lookup);
+      var foundBattleTalkMessage = await this.findBattleTalkMessageAsync(
+          lookup,
+          operationToken).ConfigureAwait(false);
+
+      if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+          !this.IsCurrentRequest(requestId, sourceLanguage))
+      {
+        return;
+      }
 
       string translatedName;
       string translatedText;
@@ -1041,7 +1066,14 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
             dialogueContext,
             TranslationSurfaceGroup.Dialogue,
             translatorResolution,
+            operationToken,
             originContext: "BattleTalk/Text").ConfigureAwait(false);
+
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
+        }
 
         translatedName = string.Empty;
         if (this.ShouldTranslateBattleTalkNpcNames() && !originalName.IsNullOrEmpty())
@@ -1054,13 +1086,20 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
                 operationScope.TargetLanguageCode,
                 TranslationSurfaceGroup.Dialogue,
                 translatorResolution,
+                operationToken,
                 originContext: "BattleTalk/Speaker").ConfigureAwait(false);
           }
-          catch (Exception ex)
+          catch (Exception ex) when (ex is not OperationCanceledException)
           {
             PluginRuntimeLog.Warning(
                 $"[{BattleTalkAddonName}] Speaker name translation failed; continuing with translated text. {ex.Message}");
           }
+        }
+
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
         }
 
         if (!usesRuntimeOnlyDialogueContext &&
@@ -1081,7 +1120,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
           await this.insertBattleTalkMessageAsync(
               translatedBattleTalkData,
-              sourceOperation.CancellationToken);
+              operationToken).ConfigureAwait(false);
           provenance = VisibleStorySurfaceProvenanceKind.FreshLiveTranslation;
         }
         else if (!usesRuntimeOnlyDialogueContext)
@@ -1094,6 +1133,13 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
               VisibleStorySurfaceProvenanceKind
                   .FreshLiveTranslationRuntimeOnlyDialogueContext;
         }
+      }
+
+      operationToken.ThrowIfCancellationRequested();
+      if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+          !this.IsCurrentRequest(requestId, sourceLanguage))
+      {
+        return;
       }
 
       this.sourceLifecycle.TryPublish(
@@ -1163,6 +1209,16 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
             }
           });
     }
+    catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
+    {
+      lock (this.stateGate)
+      {
+        if (requestId == this.activeRequestId)
+        {
+          this.translationInFlight = false;
+        }
+      }
+    }
     catch (Exception ex)
     {
       lock (this.stateGate)
@@ -1211,6 +1267,68 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
     return !string.IsNullOrWhiteSpace(
         battleTalkMessage.TranslatedBattleTalkMessage);
+  }
+
+  /// <summary>
+  ///     Gets a value indicating whether the current BattleTalk line has
+  ///     unresolved background translation work.
+  /// </summary>
+  internal bool IsTranslationInFlight
+  {
+    get
+    {
+      lock (this.stateGate)
+      {
+        return this.translationInFlight;
+      }
+    }
+  }
+
+  /// <summary>
+  ///     Returns the active resolved BattleTalk translation currently held by
+  ///     the handler state.
+  /// </summary>
+  /// <param name="sourceLanguage">The source language expected by the caller.</param>
+  /// <param name="translatedName">Receives the translated sender name.</param>
+  /// <param name="translatedText">Receives the translated BattleTalk text.</param>
+  /// <param name="replacementName">
+  ///     Receives the sender name already normalized for native replacement.
+  /// </param>
+  /// <param name="replacementText">
+  ///     Receives the BattleTalk text already normalized for native replacement.
+  /// </param>
+  /// <returns>
+  ///     <see langword="true" /> when the handler already has a translated
+  ///     BattleTalk line ready for native replacement; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  internal bool TryGetCurrentResolvedTranslation(
+      SourceClientLanguage sourceLanguage,
+      out string translatedName,
+      out string translatedText,
+      out string replacementName,
+      out string replacementText)
+  {
+    lock (this.stateGate)
+    {
+      if (NativeRuntimeSourceScope.MatchesSource(
+              this.currentSourceLanguageCode,
+              sourceLanguage) &&
+          !string.IsNullOrWhiteSpace(this.currentTranslatedText))
+      {
+        translatedName = this.currentTranslatedName;
+        translatedText = this.currentTranslatedText;
+        replacementName = this.currentReplacementName;
+        replacementText = this.currentReplacementText;
+        return true;
+      }
+    }
+
+    translatedName = string.Empty;
+    translatedText = string.Empty;
+    replacementName = string.Empty;
+    replacementText = string.Empty;
+    return false;
   }
 
   /// <summary>
@@ -1299,6 +1417,55 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   }
 
   /// <summary>
+  ///     Captures one BattleTalk line and starts its handler-owned asynchronous
+  ///     resolution without waiting for persistent lookup to complete.
+  /// </summary>
+  /// <param name="originalName">The source sender name.</param>
+  /// <param name="originalText">The source BattleTalk text.</param>
+  /// <param name="sourceLanguage">The resolved source language.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the operation was queued; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  internal bool TryQueueTranslation(
+      string originalName,
+      string originalText,
+      SourceClientLanguage sourceLanguage)
+  {
+    if (!this.TryQueueTranslation(
+            originalName,
+            originalText,
+            sourceLanguage,
+            out var requestId,
+            out var sourceOperation))
+    {
+      return false;
+    }
+
+    var accepted = this.ownedOperations.Run(
+        operationToken => this.ResolveTranslationAsync(
+            originalName,
+            originalText,
+            requestId,
+            sourceLanguage,
+            sourceOperation,
+            operationToken),
+        sourceOperation.CancellationToken);
+    if (!accepted)
+    {
+      lock (this.stateGate)
+      {
+        if (requestId == this.activeRequestId)
+        {
+          this.translationInFlight = false;
+        }
+      }
+    }
+
+    return accepted;
+  }
+
+  /// <summary>
   ///     Starts a new translation request when the BattleTalk source changes or
   ///     when the current source still has no cached translation available.
   /// </summary>
@@ -1314,7 +1481,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
   ///     <see langword="true" /> when a new translation task should be queued;
   ///     otherwise, <see langword="false" />.
   /// </returns>
-  private bool TryQueueTranslation(
+  internal bool TryQueueTranslation(
       string originalName,
       string originalText,
       SourceClientLanguage sourceLanguage,
@@ -1432,20 +1599,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
 
     this.ShowPendingSwapOverlayIfNeeded(originalName, originalText);
 
-    if (this.TryQueueTranslation(
-            originalName,
-            originalText,
-            sourceLanguage,
-            out var requestId,
-            out var sourceOperation))
-    {
-      Task.Run(() => this.ResolveTranslationAsync(
-          originalName,
-          originalText,
-          requestId,
-          sourceLanguage,
-          sourceOperation));
-    }
+    this.TryQueueTranslation(originalName, originalText, sourceLanguage);
   }
 
   /// <summary>
@@ -1971,6 +2125,29 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
       this.nativeLayoutOriginalText = originalText;
       this.nativeLayoutReplacementName = replacementName;
       this.nativeLayoutReplacementText = replacementText;
+    }
+  }
+
+  /// <summary>
+  ///     Determines whether one request still owns the active BattleTalk
+  ///     managed state for the supplied source language.
+  /// </summary>
+  /// <param name="requestId">The captured request identifier.</param>
+  /// <param name="sourceLanguage">The captured source language.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the request remains current; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool IsCurrentRequest(
+      int requestId,
+      SourceClientLanguage sourceLanguage)
+  {
+    lock (this.stateGate)
+    {
+      return requestId == this.activeRequestId &&
+             NativeRuntimeSourceScope.MatchesSource(
+                 this.currentSourceLanguageCode,
+                 sourceLanguage);
     }
   }
 }

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -35,6 +35,8 @@ public sealed class BattleTalkHandler :
       findBattleTalkMessageAsync;
   private readonly Func<BattleTalkMessage, CancellationToken, Task<string>> insertBattleTalkMessageAsync;
   private readonly Func<string, string> normalizeReplacementText;
+  private readonly Func<string, string, SourceClientLanguage, CancellationToken,
+      Task<DialogueInterlocutorHints>> resolveInterlocutorHintsAsync;
   private readonly OwnedAsyncOperationSet ownedOperations = new(
       exception => PluginRuntimeLog.Error(
           $"[{BattleTalkAddonName}] Unexpected BattleTalk background operation error: {exception}"));
@@ -88,6 +90,9 @@ public sealed class BattleTalkHandler :
   /// <param name="normalizeReplacementText">
   ///     Delegate used to normalize translated text before native replacement.
   /// </param>
+  /// <param name="resolveInterlocutorHintsAsync">
+  ///     Delegate used to resolve current-line interlocutor hints after a database miss.
+  /// </param>
   public BattleTalkHandler(
       Config config,
       TranslationService translationService,
@@ -96,7 +101,9 @@ public sealed class BattleTalkHandler :
       Func<BattleTalkMessage, Task<string>> insertBattleTalkMessageAsync,
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
-      Func<string, string> normalizeReplacementText)
+      Func<string, string> normalizeReplacementText,
+      Func<string, string, SourceClientLanguage, CancellationToken,
+          Task<DialogueInterlocutorHints>> resolveInterlocutorHintsAsync)
     : this(
         config,
         translationService,
@@ -104,7 +111,8 @@ public sealed class BattleTalkHandler :
         (message, _) => insertBattleTalkMessageAsync(message),
         updateOverlay,
         clearOverlay,
-        normalizeReplacementText)
+        normalizeReplacementText,
+        resolveInterlocutorHintsAsync)
   {
   }
 
@@ -119,6 +127,9 @@ public sealed class BattleTalkHandler :
   /// <param name="updateOverlay">The overlay publication callback.</param>
   /// <param name="clearOverlay">The overlay clear callback.</param>
   /// <param name="normalizeReplacementText">The native replacement normalizer.</param>
+  /// <param name="resolveInterlocutorHintsAsync">
+  ///     The asynchronous current-line interlocutor hint resolver.
+  /// </param>
   internal BattleTalkHandler(
       Config config,
       TranslationService translationService,
@@ -127,7 +138,9 @@ public sealed class BattleTalkHandler :
       Func<BattleTalkMessage, CancellationToken, Task<string>> insertBattleTalkMessageAsync,
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
-      Func<string, string> normalizeReplacementText)
+      Func<string, string> normalizeReplacementText,
+      Func<string, string, SourceClientLanguage, CancellationToken,
+          Task<DialogueInterlocutorHints>> resolveInterlocutorHintsAsync)
   {
     this.config = config;
     this.translationService = translationService;
@@ -136,6 +149,7 @@ public sealed class BattleTalkHandler :
     this.updateOverlay = updateOverlay;
     this.clearOverlay = clearOverlay;
     this.normalizeReplacementText = normalizeReplacementText;
+    this.resolveInterlocutorHintsAsync = resolveInterlocutorHintsAsync;
 
     this.RegisterHandler(AddonEvent.PreShow, this.OnCaptureHint);
     this.RegisterHandler(AddonEvent.PreRefresh, this.OnCaptureHint);
@@ -1048,6 +1062,17 @@ public sealed class BattleTalkHandler :
       }
       else
       {
+        var interlocutorHints = await this.resolveInterlocutorHintsAsync(
+            originalName,
+            originalText,
+            sourceLanguage,
+            operationToken).ConfigureAwait(false);
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
+        }
+
         var dialogueContext = DialogueTranslationSessionStore.BuildContext(
             BattleTalkAddonName,
             this.BuildDialogueSessionKey(
@@ -1057,7 +1082,8 @@ public sealed class BattleTalkHandler :
             originalName,
             originalText,
             DialogueSessionHistoryLimit,
-            DialogueSessionTtl);
+            DialogueSessionTtl,
+            interlocutorHints: interlocutorHints);
         var usesRuntimeOnlyDialogueContext =
             this.translationService.WillUseDialogueContext(
                 dialogueContext,

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -1062,7 +1062,7 @@ public sealed class BattleTalkHandler :
       }
       else
       {
-        var interlocutorHints = await this.resolveInterlocutorHintsAsync(
+        var interlocutorHints = await this.ResolveInterlocutorHintsOrDefaultAsync(
             originalName,
             originalText,
             sourceLanguage,
@@ -1265,6 +1265,38 @@ public sealed class BattleTalkHandler :
 
       PluginRuntimeLog.Error(
           $"[{BattleTalkAddonName}] Error resolving BattleTalk translation: {ex}");
+    }
+  }
+
+  /// <summary>
+  ///     Resolves optional BattleTalk metadata without allowing auxiliary
+  ///     failures to abort the dialogue translation.
+  /// </summary>
+  /// <param name="originalName">The original visible speaker name.</param>
+  /// <param name="originalText">The original visible dialogue text.</param>
+  /// <param name="sourceLanguage">The captured source language.</param>
+  /// <param name="cancellationToken">The token that cancels the current source operation.</param>
+  /// <returns>The resolved hints, or an empty hint set after an auxiliary failure.</returns>
+  private async Task<DialogueInterlocutorHints> ResolveInterlocutorHintsOrDefaultAsync(
+      string originalName,
+      string originalText,
+      SourceClientLanguage sourceLanguage,
+      CancellationToken cancellationToken)
+  {
+    try
+    {
+      return await this.resolveInterlocutorHintsAsync(
+          originalName,
+          originalText,
+          sourceLanguage,
+          cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception exception) when (exception is not OperationCanceledException)
+    {
+      PluginRuntimeLog.Debug(
+          BattleTalkAddonName,
+          $"Interlocutor metadata resolution failed; continuing without hints. {exception.GetType().Name}: {exception.Message}");
+      return default;
     }
   }
 

--- a/NativeUI/AddonHandlers/Talk/TalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/TalkHandler.cs
@@ -1568,20 +1568,14 @@ public sealed class TalkHandler :
 
     this.clearOverlay();
     var accepted = this.ownedOperations.Run(
-        async ownerToken =>
-        {
-          using var operationTokenSource =
-              CancellationTokenSource.CreateLinkedTokenSource(
-                  ownerToken,
-                  sourceOperation.CancellationToken);
-          await this.ResolveTranslationAsync(
-              originalName,
-              originalText,
-              requestId,
-              sourceLanguage,
-              sourceOperation,
-              operationTokenSource.Token).ConfigureAwait(false);
-        });
+        operationToken => this.ResolveTranslationAsync(
+            originalName,
+            originalText,
+            requestId,
+            sourceLanguage,
+            sourceOperation,
+            operationToken),
+        sourceOperation.CancellationToken);
     if (!accepted)
     {
       lock (this.stateGate)

--- a/NativeUI/AddonHandlers/Talk/TalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/TalkHandler.cs
@@ -32,6 +32,8 @@ public sealed class TalkHandler :
       findTalkMessageAsync;
   private readonly Func<TalkMessage, CancellationToken, Task<string>> insertTalkMessageAsync;
   private readonly Func<string, string> normalizeReplacementText;
+  private readonly Func<string, string, SourceClientLanguage, CancellationToken,
+      Task<DialogueInterlocutorHints>> resolveInterlocutorHintsAsync;
   private readonly OwnedAsyncOperationSet ownedOperations = new(
       exception => PluginRuntimeLog.Error(
           $"[{TalkAddonName}] Unexpected Talk background operation error: {exception}"));
@@ -77,6 +79,9 @@ public sealed class TalkHandler :
   /// <param name="normalizeReplacementText">
   ///     Delegate used to normalize translated text before native replacement.
   /// </param>
+  /// <param name="resolveInterlocutorHintsAsync">
+  ///     Delegate used to resolve current-line interlocutor hints after a database miss.
+  /// </param>
   /// <param name="restoreNativeMutation">
   ///     Optional native-free override for restoring tracked Talk mutation.
   /// </param>
@@ -89,6 +94,8 @@ public sealed class TalkHandler :
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
       Func<string, string> normalizeReplacementText,
+      Func<string, string, SourceClientLanguage, CancellationToken,
+          Task<DialogueInterlocutorHints>> resolveInterlocutorHintsAsync,
       Action? restoreNativeMutation = null)
     : this(
         config,
@@ -98,6 +105,7 @@ public sealed class TalkHandler :
         updateOverlay,
         clearOverlay,
         normalizeReplacementText,
+        resolveInterlocutorHintsAsync,
         restoreNativeMutation)
   {
   }
@@ -113,6 +121,9 @@ public sealed class TalkHandler :
   /// <param name="updateOverlay">The overlay publication callback.</param>
   /// <param name="clearOverlay">The overlay clear callback.</param>
   /// <param name="normalizeReplacementText">The native replacement normalizer.</param>
+  /// <param name="resolveInterlocutorHintsAsync">
+  ///     The asynchronous current-line interlocutor hint resolver.
+  /// </param>
   /// <param name="restoreNativeMutation">The optional native restoration override.</param>
   internal TalkHandler(
       Config config,
@@ -123,6 +134,8 @@ public sealed class TalkHandler :
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
       Func<string, string> normalizeReplacementText,
+      Func<string, string, SourceClientLanguage, CancellationToken,
+          Task<DialogueInterlocutorHints>> resolveInterlocutorHintsAsync,
       Action? restoreNativeMutation = null)
   {
     this.config = config;
@@ -132,6 +145,7 @@ public sealed class TalkHandler :
     this.updateOverlay = updateOverlay;
     this.clearOverlay = clearOverlay;
     this.normalizeReplacementText = normalizeReplacementText;
+    this.resolveInterlocutorHintsAsync = resolveInterlocutorHintsAsync;
     this.restoreNativeMutation =
         restoreNativeMutation ?? this.RestoreTrackedNativeMutation;
 
@@ -1166,6 +1180,17 @@ public sealed class TalkHandler :
       }
       else
       {
+        var interlocutorHints = await this.resolveInterlocutorHintsAsync(
+            originalName,
+            originalText,
+            sourceLanguage,
+            operationToken).ConfigureAwait(false);
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
+        }
+
         var dialogueContext = DialogueTranslationSessionStore.BuildContext(
             TalkAddonName,
             this.BuildDialogueSessionKey(
@@ -1175,7 +1200,8 @@ public sealed class TalkHandler :
             originalName,
             originalText,
             DialogueSessionHistoryLimit,
-            DialogueSessionTtl);
+            DialogueSessionTtl,
+            interlocutorHints: interlocutorHints);
         var usesRuntimeOnlyDialogueContext =
             this.translationService.WillUseDialogueContext(
                 dialogueContext,

--- a/NativeUI/AddonHandlers/Talk/TalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/TalkHandler.cs
@@ -1180,7 +1180,7 @@ public sealed class TalkHandler :
       }
       else
       {
-        var interlocutorHints = await this.resolveInterlocutorHintsAsync(
+        var interlocutorHints = await this.ResolveInterlocutorHintsOrDefaultAsync(
             originalName,
             originalText,
             sourceLanguage,
@@ -1475,6 +1475,38 @@ public sealed class TalkHandler :
       {
         return this.translationInFlight;
       }
+    }
+  }
+
+  /// <summary>
+  ///     Resolves optional Talk metadata without allowing auxiliary failures to
+  ///     abort the dialogue translation.
+  /// </summary>
+  /// <param name="originalName">The original visible speaker name.</param>
+  /// <param name="originalText">The original visible dialogue text.</param>
+  /// <param name="sourceLanguage">The captured source language.</param>
+  /// <param name="cancellationToken">The token that cancels the current source operation.</param>
+  /// <returns>The resolved hints, or an empty hint set after an auxiliary failure.</returns>
+  private async Task<DialogueInterlocutorHints> ResolveInterlocutorHintsOrDefaultAsync(
+      string originalName,
+      string originalText,
+      SourceClientLanguage sourceLanguage,
+      CancellationToken cancellationToken)
+  {
+    try
+    {
+      return await this.resolveInterlocutorHintsAsync(
+          originalName,
+          originalText,
+          sourceLanguage,
+          cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception exception) when (exception is not OperationCanceledException)
+    {
+      PluginRuntimeLog.Debug(
+          TalkAddonName,
+          $"Interlocutor metadata resolution failed; continuing without hints. {exception.GetType().Name}: {exception.Message}");
+      return default;
     }
   }
 

--- a/NativeUI/AddonHandlers/Talk/TalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/TalkHandler.cs
@@ -12,7 +12,11 @@ namespace Echoglossian.NativeUI.AddonHandlers.Talk;
 ///     This includes capture, translation lookup, async translation, overlay
 ///     updates, and optional native text replacement.
 /// </summary>
-public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetranslationHandler
+public sealed class TalkHandler :
+    IAddonTranslationHandler,
+    IVisibleDialogueRetranslationHandler,
+    IPluginUnloadAwareAddonHandler,
+    IDisposable
 {
   private static readonly TimeSpan DialogueSessionTtl = TimeSpan.FromSeconds(30);
   private const int DialogueSessionHistoryLimit = 3;
@@ -24,9 +28,13 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   private readonly Action clearOverlay;
   private readonly Config config;
   private readonly Dictionary<AddonEvent, List<LocalAddonHandlerDelegate>> eventHandlers = new();
-  private readonly Func<TalkMessage, TalkMessage?> findTalkMessage;
+  private readonly Func<TalkMessage, CancellationToken, Task<TalkMessage?>>
+      findTalkMessageAsync;
   private readonly Func<TalkMessage, CancellationToken, Task<string>> insertTalkMessageAsync;
   private readonly Func<string, string> normalizeReplacementText;
+  private readonly OwnedAsyncOperationSet ownedOperations = new(
+      exception => PluginRuntimeLog.Error(
+          $"[{TalkAddonName}] Unexpected Talk background operation error: {exception}"));
   private readonly Action restoreNativeMutation;
   private readonly SourcePublicationLifecycle sourceLifecycle = new();
   private readonly object stateGate = new();
@@ -54,7 +62,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
   /// <param name="translationService">The translation service used by the plugin.</param>
-  /// <param name="findTalkMessage">
+  /// <param name="findTalkMessageAsync">
   ///     Delegate used to look up previously translated Talk messages.
   /// </param>
   /// <param name="insertTalkMessageAsync">
@@ -75,7 +83,8 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   public TalkHandler(
       Config config,
       TranslationService translationService,
-      Func<TalkMessage, TalkMessage?> findTalkMessage,
+      Func<TalkMessage, CancellationToken, Task<TalkMessage?>>
+          findTalkMessageAsync,
       Func<TalkMessage, Task<string>> insertTalkMessageAsync,
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
@@ -84,7 +93,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
     : this(
         config,
         translationService,
-        findTalkMessage,
+        findTalkMessageAsync,
         (message, _) => insertTalkMessageAsync(message),
         updateOverlay,
         clearOverlay,
@@ -99,7 +108,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   /// </summary>
   /// <param name="config">The active plugin configuration.</param>
   /// <param name="translationService">The shared translation service.</param>
-  /// <param name="findTalkMessage">The canonical Talk lookup.</param>
+  /// <param name="findTalkMessageAsync">The canonical asynchronous Talk lookup.</param>
   /// <param name="insertTalkMessageAsync">The cancellation-aware persistence delegate.</param>
   /// <param name="updateOverlay">The overlay publication callback.</param>
   /// <param name="clearOverlay">The overlay clear callback.</param>
@@ -108,7 +117,8 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   internal TalkHandler(
       Config config,
       TranslationService translationService,
-      Func<TalkMessage, TalkMessage?> findTalkMessage,
+      Func<TalkMessage, CancellationToken, Task<TalkMessage?>>
+          findTalkMessageAsync,
       Func<TalkMessage, CancellationToken, Task<string>> insertTalkMessageAsync,
       Action<string, string, string> updateOverlay,
       Action clearOverlay,
@@ -117,7 +127,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   {
     this.config = config;
     this.translationService = translationService;
-    this.findTalkMessage = findTalkMessage;
+    this.findTalkMessageAsync = findTalkMessageAsync;
     this.insertTalkMessageAsync = insertTalkMessageAsync;
     this.updateOverlay = updateOverlay;
     this.clearOverlay = clearOverlay;
@@ -149,6 +159,19 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
             handler(evt, args);
           }
         }));
+  }
+
+  /// <inheritdoc />
+  public void OnPluginUnload()
+  {
+    this.InvalidateStateForSource(null);
+    this.ownedOperations.Dispose();
+  }
+
+  /// <inheritdoc />
+  public void Dispose()
+  {
+    this.OnPluginUnload();
   }
 
   /// <inheritdoc />
@@ -211,6 +234,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
           operationScope.TargetLanguageCode,
           TranslationSurfaceGroup.Dialogue,
           translatorResolution,
+          sourceOperation.CancellationToken,
           originContext: "Talk/Text").ConfigureAwait(false);
       var translatedName = this.ShouldTranslateTalkNpcNames() &&
                            !originalName.IsNullOrEmpty()
@@ -220,6 +244,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
               operationScope.TargetLanguageCode,
               TranslationSurfaceGroup.Dialogue,
               translatorResolution,
+              sourceOperation.CancellationToken,
               originContext: "Talk/Speaker").ConfigureAwait(false)
           : string.Empty;
       var dialogueTranslationEngine = operationScope.TranslationEngine
@@ -472,44 +497,12 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
       return;
     }
 
-    if (this.TryLoadStoredTranslation(
-            originalName,
-            originalText,
-            sourceLanguage,
-            out var storedTranslatedName,
-            out var storedTranslatedText))
-    {
-      this.PublishOverlay(
-          originalName,
-          originalText,
-          storedTranslatedName,
-          storedTranslatedText);
-
-      if (this.ShouldApplyNativeTalkText())
-      {
-        this.ApplyTranslatedRefreshValues(
-            atkValues,
-            storedTranslatedName,
-            storedTranslatedText);
-      }
-
-      return;
-    }
-
     if (this.TryQueueTranslation(
             originalName,
             originalText,
-            sourceLanguage,
-            out var requestId,
-            out var sourceOperation))
+            sourceLanguage))
     {
-      this.clearOverlay();
-      Task.Run(() => this.ResolveTranslationAsync(
-          originalName,
-          originalText,
-          requestId,
-          sourceLanguage,
-          sourceOperation));
+      return;
     }
   }
 
@@ -1114,72 +1107,6 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   }
 
   /// <summary>
-  ///     Tries to load an existing Talk translation synchronously from the
-  ///     database so saved lines can still swap immediately during refresh.
-  /// </summary>
-  /// <param name="originalName">The original sender name.</param>
-  /// <param name="originalText">The original Talk text.</param>
-  /// <param name="sourceLanguage">The resolved source language.</param>
-  /// <param name="translatedName">Receives the translated sender name.</param>
-  /// <param name="translatedText">Receives the translated Talk text.</param>
-  /// <returns>
-  ///     <see langword="true" /> when a stored translation exists for the current
-  ///     Talk line; otherwise, <see langword="false" />.
-  /// </returns>
-  private bool TryLoadStoredTranslation(
-      string originalName,
-      string originalText,
-      SourceClientLanguage sourceLanguage,
-      out string translatedName,
-      out string translatedText)
-  {
-    var foundTalkMessage = this.findTalkMessage(
-        this.BuildLookupMessage(
-            originalName,
-            originalText,
-            sourceLanguage));
-    if (foundTalkMessage == null)
-    {
-      translatedName = string.Empty;
-      translatedText = string.Empty;
-      return false;
-    }
-
-    translatedName = this.ShouldTranslateTalkNpcNames()
-        ? foundTalkMessage.TranslatedSenderName ?? string.Empty
-        : string.Empty;
-    translatedText = foundTalkMessage.TranslatedTalkMessage ?? string.Empty;
-
-    lock (this.stateGate)
-    {
-      this.activeRequestId++;
-      this.currentSourceLanguageCode = sourceLanguage.PersistenceCode;
-      this.currentOriginalName = originalName;
-      this.currentOriginalText = originalText;
-      this.currentReplacementName = this.NormalizeForReplacement(translatedName);
-      this.currentReplacementText = this.NormalizeForReplacement(translatedText);
-      this.currentTranslatedName = translatedName;
-      this.currentTranslatedText = translatedText;
-      this.translationInFlight = false;
-    }
-
-    if (string.IsNullOrWhiteSpace(translatedText))
-    {
-      return false;
-    }
-
-    this.RecordDiagnosticsSnapshot(
-        VisibleStorySurfaceProvenanceKind.DbReuse,
-        originalName,
-        originalText,
-        translatedName,
-        translatedText,
-        usedRuntimeOnlyDialogueContext: false,
-        this.GetDialogueTranslationEngineId());
-    return true;
-  }
-
-  /// <summary>
   ///     Resolves a Talk translation from cache or external translation and stores
   ///     the result as the current translation state.
   /// </summary>
@@ -1188,16 +1115,19 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   /// <param name="requestId">The request identifier used to reject stale results.</param>
   /// <param name="sourceLanguage">The resolved source language.</param>
   /// <param name="sourceOperation">The source generation captured when queued.</param>
+  /// <param name="operationToken">The token owned by the queued operation.</param>
   /// <returns>A task that completes when the translation state has been updated.</returns>
   internal async Task ResolveTranslationAsync(
       string originalName,
       string originalText,
       int requestId,
       SourceClientLanguage sourceLanguage,
-      SourcePublicationOperation sourceOperation)
+      SourcePublicationOperation sourceOperation,
+      CancellationToken operationToken)
   {
     try
     {
+      operationToken.ThrowIfCancellationRequested();
       var operationScope = sourceOperation.Scope ??
                            this.CreateDialogueReuseScope(sourceLanguage);
       var translatorResolution = this.translationService
@@ -1209,7 +1139,15 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
           originalText,
           sourceLanguage,
           operationScope);
-      var foundTalkMessage = this.findTalkMessage(lookup);
+      var foundTalkMessage = await this.findTalkMessageAsync(
+          lookup,
+          operationToken).ConfigureAwait(false);
+
+      if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+          !this.IsCurrentRequest(requestId, sourceLanguage))
+      {
+        return;
+      }
 
       string translatedName;
       string translatedText;
@@ -1251,7 +1189,14 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
             dialogueContext,
             TranslationSurfaceGroup.Dialogue,
             translatorResolution,
+            operationToken,
             originContext: "Talk/Text").ConfigureAwait(false);
+
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
+        }
 
         translatedName = this.ShouldTranslateTalkNpcNames() && !originalName.IsNullOrEmpty()
             ? await this.translationService.TranslateAsync(
@@ -1260,10 +1205,25 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
                 operationScope.TargetLanguageCode,
                 TranslationSurfaceGroup.Dialogue,
                 translatorResolution,
+                operationToken,
                 originContext: "Talk/Speaker").ConfigureAwait(false)
             : string.Empty;
 
-        var existingTranslatedTalkMessage = this.findTalkMessage(lookup);
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
+        }
+
+        var existingTranslatedTalkMessage = await this.findTalkMessageAsync(
+            lookup,
+            operationToken).ConfigureAwait(false);
+        if (!this.sourceLifecycle.IsCurrent(sourceOperation) ||
+            !this.IsCurrentRequest(requestId, sourceLanguage))
+        {
+          return;
+        }
+
         if (!string.IsNullOrWhiteSpace(
                 existingTranslatedTalkMessage?.TranslatedTalkMessage))
         {
@@ -1292,7 +1252,7 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
 
           await this.insertTalkMessageAsync(
               translatedTalkData,
-              sourceOperation.CancellationToken);
+              operationToken).ConfigureAwait(false);
           provenance = VisibleStorySurfaceProvenanceKind.FreshLiveTranslation;
         }
         else if (!usesRuntimeOnlyDialogueContext)
@@ -1305,6 +1265,11 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
               VisibleStorySurfaceProvenanceKind
                   .FreshLiveTranslationRuntimeOnlyDialogueContext;
         }
+      }
+
+      if (!this.sourceLifecycle.IsCurrent(sourceOperation))
+      {
+        return;
       }
 
       this.sourceLifecycle.TryPublish(
@@ -1351,6 +1316,16 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
               this.clearOverlay();
             }
           });
+    }
+    catch (OperationCanceledException) when (operationToken.IsCancellationRequested)
+    {
+      lock (this.stateGate)
+      {
+        if (requestId == this.activeRequestId)
+        {
+          this.translationInFlight = false;
+        }
+      }
     }
     catch (Exception ex)
     {
@@ -1463,6 +1438,21 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   }
 
   /// <summary>
+  ///     Gets a value indicating whether the current Talk line has unresolved
+  ///     background translation work.
+  /// </summary>
+  internal bool IsTranslationInFlight
+  {
+    get
+    {
+      lock (this.stateGate)
+      {
+        return this.translationInFlight;
+      }
+    }
+  }
+
+  /// <summary>
   ///     Returns the active resolved Talk translation currently held by the
   ///     handler state.
   /// </summary>
@@ -1551,6 +1541,62 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
   }
 
   /// <summary>
+  ///     Captures one Talk line and starts its handler-owned asynchronous
+  ///     resolution without waiting for persistent lookup to complete.
+  /// </summary>
+  /// <param name="originalName">The source sender name.</param>
+  /// <param name="originalText">The source Talk text.</param>
+  /// <param name="sourceLanguage">The resolved source language.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the operation was queued; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  internal bool TryQueueTranslation(
+      string originalName,
+      string originalText,
+      SourceClientLanguage sourceLanguage)
+  {
+    if (!this.TryQueueTranslation(
+            originalName,
+            originalText,
+            sourceLanguage,
+            out var requestId,
+            out var sourceOperation))
+    {
+      return false;
+    }
+
+    this.clearOverlay();
+    var accepted = this.ownedOperations.Run(
+        async ownerToken =>
+        {
+          using var operationTokenSource =
+              CancellationTokenSource.CreateLinkedTokenSource(
+                  ownerToken,
+                  sourceOperation.CancellationToken);
+          await this.ResolveTranslationAsync(
+              originalName,
+              originalText,
+              requestId,
+              sourceLanguage,
+              sourceOperation,
+              operationTokenSource.Token).ConfigureAwait(false);
+        });
+    if (!accepted)
+    {
+      lock (this.stateGate)
+      {
+        if (requestId == this.activeRequestId)
+        {
+          this.translationInFlight = false;
+        }
+      }
+    }
+
+    return accepted;
+  }
+
+  /// <summary>
   ///     Starts a new translation request when the Talk source changes or when the
   ///     current source still has no cached translation available.
   /// </summary>
@@ -1605,6 +1651,29 @@ public sealed class TalkHandler : IAddonTranslationHandler, IVisibleDialogueRetr
       sourceOperation = this.sourceLifecycle.Capture(
           this.CreateDialogueReuseScope(sourceLanguage));
       return true;
+    }
+  }
+
+  /// <summary>
+  ///     Determines whether one request still owns the active Talk managed
+  ///     state for the supplied source language.
+  /// </summary>
+  /// <param name="requestId">The captured request identifier.</param>
+  /// <param name="sourceLanguage">The captured source language.</param>
+  /// <returns>
+  ///     <see langword="true" /> when the request remains current; otherwise,
+  ///     <see langword="false" />.
+  /// </returns>
+  private bool IsCurrentRequest(
+      int requestId,
+      SourceClientLanguage sourceLanguage)
+  {
+    lock (this.stateGate)
+    {
+      return requestId == this.activeRequestId &&
+             NativeRuntimeSourceScope.MatchesSource(
+                 this.currentSourceLanguageCode,
+                 sourceLanguage);
     }
   }
 }

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -362,8 +362,6 @@ public partial class Echoglossian
 
     await this.UpsertQuestDialogueMetadataBatchAsync(
             metadataEntries,
-            () => workItem.Generation ==
-                Volatile.Read(ref this.acceptedQuestPrefetchGeneration),
             cancellationToken)
         .ConfigureAwait(false);
   }

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -362,6 +362,8 @@ public partial class Echoglossian
 
     await this.UpsertQuestDialogueMetadataBatchAsync(
             metadataEntries,
+            () => workItem.Generation ==
+                Volatile.Read(ref this.acceptedQuestPrefetchGeneration),
             cancellationToken)
         .ConfigureAwait(false);
   }

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -48,6 +48,8 @@ public partial class Echoglossian
 
   private int acceptedQuestPrefetchGeneration;
 
+  private long acceptedQuestDialogueMetadataLastObservedAtUtcTicks;
+
   /// <summary>
   ///     Ticks the accepted-quest prefetch runtime so active quests can be
   ///     translated into the canonical quest table before quest addons need to
@@ -312,8 +314,32 @@ public partial class Echoglossian
             workItem.SourceLanguage,
             GetGameVersion() ?? string.Empty,
             AcceptedQuestDialogueMetadataDerivationVersion,
+            this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc(),
             workItem.Generation,
             this.acceptedQuestDialogueMetadataGenerationCancellationSource.Token));
+  }
+
+  /// <summary>
+  ///     Captures a strictly increasing observation time before dialogue
+  ///     metadata work crosses the background handoff.
+  /// </summary>
+  /// <returns>The immutable UTC observation time.</returns>
+  private DateTime CaptureAcceptedQuestDialogueMetadataObservedAtUtc()
+  {
+    var utcNowTicks = DateTime.UtcNow.Ticks;
+    while (true)
+    {
+      var previousTicks = Volatile.Read(
+          ref this.acceptedQuestDialogueMetadataLastObservedAtUtcTicks);
+      var observedAtUtcTicks = Math.Max(utcNowTicks, previousTicks + 1);
+      if (Interlocked.CompareExchange(
+              ref this.acceptedQuestDialogueMetadataLastObservedAtUtcTicks,
+              observedAtUtcTicks,
+              previousTicks) == previousTicks)
+      {
+        return new DateTime(observedAtUtcTicks, DateTimeKind.Utc);
+      }
+    }
   }
 
   /// <summary>
@@ -351,7 +377,7 @@ public partial class Echoglossian
         workItem.SourceLanguage.PersistenceCode,
         workItem.GameVersion,
         workItem.DerivationVersion,
-        DateTime.UtcNow);
+        workItem.ObservedAtUtc);
     if (workItem.Generation !=
         Volatile.Read(ref this.acceptedQuestPrefetchGeneration))
     {
@@ -1521,6 +1547,7 @@ public partial class Echoglossian
       SourceClientLanguage SourceLanguage,
       string GameVersion,
       string DerivationVersion,
+      DateTime ObservedAtUtc,
       int Generation,
       CancellationToken GenerationCancellationToken);
 }

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -57,7 +57,7 @@ public partial class Echoglossian
   /// </summary>
   private void TickAcceptedQuestPrefetch()
   {
-    if (!this.ShouldPrefetchAcceptedQuests() ||
+    if (!this.ShouldProcessAcceptedQuests() ||
         DateTime.UtcNow - this.acceptedQuestPrefetchLastTickUtc <
         AcceptedQuestPrefetchTickInterval)
     {
@@ -213,7 +213,9 @@ public partial class Echoglossian
   /// <param name="questCount">The number of accepted quests being prefetched.</param>
   private void NotifyAcceptedQuestPrefetchStarted(int questCount)
   {
-    if (questCount <= 0 || !this.configuration.ShowQuestProgressNotifications)
+    if (questCount <= 0 ||
+        !this.configuration.ShowQuestProgressNotifications ||
+        !IsAcceptedQuestCanonicalPrefetchEnabled(this.configuration))
     {
       return;
     }
@@ -271,18 +273,42 @@ public partial class Echoglossian
   ///     runtime state.
   /// </summary>
   /// <returns>True when the background prefetch should run.</returns>
-  private bool ShouldPrefetchAcceptedQuests()
+  private bool ShouldProcessAcceptedQuests()
   {
-    return this.configuration.Translate &&
-           FrameworkAccessGuard.IsClientReadyForPlayerScopedFrameworkAccess() &&
-           (this.configuration.TranslateJournal ||
-            this.configuration.TranslateJournalDetail ||
-            this.configuration.TranslateJournalAccept ||
-            this.configuration.TranslateJournalResult ||
-            this.configuration.TranslateToDoList ||
-            this.configuration.TranslateScenarioTree ||
-            this.configuration.TranslateRecommendList ||
-            this.configuration.TranslateAreaMap);
+    return FrameworkAccessGuard.IsClientReadyForPlayerScopedFrameworkAccess() &&
+           (IsAcceptedQuestCanonicalPrefetchEnabled(this.configuration) ||
+            IsAcceptedQuestDialogueMetadataGenerationEnabled(this.configuration));
+  }
+
+  /// <summary>
+  ///     Gets whether canonical accepted-quest prefetch is enabled by the
+  ///     current translation configuration.
+  /// </summary>
+  /// <param name="configuration">The active plugin configuration.</param>
+  /// <returns><see langword="true" /> when canonical prefetch is enabled.</returns>
+  private static bool IsAcceptedQuestCanonicalPrefetchEnabled(Config configuration)
+  {
+    return configuration.Translate &&
+           (configuration.TranslateJournal ||
+            configuration.TranslateJournalDetail ||
+            configuration.TranslateJournalAccept ||
+            configuration.TranslateJournalResult ||
+            configuration.TranslateToDoList ||
+            configuration.TranslateScenarioTree ||
+            configuration.TranslateRecommendList ||
+            configuration.TranslateAreaMap);
+  }
+
+  /// <summary>
+  ///     Gets whether accepted-quest dialogue metadata generation is enabled
+  ///     by a dialogue translation surface.
+  /// </summary>
+  /// <param name="configuration">The active plugin configuration.</param>
+  /// <returns><see langword="true" /> when metadata generation is enabled.</returns>
+  private static bool IsAcceptedQuestDialogueMetadataGenerationEnabled(Config configuration)
+  {
+    return configuration.Translate &&
+           (configuration.TranslateTalk || configuration.TranslateBattleTalk);
   }
 
   /// <summary>
@@ -306,17 +332,24 @@ public partial class Echoglossian
       return;
     }
 
-    this.acceptedQuestPrefetchActionPump.Enqueue(
-        () => this.ProcessAcceptedQuestPrefetchWorkItem(workItem));
-    this.ScheduleAcceptedQuestDialogueMetadataGeneration(
-        new AcceptedQuestDialogueMetadataWorkItem(
-            workItem.QuestProgressSnapshot,
-            workItem.SourceLanguage,
-            GetGameVersion() ?? string.Empty,
-            AcceptedQuestDialogueMetadataDerivationVersion,
-            this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc(),
-            workItem.Generation,
-            this.acceptedQuestDialogueMetadataGenerationCancellationSource.Token));
+    if (IsAcceptedQuestCanonicalPrefetchEnabled(this.configuration))
+    {
+      this.acceptedQuestPrefetchActionPump.Enqueue(
+          () => this.ProcessAcceptedQuestPrefetchWorkItem(workItem));
+    }
+
+    if (IsAcceptedQuestDialogueMetadataGenerationEnabled(this.configuration))
+    {
+      this.ScheduleAcceptedQuestDialogueMetadataGeneration(
+          new AcceptedQuestDialogueMetadataWorkItem(
+              workItem.QuestProgressSnapshot,
+              workItem.SourceLanguage,
+              GetGameVersion() ?? string.Empty,
+              AcceptedQuestDialogueMetadataDerivationVersion,
+              this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc(),
+              workItem.Generation,
+              this.acceptedQuestDialogueMetadataGenerationCancellationSource.Token));
+    }
   }
 
   /// <summary>

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -13,6 +13,8 @@ public partial class Echoglossian
 {
   private const int AcceptedQuestPrefetchQuestsPerTick = 2;
 
+  private const string AcceptedQuestDialogueMetadataDerivationVersion = "v1";
+
   private const bool AcceptedQuestPrefetchEmitDalamudLog = true;
 
   private const bool AcceptedQuestPrefetchEmitCanonicalDiagnostic = false;
@@ -26,6 +28,9 @@ public partial class Echoglossian
       acceptedQuestPrefetchRequestedQuestQueue = new();
 
   private readonly AsyncSerialActionPump acceptedQuestPrefetchActionPump =
+      new();
+
+  private readonly OwnedAsyncOperationSet acceptedQuestDialogueMetadataOperations =
       new();
 
   private string acceptedQuestPrefetchSignature = string.Empty;
@@ -293,6 +298,60 @@ public partial class Echoglossian
 
     this.acceptedQuestPrefetchActionPump.Enqueue(
         () => this.ProcessAcceptedQuestPrefetchWorkItem(workItem));
+    this.ScheduleAcceptedQuestDialogueMetadataGeneration(
+        new AcceptedQuestDialogueMetadataWorkItem(
+            workItem.QuestProgressSnapshot,
+            workItem.SourceLanguage,
+            GetGameVersion() ?? string.Empty,
+            AcceptedQuestDialogueMetadataDerivationVersion,
+            workItem.Generation));
+  }
+
+  /// <summary>
+  ///     Starts owned background generation of persistent dialogue metadata for
+  ///     one accepted-quest snapshot.
+  /// </summary>
+  /// <param name="workItem">The immutable metadata generation work item.</param>
+  private void ScheduleAcceptedQuestDialogueMetadataGeneration(
+      AcceptedQuestDialogueMetadataWorkItem workItem)
+  {
+    this.acceptedQuestDialogueMetadataOperations.Run(
+        cancellationToken =>
+            this.ProcessAcceptedQuestDialogueMetadataWorkItemAsync(
+                workItem,
+                cancellationToken));
+  }
+
+  /// <summary>
+  ///     Derives and persists dialogue metadata without blocking the framework
+  ///     tick that captured the accepted quest.
+  /// </summary>
+  /// <param name="workItem">The immutable metadata generation work item.</param>
+  /// <param name="cancellationToken">The token that cancels the owned operation.</param>
+  /// <returns>A task representing the metadata generation operation.</returns>
+  private async Task ProcessAcceptedQuestDialogueMetadataWorkItemAsync(
+      AcceptedQuestDialogueMetadataWorkItem workItem,
+      CancellationToken cancellationToken)
+  {
+    var dialogueEntries = QuestDialogueMetadataDerivation.ReadDialogueEntries(
+        workItem.QuestProgressSnapshot);
+    var metadataEntries = QuestDialogueMetadataDerivation.BuildEntries(
+        workItem.QuestProgressSnapshot,
+        dialogueEntries,
+        workItem.SourceLanguage.PersistenceCode,
+        workItem.GameVersion,
+        workItem.DerivationVersion,
+        DateTime.UtcNow);
+    if (workItem.Generation !=
+        Volatile.Read(ref this.acceptedQuestPrefetchGeneration))
+    {
+      return;
+    }
+
+    await this.UpsertQuestDialogueMetadataBatchAsync(
+            metadataEntries,
+            cancellationToken)
+        .ConfigureAwait(false);
   }
 
   /// <summary>
@@ -1443,6 +1502,13 @@ public partial class Echoglossian
       QuestCanonicalData QuestCanonicalData,
       SourceClientLanguage SourceLanguage,
       TranslationReuseScope Scope,
+      int Generation);
+
+  private readonly record struct AcceptedQuestDialogueMetadataWorkItem(
+      QuestProgressSnapshot QuestProgressSnapshot,
+      SourceClientLanguage SourceLanguage,
+      string GameVersion,
+      string DerivationVersion,
       int Generation);
 }
 

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -312,8 +312,8 @@ public partial class Echoglossian
   }
 
   /// <summary>
-  ///     Captures one accepted-quest snapshot on the plugin tick and queues the
-  ///     heavy canonical prefetch work onto a serialized background worker.
+  ///     Captures lightweight accepted-quest state on the plugin tick and queues
+  ///     sheet-backed work onto a serialized background worker.
   /// </summary>
   /// <param name="questId">The accepted quest identifier.</param>
   /// <param name="requestSources">
@@ -332,24 +332,8 @@ public partial class Echoglossian
       return;
     }
 
-    if (IsAcceptedQuestCanonicalPrefetchEnabled(this.configuration))
-    {
-      this.acceptedQuestPrefetchActionPump.Enqueue(
-          () => this.ProcessAcceptedQuestPrefetchWorkItem(workItem));
-    }
-
-    if (IsAcceptedQuestDialogueMetadataGenerationEnabled(this.configuration))
-    {
-      this.ScheduleAcceptedQuestDialogueMetadataGeneration(
-          new AcceptedQuestDialogueMetadataWorkItem(
-              workItem.QuestProgressSnapshot,
-              workItem.SourceLanguage,
-              GetGameVersion() ?? string.Empty,
-              AcceptedQuestDialogueMetadataDerivationVersion,
-              this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc(),
-              workItem.Generation,
-              this.acceptedQuestDialogueMetadataGenerationCancellationSource.Token));
-    }
+    this.acceptedQuestPrefetchActionPump.Enqueue(
+        () => this.ProcessAcceptedQuestPrefetchWorkItem(workItem));
   }
 
   /// <summary>
@@ -403,14 +387,16 @@ public partial class Echoglossian
       CancellationToken cancellationToken)
   {
     var dialogueEntries = QuestDialogueMetadataDerivation.ReadDialogueEntries(
-        workItem.QuestProgressSnapshot);
+        workItem.QuestProgressSnapshot,
+        cancellationToken);
     var metadataEntries = QuestDialogueMetadataDerivation.BuildEntries(
         workItem.QuestProgressSnapshot,
         dialogueEntries,
         workItem.SourceLanguage.PersistenceCode,
         workItem.GameVersion,
         workItem.DerivationVersion,
-        workItem.ObservedAtUtc);
+        workItem.ObservedAtUtc,
+        cancellationToken);
     if (workItem.Generation !=
         Volatile.Read(ref this.acceptedQuestPrefetchGeneration))
     {
@@ -427,7 +413,7 @@ public partial class Echoglossian
 
   /// <summary>
   ///     Captures one immutable accepted-quest prefetch work item from the
-  ///     current live quest state.
+  ///     current live quest state without traversing Lumina sheets.
   /// </summary>
   /// <param name="questId">The accepted quest identifier.</param>
   /// <param name="requestSources">
@@ -435,7 +421,7 @@ public partial class Echoglossian
   ///     prefetch cycle.
   /// </param>
   /// <param name="workItem">
-  ///     The captured background work item when snapshot capture succeeds.
+  ///     The captured background work item when native state capture succeeds.
   /// </param>
   /// <returns><see langword="true" /> when a complete work item was captured.</returns>
   private bool TryCaptureAcceptedQuestPrefetchWorkItem(
@@ -452,18 +438,6 @@ public partial class Echoglossian
         detail:
         $"source={requestSourceLabel}; Accepted-quest prefetch tick queued this quest for background processing.");
 
-    if (!QuestProgressResolver.TryResolveQuestProgress(
-            questId.ToString(CultureInfo.InvariantCulture),
-            out var questProgressSnapshot))
-    {
-      this.LogAcceptedQuestPrefetchEvent(
-          "resolve-failed",
-          questId,
-          detail: "QuestProgressResolver could not resolve live progress for this accepted quest.");
-      workItem = default;
-      return false;
-    }
-
     if (!TryCapturePrefetchOperationScope(
             ResolveCurrentPrefetchSourceLanguage,
             this.configuration,
@@ -474,14 +448,25 @@ public partial class Echoglossian
       return false;
     }
 
+    var runtimeQuestId = (ushort)(questId & 0xFFFF);
+    var questProgressCapture = new QuestProgressCapture(
+        questId,
+        QuestManager.GetQuestSequence(runtimeQuestId),
+        ClientStateInterface.ClientLanguage);
+    var generateDialogueMetadata =
+        IsAcceptedQuestDialogueMetadataGenerationEnabled(this.configuration);
     workItem = new AcceptedQuestPrefetchWorkItem(
-        questProgressSnapshot,
-        QuestCanonicalData.Create(
-            questProgressSnapshot,
-            GetGameVersion()),
+        questProgressCapture,
         sourceLanguage,
         scope,
-        Volatile.Read(ref this.acceptedQuestPrefetchGeneration));
+        GetGameVersion() ?? string.Empty,
+        IsAcceptedQuestCanonicalPrefetchEnabled(this.configuration),
+        generateDialogueMetadata,
+        generateDialogueMetadata
+            ? this.CaptureAcceptedQuestDialogueMetadataObservedAtUtc()
+            : default,
+        Volatile.Read(ref this.acceptedQuestPrefetchGeneration),
+        this.acceptedQuestDialogueMetadataGenerationCancellationSource.Token);
     return true;
   }
 
@@ -499,8 +484,46 @@ public partial class Echoglossian
       return;
     }
 
-    var questProgressSnapshot = workItem.QuestProgressSnapshot;
-    var questCanonicalData = workItem.QuestCanonicalData;
+    if (!QuestProgressResolver.TryResolveQuestProgress(
+            workItem.QuestProgressCapture,
+            workItem.GenerationCancellationToken,
+            out var questProgressSnapshot))
+    {
+      this.LogAcceptedQuestPrefetchEvent(
+          "resolve-failed",
+          workItem.QuestProgressCapture.QuestId,
+          detail: "QuestProgressResolver could not resolve live progress for this accepted quest.");
+      return;
+    }
+
+    if (workItem.Generation !=
+        Volatile.Read(ref this.acceptedQuestPrefetchGeneration))
+    {
+      return;
+    }
+
+    workItem.GenerationCancellationToken.ThrowIfCancellationRequested();
+    if (workItem.GenerateDialogueMetadata)
+    {
+      this.ScheduleAcceptedQuestDialogueMetadataGeneration(
+          new AcceptedQuestDialogueMetadataWorkItem(
+              questProgressSnapshot,
+              workItem.SourceLanguage,
+              workItem.GameVersion,
+              AcceptedQuestDialogueMetadataDerivationVersion,
+              workItem.ObservedAtUtc,
+              workItem.Generation,
+              workItem.GenerationCancellationToken));
+    }
+
+    if (!workItem.RunCanonicalPrefetch)
+    {
+      return;
+    }
+
+    var questCanonicalData = QuestCanonicalData.Create(
+        questProgressSnapshot,
+        workItem.GameVersion);
     var currentQuestSequenceText = questCanonicalData.CurrentSequenceText;
     var translationService = TranslationService;
     var nameDispatchResult = RunAcceptedQuestPrefetchOperationEntry(
@@ -1569,11 +1592,15 @@ public partial class Echoglossian
   }
 
   private readonly record struct AcceptedQuestPrefetchWorkItem(
-      QuestProgressSnapshot QuestProgressSnapshot,
-      QuestCanonicalData QuestCanonicalData,
+      QuestProgressCapture QuestProgressCapture,
       SourceClientLanguage SourceLanguage,
       TranslationReuseScope Scope,
-      int Generation);
+      string GameVersion,
+      bool RunCanonicalPrefetch,
+      bool GenerateDialogueMetadata,
+      DateTime ObservedAtUtc,
+      int Generation,
+      CancellationToken GenerationCancellationToken);
 
   private readonly record struct AcceptedQuestDialogueMetadataWorkItem(
       QuestProgressSnapshot QuestProgressSnapshot,

--- a/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
+++ b/NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs
@@ -33,6 +33,9 @@ public partial class Echoglossian
   private readonly OwnedAsyncOperationSet acceptedQuestDialogueMetadataOperations =
       new();
 
+  private CancellationTokenSource acceptedQuestDialogueMetadataGenerationCancellationSource =
+      new();
+
   private string acceptedQuestPrefetchSignature = string.Empty;
 
   private DateTime acceptedQuestPrefetchLastTickUtc = DateTime.MinValue;
@@ -186,6 +189,11 @@ public partial class Echoglossian
   /// </summary>
   private void ClearAcceptedQuestPrefetchState()
   {
+    var previousGenerationCancellationSource = Interlocked.Exchange(
+        ref this.acceptedQuestDialogueMetadataGenerationCancellationSource,
+        new CancellationTokenSource());
+    previousGenerationCancellationSource.Cancel();
+    previousGenerationCancellationSource.Dispose();
     Interlocked.Increment(ref this.acceptedQuestPrefetchGeneration);
     this.acceptedQuestPrefetchQueue.Clear();
     this.acceptedQuestPrefetchRequestedQuestQueue.Clear();
@@ -304,7 +312,8 @@ public partial class Echoglossian
             workItem.SourceLanguage,
             GetGameVersion() ?? string.Empty,
             AcceptedQuestDialogueMetadataDerivationVersion,
-            workItem.Generation));
+            workItem.Generation,
+            this.acceptedQuestDialogueMetadataGenerationCancellationSource.Token));
   }
 
   /// <summary>
@@ -319,7 +328,8 @@ public partial class Echoglossian
         cancellationToken =>
             this.ProcessAcceptedQuestDialogueMetadataWorkItemAsync(
                 workItem,
-                cancellationToken));
+                cancellationToken),
+        workItem.GenerationCancellationToken);
   }
 
   /// <summary>
@@ -347,6 +357,8 @@ public partial class Echoglossian
     {
       return;
     }
+
+    cancellationToken.ThrowIfCancellationRequested();
 
     await this.UpsertQuestDialogueMetadataBatchAsync(
             metadataEntries,
@@ -1509,7 +1521,8 @@ public partial class Echoglossian
       SourceClientLanguage SourceLanguage,
       string GameVersion,
       string DerivationVersion,
-      int Generation);
+      int Generation,
+      CancellationToken GenerationCancellationToken);
 }
 
 

--- a/NativeUI/Helpers/AddonHandlerWiring.cs
+++ b/NativeUI/Helpers/AddonHandlerWiring.cs
@@ -131,7 +131,7 @@ public partial class Echoglossian
               Handler: new TalkHandler(
                   this.configuration,
                   TranslationService,
-                  this.FindAndReturnTalkMessage,
+                  this.FindAndReturnTalkMessageAsync,
                   (talkMessage, cancellationToken) =>
                       InsertTalkData(talkMessage, cancellationToken),
                   (translatedName, translatedText, originalName) =>

--- a/NativeUI/Helpers/AddonHandlerWiring.cs
+++ b/NativeUI/Helpers/AddonHandlerWiring.cs
@@ -143,7 +143,8 @@ public partial class Echoglossian
                   () => this.ClearOverlay(this.talkOverlay, clearText: true),
                   text => this.RemoveDiacritics(
                       text,
-                      this.SpecialCharsSupportedByGameFont))));
+                      this.SpecialCharsSupportedByGameFont),
+                  this.ResolveDialogueInterlocutorHintsAsync)));
     }
 
     if (this.configuration.TranslateBattleTalk)
@@ -169,7 +170,8 @@ public partial class Echoglossian
                       clearText: true),
                   text => this.RemoveDiacritics(
                       text,
-                      this.SpecialCharsSupportedByGameFont))));
+                      this.SpecialCharsSupportedByGameFont),
+                  this.ResolveDialogueInterlocutorHintsAsync)));
     }
 
     if (this.configuration.TranslateTalkSubtitle)
@@ -628,6 +630,54 @@ public partial class Echoglossian
       //   "_BattleTalk",
       //   lifecycleLogEventsWithoutUpdatesAndDraws);
 
+  }
+
+  /// <summary>
+  ///     Projects resolver output onto the smaller per-request dialogue hint
+  ///     contract without retaining live actor snapshots in translation state.
+  /// </summary>
+  /// <param name="metadata">The resolved quest and live interlocutor metadata.</param>
+  /// <returns>The hints applicable to the current dialogue translation request.</returns>
+  private static DialogueInterlocutorHints CreateDialogueInterlocutorHints(
+      DialogueInterlocutorMetadata? metadata)
+  {
+    return metadata == null
+        ? default
+        : new DialogueInterlocutorHints(
+            metadata.SpeakerRoleHint,
+            metadata.SpeakerGenderHint,
+            metadata.AddresseeHint,
+            metadata.AddresseeRoleHint,
+            metadata.AddresseeGenderHint,
+            metadata.ResolutionTier.ToString(),
+            metadata.ResolutionTier.ToString());
+  }
+
+  /// <summary>
+  ///     Resolves current dialogue hints through the owned handler operation
+  ///     instead of the native callback that queued it.
+  /// </summary>
+  /// <param name="originalName">The visible dialogue speaker name.</param>
+  /// <param name="originalText">The visible dialogue source text.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="cancellationToken">The handler-owned cancellation token.</param>
+  /// <returns>The resolved hints for the current dialogue request.</returns>
+  private async Task<DialogueInterlocutorHints> ResolveDialogueInterlocutorHintsAsync(
+      string originalName,
+      string originalText,
+      SourceClientLanguage sourceLanguage,
+      CancellationToken cancellationToken)
+  {
+    var resolver = new DialogueInterlocutorMetadataResolver(this);
+    var metadata = await resolver.ResolveAsync(
+        new DialogueInterlocutorMetadataRequest(
+            originalText,
+            originalName,
+            sourceLanguage.PersistenceCode,
+            GetGameVersion() ?? string.Empty,
+            AcceptedQuestDialogueMetadataDerivationVersion),
+        cancellationToken).ConfigureAwait(false);
+    return CreateDialogueInterlocutorHints(metadata);
   }
 }
 

--- a/NativeUI/Helpers/AddonHandlerWiring.cs
+++ b/NativeUI/Helpers/AddonHandlerWiring.cs
@@ -153,7 +153,7 @@ public partial class Echoglossian
               Handler: new BattleTalkHandler(
                   this.configuration,
                   TranslationService,
-                  this.FindAndReturnBattleTalkMessage,
+                  this.FindAndReturnBattleTalkMessageAsync,
                   (battleTalkMessage, cancellationToken) =>
                       InsertBattleTalkDataAsync(
                           battleTalkMessage,

--- a/NativeUI/Helpers/AddonHandlerWiring.cs
+++ b/NativeUI/Helpers/AddonHandlerWiring.cs
@@ -649,8 +649,8 @@ public partial class Echoglossian
             metadata.AddresseeHint,
             metadata.AddresseeRoleHint,
             metadata.AddresseeGenderHint,
-            metadata.ResolutionTier.ToString(),
-            metadata.ResolutionTier.ToString());
+            metadata.Provenance,
+            metadata.ConfidenceTier);
   }
 
   /// <summary>

--- a/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
@@ -19,6 +19,12 @@ public enum DialogueInterlocutorResolutionTier
     ///     Indicates that persisted quest-sheet metadata was enriched by a live actor.
     /// </summary>
     QuestSheetPlusLiveFusion,
+
+    /// <summary>
+    ///     Indicates that no exact persisted metadata existed, so a unique visible
+    ///     speaker match against live actors supplied the available hints.
+    /// </summary>
+    LiveActorVisibleSpeakerFallback,
 }
 
 /// <summary>

--- a/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
@@ -52,6 +52,25 @@ public sealed record LiveDialogueActorSnapshot(
     string? BodyTypeHint);
 
 /// <summary>
+///     Carries resolved interlocutor hints for one current dialogue request.
+/// </summary>
+/// <param name="SpeakerRoleHint">The resolved speaker role hint.</param>
+/// <param name="SpeakerGenderHint">The resolved speaker gender hint.</param>
+/// <param name="AddresseeHint">The resolved addressee name hint.</param>
+/// <param name="AddresseeRoleHint">The resolved addressee role hint.</param>
+/// <param name="AddresseeGenderHint">The resolved addressee gender hint.</param>
+/// <param name="MetadataProvenance">The source that resolved the metadata.</param>
+/// <param name="MetadataConfidenceTier">The confidence tier of the resolved metadata.</param>
+public readonly record struct DialogueInterlocutorHints(
+    string? SpeakerRoleHint,
+    string? SpeakerGenderHint,
+    string? AddresseeHint,
+    string? AddresseeRoleHint,
+    string? AddresseeGenderHint,
+    string? MetadataProvenance,
+    string? MetadataConfidenceTier);
+
+/// <summary>
 ///     Represents the resolved persisted and live dialogue interlocutor hints.
 /// </summary>
 public sealed class DialogueInterlocutorMetadata

--- a/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
@@ -68,7 +68,7 @@ public readonly record struct DialogueInterlocutorHints(
     string? AddresseeRoleHint,
     string? AddresseeGenderHint,
     string? MetadataProvenance,
-    string? MetadataConfidenceTier);
+    int? MetadataConfidenceTier);
 
 /// <summary>
 ///     Represents the resolved persisted and live dialogue interlocutor hints.
@@ -79,6 +79,16 @@ public sealed class DialogueInterlocutorMetadata
     ///     Gets the evidence tier used for this result.
     /// </summary>
     public required DialogueInterlocutorResolutionTier ResolutionTier { get; init; }
+
+    /// <summary>
+    ///     Gets the persisted metadata provenance.
+    /// </summary>
+    public required string Provenance { get; init; }
+
+    /// <summary>
+    ///     Gets the persisted numeric confidence tier.
+    /// </summary>
+    public required int ConfidenceTier { get; init; }
 
     /// <summary>
     ///     Gets the persisted speaker hint.

--- a/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadata.cs
@@ -1,0 +1,123 @@
+// <copyright file="DialogueInterlocutorMetadata.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian;
+
+/// <summary>
+///     Specifies the evidence tier used to resolve dialogue interlocutor metadata.
+/// </summary>
+public enum DialogueInterlocutorResolutionTier
+{
+    /// <summary>
+    ///     Indicates that exact persisted quest-sheet metadata supplied the result.
+    /// </summary>
+    QuestSheetDerivedExact,
+
+    /// <summary>
+    ///     Indicates that persisted quest-sheet metadata was enriched by a live actor.
+    /// </summary>
+    QuestSheetPlusLiveFusion,
+}
+
+/// <summary>
+///     Represents the managed dialogue input used to resolve interlocutor metadata.
+/// </summary>
+/// <param name="SourceText">The visible source dialogue text.</param>
+/// <param name="VisibleSpeakerName">The visible speaker name, when available.</param>
+/// <param name="SourceLanguageCode">The source language persistence code.</param>
+/// <param name="GameVersion">The game version that supplied the source text.</param>
+/// <param name="DerivationVersion">The quest metadata derivation version.</param>
+public readonly record struct DialogueInterlocutorMetadataRequest(
+    string SourceText,
+    string? VisibleSpeakerName,
+    string SourceLanguageCode,
+    string GameVersion,
+    string DerivationVersion);
+
+/// <summary>
+///     Represents a copied live actor state that is safe to retain across awaits.
+/// </summary>
+/// <param name="Name">The actor name.</param>
+/// <param name="DataId">The actor data identifier.</param>
+/// <param name="GenderHint">The actor gender hint.</param>
+/// <param name="RaceHint">The actor race hint.</param>
+/// <param name="BodyTypeHint">The actor body-type hint.</param>
+public sealed record LiveDialogueActorSnapshot(
+    string Name,
+    uint DataId,
+    string? GenderHint,
+    string? RaceHint,
+    string? BodyTypeHint);
+
+/// <summary>
+///     Represents the resolved persisted and live dialogue interlocutor hints.
+/// </summary>
+public sealed class DialogueInterlocutorMetadata
+{
+    /// <summary>
+    ///     Gets the evidence tier used for this result.
+    /// </summary>
+    public required DialogueInterlocutorResolutionTier ResolutionTier { get; init; }
+
+    /// <summary>
+    ///     Gets the persisted speaker hint.
+    /// </summary>
+    public required string SpeakerHint { get; init; }
+
+    /// <summary>
+    ///     Gets the persisted addressee hint.
+    /// </summary>
+    public required string AddresseeHint { get; init; }
+
+    /// <summary>
+    ///     Gets the persisted speaker role hint.
+    /// </summary>
+    public required string SpeakerRoleHint { get; init; }
+
+    /// <summary>
+    ///     Gets the persisted addressee role hint.
+    /// </summary>
+    public required string AddresseeRoleHint { get; init; }
+
+    /// <summary>
+    ///     Gets the resolved speaker gender hint.
+    /// </summary>
+    public string? SpeakerGenderHint { get; init; }
+
+    /// <summary>
+    ///     Gets the resolved speaker race hint.
+    /// </summary>
+    public string? SpeakerRaceHint { get; init; }
+
+    /// <summary>
+    ///     Gets the resolved speaker body-type hint.
+    /// </summary>
+    public string? SpeakerBodyTypeHint { get; init; }
+
+    /// <summary>
+    ///     Gets the resolved addressee gender hint.
+    /// </summary>
+    public string? AddresseeGenderHint { get; init; }
+
+    /// <summary>
+    ///     Gets the resolved addressee race hint.
+    /// </summary>
+    public string? AddresseeRaceHint { get; init; }
+
+    /// <summary>
+    ///     Gets the resolved addressee body-type hint.
+    /// </summary>
+    public string? AddresseeBodyTypeHint { get; init; }
+
+    /// <summary>
+    ///     Gets the copied live speaker actor, when one matched.
+    /// </summary>
+    public LiveDialogueActorSnapshot? SpeakerActor { get; init; }
+
+    /// <summary>
+    ///     Gets the copied live addressee actor, when one matched.
+    /// </summary>
+    public LiveDialogueActorSnapshot? AddresseeActor { get; init; }
+}

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -7,6 +7,8 @@ using Dalamud.Game.ClientState.Objects.Types;
 
 using Echoglossian.EFCoreSqlite.Models.Journal;
 
+using QuestManager = FFXIVClientStructs.FFXIV.Client.Game.QuestManager;
+
 namespace Echoglossian;
 
 /// <summary>
@@ -16,13 +18,14 @@ namespace Echoglossian;
 public sealed class DialogueInterlocutorMetadataResolver
 {
     private readonly Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors;
+    private readonly Func<uint, byte> captureQuestSequence;
     private readonly Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync;
     private readonly Func<string> localPlayerName;
     private readonly Func<string?> playerSexHint;
-    private readonly Func<QuestProgressSnapshot, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries;
+    private readonly Func<QuestProgressSnapshot, CancellationToken, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries;
     private readonly Func<Action, CancellationToken, Task> runOnFrameworkThreadAsync;
     private readonly Func<IReadOnlyList<uint>> tryCollectAcceptedQuestIds;
-    private readonly Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress;
+    private readonly Func<uint, byte, CancellationToken, QuestProgressSnapshot?> tryResolveQuestProgress;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="DialogueInterlocutorMetadataResolver" /> class.
@@ -31,6 +34,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     public DialogueInterlocutorMetadataResolver(Echoglossian plugin)
         : this(
             CollectAcceptedQuestIds,
+            CaptureQuestSequence,
             ResolveQuestProgress,
             QuestDialogueMetadataDerivation.ReadDialogueEntries,
             plugin.FindQuestDialogueMetadataAsync,
@@ -45,6 +49,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     ///     Initializes a new instance of the <see cref="DialogueInterlocutorMetadataResolver" /> class.
     /// </summary>
     /// <param name="tryCollectAcceptedQuestIds">The accepted quest identifier collector.</param>
+    /// <param name="captureQuestSequence">The live quest sequence capture.</param>
     /// <param name="tryResolveQuestProgress">The live quest progress resolver.</param>
     /// <param name="readDialogueEntries">The quest dialogue row reader.</param>
     /// <param name="findMetadataAsync">The exact persisted metadata lookup.</param>
@@ -54,8 +59,9 @@ public sealed class DialogueInterlocutorMetadataResolver
     /// <param name="runOnFrameworkThreadAsync">The native capture scheduler.</param>
     internal DialogueInterlocutorMetadataResolver(
         Func<IReadOnlyList<uint>> tryCollectAcceptedQuestIds,
-        Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress,
-        Func<QuestProgressSnapshot, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries,
+        Func<uint, byte> captureQuestSequence,
+        Func<uint, byte, CancellationToken, QuestProgressSnapshot?> tryResolveQuestProgress,
+        Func<QuestProgressSnapshot, CancellationToken, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries,
         Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync,
         Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors,
         Func<string> localPlayerName,
@@ -63,6 +69,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         Func<Action, CancellationToken, Task>? runOnFrameworkThreadAsync = null)
     {
         this.tryCollectAcceptedQuestIds = tryCollectAcceptedQuestIds;
+        this.captureQuestSequence = captureQuestSequence;
         this.tryResolveQuestProgress = tryResolveQuestProgress;
         this.readDialogueEntries = readDialogueEntries;
         this.findMetadataAsync = findMetadataAsync;
@@ -104,7 +111,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         var localPlayerName = captureSnapshot.LocalPlayerName;
         var playerSexHint = captureSnapshot.PlayerSexHint;
         var matchingRows = this.FindMatchingRows(
-            captureSnapshot.AcceptedQuestIds,
+            captureSnapshot.AcceptedQuests,
             request.SourceText,
             cancellationToken);
 
@@ -176,38 +183,45 @@ public sealed class DialogueInterlocutorMetadataResolver
         var liveActors = this.captureLiveActors().ToArray();
         var localPlayerName = this.localPlayerName();
         var playerSexHint = this.playerSexHint();
-        var acceptedQuestIds = this.tryCollectAcceptedQuestIds().ToArray();
+        var acceptedQuests = this.tryCollectAcceptedQuestIds()
+            .Select(questId => new AcceptedQuestCapture(
+                questId,
+                this.captureQuestSequence(questId)))
+            .ToArray();
         return new ResolverCaptureSnapshot(
             liveActors,
             localPlayerName,
             playerSexHint,
-            acceptedQuestIds);
+            acceptedQuests);
     }
 
     /// <summary>
     ///     Resolves exact accepted-quest dialogue rows outside the native capture
     ///     scheduler using the copied accepted quest identifiers.
     /// </summary>
-    /// <param name="acceptedQuestIds">The accepted quest identifiers captured on the framework thread.</param>
+    /// <param name="acceptedQuests">The accepted quest identifiers and sequences captured on the framework thread.</param>
     /// <param name="sourceText">The visible source text requiring an exact match.</param>
     /// <param name="cancellationToken">The token that cancels traversal.</param>
     /// <returns>The exact matching quest snapshots and dialogue entries.</returns>
     private IReadOnlyList<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> FindMatchingRows(
-        IReadOnlyList<uint> acceptedQuestIds,
+        IReadOnlyList<AcceptedQuestCapture> acceptedQuests,
         string sourceText,
         CancellationToken cancellationToken)
     {
         List<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> matchingRows = [];
-        foreach (var acceptedQuestId in acceptedQuestIds)
+        foreach (var acceptedQuest in acceptedQuests)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var questProgress = this.tryResolveQuestProgress(acceptedQuestId);
+            var questProgress = this.tryResolveQuestProgress(
+                acceptedQuest.QuestId,
+                acceptedQuest.QuestSequence,
+                cancellationToken);
             if (!questProgress.HasValue)
             {
                 continue;
             }
 
-            foreach (var entry in this.readDialogueEntries(questProgress.Value))
+            foreach (var entry in this.readDialogueEntries(questProgress.Value, cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (entry.QuestSequence == questProgress.Value.QuestSequence &&
@@ -258,10 +272,22 @@ public sealed class DialogueInterlocutorMetadataResolver
         return QuestProgressResolver.TryCollectAcceptedQuestIds(out var questIds) ? questIds : [];
     }
 
-    private static QuestProgressSnapshot? ResolveQuestProgress(uint questId)
+    private static byte CaptureQuestSequence(uint questId)
+    {
+        return QuestManager.GetQuestSequence((ushort)(questId & 0xFFFF));
+    }
+
+    private static QuestProgressSnapshot? ResolveQuestProgress(
+        uint questId,
+        byte questSequence,
+        CancellationToken cancellationToken)
     {
         return QuestProgressResolver.TryResolveQuestProgress(
-            questId.ToString(CultureInfo.InvariantCulture),
+            new QuestProgressCapture(
+                questId,
+                questSequence,
+                Echoglossian.ClientStateInterface.ClientLanguage),
+            cancellationToken,
             out var snapshot) ? snapshot : null;
     }
 
@@ -355,10 +381,20 @@ public sealed class DialogueInterlocutorMetadataResolver
     /// <param name="LiveActors">The copied live actor snapshots.</param>
     /// <param name="LocalPlayerName">The copied local player name.</param>
     /// <param name="PlayerSexHint">The copied local player sex hint.</param>
-    /// <param name="AcceptedQuestIds">The copied accepted quest identifiers.</param>
+    /// <param name="AcceptedQuests">The copied accepted quest identifiers and sequences.</param>
     private sealed record ResolverCaptureSnapshot(
         IReadOnlyList<LiveDialogueActorSnapshot> LiveActors,
         string LocalPlayerName,
         string? PlayerSexHint,
-        IReadOnlyList<uint> AcceptedQuestIds);
+        IReadOnlyList<AcceptedQuestCapture> AcceptedQuests);
+
+    /// <summary>
+    ///     Carries one accepted quest's native identity and sequence beyond the
+    ///     framework-thread capture boundary.
+    /// </summary>
+    /// <param name="QuestId">The accepted quest identifier.</param>
+    /// <param name="QuestSequence">The captured live quest sequence.</param>
+    private readonly record struct AcceptedQuestCapture(
+        uint QuestId,
+        byte QuestSequence);
 }

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -92,7 +92,7 @@ public sealed class DialogueInterlocutorMetadataResolver
 
         ResolverCaptureSnapshot? captureSnapshot = null;
         await this.runOnFrameworkThreadAsync(
-            () => captureSnapshot = this.CaptureSnapshot(request),
+            () => captureSnapshot = this.CaptureSnapshot(),
             cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
         if (captureSnapshot == null)
@@ -103,7 +103,10 @@ public sealed class DialogueInterlocutorMetadataResolver
         var liveActors = captureSnapshot.LiveActors;
         var localPlayerName = captureSnapshot.LocalPlayerName;
         var playerSexHint = captureSnapshot.PlayerSexHint;
-        var matchingRows = captureSnapshot.MatchingRows;
+        var matchingRows = this.FindMatchingRows(
+            captureSnapshot.AcceptedQuestIds,
+            request.SourceText,
+            cancellationToken);
 
         List<QuestDialogueMetadata> candidates = [];
         foreach (var (snapshot, entry) in matchingRows)
@@ -164,20 +167,40 @@ public sealed class DialogueInterlocutorMetadataResolver
     }
 
     /// <summary>
-    ///     Captures all native and game-owned resolver inputs into immutable
-    ///     managed values before database work begins.
+    ///     Captures native resolver inputs into immutable managed values before
+    ///     asynchronous work begins.
     /// </summary>
-    /// <param name="request">The visible dialogue source values.</param>
     /// <returns>The immutable resolver capture.</returns>
-    private ResolverCaptureSnapshot CaptureSnapshot(DialogueInterlocutorMetadataRequest request)
+    private ResolverCaptureSnapshot CaptureSnapshot()
     {
         var liveActors = this.captureLiveActors().ToArray();
         var localPlayerName = this.localPlayerName();
         var playerSexHint = this.playerSexHint();
-        var acceptedQuestIds = this.tryCollectAcceptedQuestIds();
+        var acceptedQuestIds = this.tryCollectAcceptedQuestIds().ToArray();
+        return new ResolverCaptureSnapshot(
+            liveActors,
+            localPlayerName,
+            playerSexHint,
+            acceptedQuestIds);
+    }
+
+    /// <summary>
+    ///     Resolves exact accepted-quest dialogue rows outside the native capture
+    ///     scheduler using the copied accepted quest identifiers.
+    /// </summary>
+    /// <param name="acceptedQuestIds">The accepted quest identifiers captured on the framework thread.</param>
+    /// <param name="sourceText">The visible source text requiring an exact match.</param>
+    /// <param name="cancellationToken">The token that cancels traversal.</param>
+    /// <returns>The exact matching quest snapshots and dialogue entries.</returns>
+    private IReadOnlyList<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> FindMatchingRows(
+        IReadOnlyList<uint> acceptedQuestIds,
+        string sourceText,
+        CancellationToken cancellationToken)
+    {
         List<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> matchingRows = [];
         foreach (var acceptedQuestId in acceptedQuestIds)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var questProgress = this.tryResolveQuestProgress(acceptedQuestId);
             if (!questProgress.HasValue)
             {
@@ -186,19 +209,16 @@ public sealed class DialogueInterlocutorMetadataResolver
 
             foreach (var entry in this.readDialogueEntries(questProgress.Value))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (entry.QuestSequence == questProgress.Value.QuestSequence &&
-                    string.Equals(entry.Text, request.SourceText, StringComparison.Ordinal))
+                    string.Equals(entry.Text, sourceText, StringComparison.Ordinal))
                 {
                     matchingRows.Add((questProgress.Value, entry));
                 }
             }
         }
 
-        return new ResolverCaptureSnapshot(
-            liveActors,
-            localPlayerName,
-            playerSexHint,
-            matchingRows.ToArray());
+        return matchingRows;
     }
 
     /// <summary>
@@ -335,10 +355,10 @@ public sealed class DialogueInterlocutorMetadataResolver
     /// <param name="LiveActors">The copied live actor snapshots.</param>
     /// <param name="LocalPlayerName">The copied local player name.</param>
     /// <param name="PlayerSexHint">The copied local player sex hint.</param>
-    /// <param name="MatchingRows">The copied accepted-quest dialogue matches.</param>
+    /// <param name="AcceptedQuestIds">The copied accepted quest identifiers.</param>
     private sealed record ResolverCaptureSnapshot(
         IReadOnlyList<LiveDialogueActorSnapshot> LiveActors,
         string LocalPlayerName,
         string? PlayerSexHint,
-        IReadOnlyList<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> MatchingRows);
+        IReadOnlyList<uint> AcceptedQuestIds);
 }

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -1,0 +1,253 @@
+// <copyright file="DialogueInterlocutorMetadataResolver.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Dalamud.Game.ClientState.Objects.Types;
+
+using Echoglossian.EFCoreSqlite.Models.Journal;
+
+namespace Echoglossian;
+
+/// <summary>
+///     Resolves exact persisted quest dialogue metadata and enriches it with
+///     managed live actor and player-state hints.
+/// </summary>
+public sealed class DialogueInterlocutorMetadataResolver
+{
+    private readonly Func<IReadOnlyDictionary<string, LiveDialogueActorSnapshot>> captureLiveActors;
+    private readonly Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync;
+    private readonly Func<string> localPlayerName;
+    private readonly Func<string?> playerSexHint;
+    private readonly Func<QuestProgressSnapshot, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries;
+    private readonly Func<IReadOnlyList<uint>> tryCollectAcceptedQuestIds;
+    private readonly Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DialogueInterlocutorMetadataResolver" /> class.
+    /// </summary>
+    /// <param name="plugin">The plugin that owns exact database lookups.</param>
+    public DialogueInterlocutorMetadataResolver(Echoglossian plugin)
+        : this(
+            CollectAcceptedQuestIds,
+            ResolveQuestProgress,
+            QuestDialogueMetadataDerivation.ReadDialogueEntries,
+            plugin.FindQuestDialogueMetadataAsync,
+            CaptureLiveActors,
+            CaptureLocalPlayerName,
+            CapturePlayerSexHint)
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DialogueInterlocutorMetadataResolver" /> class.
+    /// </summary>
+    /// <param name="tryCollectAcceptedQuestIds">The accepted quest identifier collector.</param>
+    /// <param name="tryResolveQuestProgress">The live quest progress resolver.</param>
+    /// <param name="readDialogueEntries">The quest dialogue row reader.</param>
+    /// <param name="findMetadataAsync">The exact persisted metadata lookup.</param>
+    /// <param name="captureLiveActors">The managed live actor snapshot collector.</param>
+    /// <param name="localPlayerName">The managed local player name reader.</param>
+    /// <param name="playerSexHint">The managed local player sex hint reader.</param>
+    internal DialogueInterlocutorMetadataResolver(
+        Func<IReadOnlyList<uint>> tryCollectAcceptedQuestIds,
+        Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress,
+        Func<QuestProgressSnapshot, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries,
+        Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync,
+        Func<IReadOnlyDictionary<string, LiveDialogueActorSnapshot>> captureLiveActors,
+        Func<string> localPlayerName,
+        Func<string?> playerSexHint)
+    {
+        this.tryCollectAcceptedQuestIds = tryCollectAcceptedQuestIds;
+        this.tryResolveQuestProgress = tryResolveQuestProgress;
+        this.readDialogueEntries = readDialogueEntries;
+        this.findMetadataAsync = findMetadataAsync;
+        this.captureLiveActors = captureLiveActors;
+        this.localPlayerName = localPlayerName;
+        this.playerSexHint = playerSexHint;
+    }
+
+    /// <summary>
+    ///     Resolves exact accepted-quest dialogue metadata for one visible text payload.
+    /// </summary>
+    /// <param name="request">The visible dialogue source values.</param>
+    /// <param name="cancellationToken">The token that cancels asynchronous database lookups.</param>
+    /// <returns>The resolved dialogue metadata; otherwise, <see langword="null" />.</returns>
+    public async Task<DialogueInterlocutorMetadata?> ResolveAsync(
+        DialogueInterlocutorMetadataRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.SourceText) ||
+            string.IsNullOrWhiteSpace(request.SourceLanguageCode) ||
+            string.IsNullOrWhiteSpace(request.GameVersion) ||
+            string.IsNullOrWhiteSpace(request.DerivationVersion))
+        {
+            return null;
+        }
+
+        // Capture all plugin-service values before database work crosses an await boundary.
+        var liveActors = this.captureLiveActors();
+        var localPlayerName = this.localPlayerName();
+        var playerSexHint = this.playerSexHint();
+        var acceptedQuestIds = this.tryCollectAcceptedQuestIds();
+        List<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> matchingRows = [];
+        foreach (var acceptedQuestId in acceptedQuestIds)
+        {
+            var questProgress = this.tryResolveQuestProgress(acceptedQuestId);
+            if (!questProgress.HasValue)
+            {
+                continue;
+            }
+
+            foreach (var entry in this.readDialogueEntries(questProgress.Value))
+            {
+                if (entry.QuestSequence == questProgress.Value.QuestSequence &&
+                    string.Equals(entry.Text, request.SourceText, StringComparison.Ordinal))
+                {
+                    matchingRows.Add((questProgress.Value, entry));
+                }
+            }
+        }
+
+        List<QuestDialogueMetadata> candidates = [];
+        foreach (var (snapshot, entry) in matchingRows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var lookup = new QuestDialogueMetadataLookup(
+                snapshot.QuestId,
+                entry.QuestSequence,
+                request.SourceLanguageCode,
+                request.GameVersion,
+                entry.RowKey,
+                QuestContentHash.ComputeLine(entry.RowKey, entry.Text),
+                request.DerivationVersion);
+            var metadata = await this.findMetadataAsync(lookup, cancellationToken).ConfigureAwait(false);
+            if (metadata != null)
+            {
+                candidates.Add(metadata);
+            }
+        }
+
+        var resolvedMetadata = SelectUniqueMetadata(candidates, request.VisibleSpeakerName);
+        if (resolvedMetadata == null)
+        {
+            return null;
+        }
+
+        liveActors.TryGetValue(resolvedMetadata.SpeakerHint, out var speakerActor);
+        liveActors.TryGetValue(resolvedMetadata.AddresseeHint, out var addresseeActor);
+        var addresseeIsPlayer = string.Equals(
+            resolvedMetadata.AddresseeHint,
+            localPlayerName,
+            StringComparison.Ordinal) || string.Equals(
+            resolvedMetadata.AddresseeRoleHint,
+            "player",
+            StringComparison.OrdinalIgnoreCase);
+        var usesLiveActor = speakerActor != null || addresseeActor != null;
+
+        return new DialogueInterlocutorMetadata
+        {
+            ResolutionTier = usesLiveActor
+                ? DialogueInterlocutorResolutionTier.QuestSheetPlusLiveFusion
+                : DialogueInterlocutorResolutionTier.QuestSheetDerivedExact,
+            SpeakerHint = resolvedMetadata.SpeakerHint,
+            AddresseeHint = resolvedMetadata.AddresseeHint,
+            SpeakerRoleHint = resolvedMetadata.SpeakerRoleHint,
+            AddresseeRoleHint = resolvedMetadata.AddresseeRoleHint,
+            SpeakerGenderHint = speakerActor?.GenderHint,
+            SpeakerRaceHint = speakerActor?.RaceHint,
+            SpeakerBodyTypeHint = speakerActor?.BodyTypeHint,
+            AddresseeGenderHint = addresseeActor?.GenderHint ?? (addresseeIsPlayer ? playerSexHint : null),
+            AddresseeRaceHint = addresseeActor?.RaceHint,
+            AddresseeBodyTypeHint = addresseeActor?.BodyTypeHint,
+            SpeakerActor = speakerActor,
+            AddresseeActor = addresseeActor,
+        };
+    }
+
+    private static IReadOnlyList<uint> CollectAcceptedQuestIds()
+    {
+        return QuestProgressResolver.TryCollectAcceptedQuestIds(out var questIds) ? questIds : [];
+    }
+
+    private static QuestProgressSnapshot? ResolveQuestProgress(uint questId)
+    {
+        return QuestProgressResolver.TryResolveQuestProgress(
+            questId.ToString(CultureInfo.InvariantCulture),
+            out var snapshot) ? snapshot : null;
+    }
+
+    private static string CaptureLocalPlayerName()
+    {
+        return Echoglossian.ObjectTableInterface?.LocalPlayer?.Name.TextValue ?? string.Empty;
+    }
+
+    private static string? CapturePlayerSexHint()
+    {
+        return NormalizeSexHint(Echoglossian.PlayerStateInterface?.Sex.ToString());
+    }
+
+    private static IReadOnlyDictionary<string, LiveDialogueActorSnapshot> CaptureLiveActors()
+    {
+        Dictionary<string, LiveDialogueActorSnapshot> actors = new(StringComparer.Ordinal);
+        if (Echoglossian.ObjectTableInterface == null)
+        {
+            return actors;
+        }
+
+        foreach (var gameObject in Echoglossian.ObjectTableInterface)
+        {
+            if (gameObject is not ICharacter character ||
+                string.IsNullOrWhiteSpace(gameObject.Name.TextValue))
+            {
+                continue;
+            }
+
+            var customize = character.CustomizeData;
+            actors.TryAdd(gameObject.Name.TextValue, new LiveDialogueActorSnapshot(
+                gameObject.Name.TextValue,
+                gameObject.BaseId,
+                NormalizeSexHint(customize.Sex.ToString()),
+                customize.Race.ToString().ToLowerInvariant(),
+                customize.BodyType.ToString().ToLowerInvariant()));
+        }
+
+        return actors;
+    }
+
+    private static QuestDialogueMetadata? SelectUniqueMetadata(
+        IReadOnlyList<QuestDialogueMetadata> candidates,
+        string? visibleSpeakerName)
+    {
+        var distinctCandidates = candidates
+            .DistinctBy(candidate => candidate.Id)
+            .ToList();
+        if (distinctCandidates.Count == 1)
+        {
+            return distinctCandidates[0];
+        }
+
+        if (string.IsNullOrWhiteSpace(visibleSpeakerName))
+        {
+            return null;
+        }
+
+        var speakerMatches = distinctCandidates
+            .Where(candidate => string.Equals(
+                candidate.SpeakerHint,
+                visibleSpeakerName,
+                StringComparison.Ordinal))
+            .ToList();
+        return speakerMatches.Count == 1 ? speakerMatches[0] : null;
+    }
+
+    private static string? NormalizeSexHint(string? sex)
+    {
+        return sex?.ToLowerInvariant() switch
+        {
+            "male" => "male",
+            "female" => "female",
+            _ => null,
+        };
+    }
+}

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -137,7 +137,11 @@ public sealed class DialogueInterlocutorMetadataResolver
         var resolvedMetadata = SelectUniqueMetadata(candidates, request.VisibleSpeakerName);
         if (resolvedMetadata == null)
         {
-            return null;
+            return BuildVisibleSpeakerLiveActorFallback(
+                request.VisibleSpeakerName,
+                liveActors,
+                localPlayerName,
+                playerSexHint);
         }
 
         var speakerActor = FindUniqueLiveActor(liveActors, resolvedMetadata.SpeakerHint);
@@ -363,6 +367,57 @@ public sealed class DialogueInterlocutorMetadataResolver
             .Where(actor => string.Equals(actor.Name, name, StringComparison.Ordinal))
             .ToList();
         return matches.Count == 1 ? matches[0] : null;
+    }
+
+    /// <summary>
+    ///     Builds a live-actor-only fallback when the visible speaker uniquely
+    ///     matches a loaded actor but exact persisted quest metadata is not yet
+    ///     available.
+    /// </summary>
+    /// <param name="visibleSpeakerName">The current visible speaker name.</param>
+    /// <param name="liveActors">The copied live actor snapshot.</param>
+    /// <param name="localPlayerName">The copied local player name.</param>
+    /// <param name="playerSexHint">The copied local player sex hint.</param>
+    /// <returns>The live-only fallback metadata; otherwise, <see langword="null" />.</returns>
+    private static DialogueInterlocutorMetadata? BuildVisibleSpeakerLiveActorFallback(
+        string? visibleSpeakerName,
+        IReadOnlyList<LiveDialogueActorSnapshot> liveActors,
+        string localPlayerName,
+        string? playerSexHint)
+    {
+        if (string.IsNullOrWhiteSpace(visibleSpeakerName))
+        {
+            return null;
+        }
+
+        var speakerActor = FindUniqueLiveActor(liveActors, visibleSpeakerName);
+        if (speakerActor == null)
+        {
+            return null;
+        }
+
+        var speakerIsPlayer = string.Equals(
+            speakerActor.Name,
+            localPlayerName,
+            StringComparison.Ordinal);
+        return new DialogueInterlocutorMetadata
+        {
+            ResolutionTier = DialogueInterlocutorResolutionTier.LiveActorVisibleSpeakerFallback,
+            Provenance = "LiveActorFallback",
+            ConfidenceTier = 0,
+            SpeakerHint = speakerActor.Name,
+            AddresseeHint = string.Empty,
+            SpeakerRoleHint = speakerIsPlayer ? "player" : "npc",
+            AddresseeRoleHint = string.Empty,
+            SpeakerGenderHint = speakerActor.GenderHint ?? (speakerIsPlayer ? playerSexHint : null),
+            SpeakerRaceHint = speakerActor.RaceHint,
+            SpeakerBodyTypeHint = speakerActor.BodyTypeHint,
+            AddresseeGenderHint = null,
+            AddresseeRaceHint = null,
+            AddresseeBodyTypeHint = null,
+            SpeakerActor = speakerActor,
+            AddresseeActor = null,
+        };
     }
 
     private static string? NormalizeSexHint(string? sex)

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -20,6 +20,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     private readonly Func<string> localPlayerName;
     private readonly Func<string?> playerSexHint;
     private readonly Func<QuestProgressSnapshot, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries;
+    private readonly Func<Action, CancellationToken, Task> runOnFrameworkThreadAsync;
     private readonly Func<IReadOnlyList<uint>> tryCollectAcceptedQuestIds;
     private readonly Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress;
 
@@ -35,7 +36,8 @@ public sealed class DialogueInterlocutorMetadataResolver
             plugin.FindQuestDialogueMetadataAsync,
             CaptureLiveActors,
             CaptureLocalPlayerName,
-            CapturePlayerSexHint)
+            CapturePlayerSexHint,
+            RunOnFrameworkThreadAsync)
     {
     }
 
@@ -49,6 +51,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     /// <param name="captureLiveActors">The managed live actor snapshot collector.</param>
     /// <param name="localPlayerName">The managed local player name reader.</param>
     /// <param name="playerSexHint">The managed local player sex hint reader.</param>
+    /// <param name="runOnFrameworkThreadAsync">The native capture scheduler.</param>
     internal DialogueInterlocutorMetadataResolver(
         Func<IReadOnlyList<uint>> tryCollectAcceptedQuestIds,
         Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress,
@@ -56,7 +59,8 @@ public sealed class DialogueInterlocutorMetadataResolver
         Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync,
         Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors,
         Func<string> localPlayerName,
-        Func<string?> playerSexHint)
+        Func<string?> playerSexHint,
+        Func<Action, CancellationToken, Task>? runOnFrameworkThreadAsync = null)
     {
         this.tryCollectAcceptedQuestIds = tryCollectAcceptedQuestIds;
         this.tryResolveQuestProgress = tryResolveQuestProgress;
@@ -65,6 +69,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         this.captureLiveActors = captureLiveActors;
         this.localPlayerName = localPlayerName;
         this.playerSexHint = playerSexHint;
+        this.runOnFrameworkThreadAsync = runOnFrameworkThreadAsync ?? RunInlineAsync;
     }
 
     /// <summary>
@@ -85,29 +90,20 @@ public sealed class DialogueInterlocutorMetadataResolver
             return null;
         }
 
-        // Capture all plugin-service values before database work crosses an await boundary.
-        var liveActors = this.captureLiveActors();
-        var localPlayerName = this.localPlayerName();
-        var playerSexHint = this.playerSexHint();
-        var acceptedQuestIds = this.tryCollectAcceptedQuestIds();
-        List<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> matchingRows = [];
-        foreach (var acceptedQuestId in acceptedQuestIds)
+        ResolverCaptureSnapshot? captureSnapshot = null;
+        await this.runOnFrameworkThreadAsync(
+            () => captureSnapshot = this.CaptureSnapshot(request),
+            cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (captureSnapshot == null)
         {
-            var questProgress = this.tryResolveQuestProgress(acceptedQuestId);
-            if (!questProgress.HasValue)
-            {
-                continue;
-            }
-
-            foreach (var entry in this.readDialogueEntries(questProgress.Value))
-            {
-                if (entry.QuestSequence == questProgress.Value.QuestSequence &&
-                    string.Equals(entry.Text, request.SourceText, StringComparison.Ordinal))
-                {
-                    matchingRows.Add((questProgress.Value, entry));
-                }
-            }
+            return null;
         }
+
+        var liveActors = captureSnapshot.LiveActors;
+        var localPlayerName = captureSnapshot.LocalPlayerName;
+        var playerSexHint = captureSnapshot.PlayerSexHint;
+        var matchingRows = captureSnapshot.MatchingRows;
 
         List<QuestDialogueMetadata> candidates = [];
         foreach (var (snapshot, entry) in matchingRows)
@@ -150,6 +146,8 @@ public sealed class DialogueInterlocutorMetadataResolver
             ResolutionTier = usesLiveActor
                 ? DialogueInterlocutorResolutionTier.QuestSheetPlusLiveFusion
                 : DialogueInterlocutorResolutionTier.QuestSheetDerivedExact,
+            Provenance = resolvedMetadata.Provenance,
+            ConfidenceTier = resolvedMetadata.ConfidenceTier,
             SpeakerHint = resolvedMetadata.SpeakerHint,
             AddresseeHint = resolvedMetadata.AddresseeHint,
             SpeakerRoleHint = resolvedMetadata.SpeakerRoleHint,
@@ -163,6 +161,76 @@ public sealed class DialogueInterlocutorMetadataResolver
             SpeakerActor = speakerActor,
             AddresseeActor = addresseeActor,
         };
+    }
+
+    /// <summary>
+    ///     Captures all native and game-owned resolver inputs into immutable
+    ///     managed values before database work begins.
+    /// </summary>
+    /// <param name="request">The visible dialogue source values.</param>
+    /// <returns>The immutable resolver capture.</returns>
+    private ResolverCaptureSnapshot CaptureSnapshot(DialogueInterlocutorMetadataRequest request)
+    {
+        var liveActors = this.captureLiveActors().ToArray();
+        var localPlayerName = this.localPlayerName();
+        var playerSexHint = this.playerSexHint();
+        var acceptedQuestIds = this.tryCollectAcceptedQuestIds();
+        List<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> matchingRows = [];
+        foreach (var acceptedQuestId in acceptedQuestIds)
+        {
+            var questProgress = this.tryResolveQuestProgress(acceptedQuestId);
+            if (!questProgress.HasValue)
+            {
+                continue;
+            }
+
+            foreach (var entry in this.readDialogueEntries(questProgress.Value))
+            {
+                if (entry.QuestSequence == questProgress.Value.QuestSequence &&
+                    string.Equals(entry.Text, request.SourceText, StringComparison.Ordinal))
+                {
+                    matchingRows.Add((questProgress.Value, entry));
+                }
+            }
+        }
+
+        return new ResolverCaptureSnapshot(
+            liveActors,
+            localPlayerName,
+            playerSexHint,
+            matchingRows.ToArray());
+    }
+
+    /// <summary>
+    ///     Marshals one native capture action onto the Dalamud framework thread.
+    /// </summary>
+    /// <param name="capture">The native capture action.</param>
+    /// <param name="cancellationToken">The token that cancels the resolver operation.</param>
+    /// <returns>A task representing the framework-thread capture.</returns>
+    private static async Task RunOnFrameworkThreadAsync(
+        Action capture,
+        CancellationToken cancellationToken)
+    {
+        await Echoglossian.FrameworkInterface.RunOnFrameworkThread(
+            () =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                capture();
+            }).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    /// <summary>
+    ///     Runs managed capture delegates inline for native-free unit tests.
+    /// </summary>
+    /// <param name="capture">The managed capture action.</param>
+    /// <param name="cancellationToken">The token that cancels the resolver operation.</param>
+    /// <returns>A completed task after capture.</returns>
+    private static Task RunInlineAsync(Action capture, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        capture();
+        return Task.CompletedTask;
     }
 
     private static IReadOnlyList<uint> CollectAcceptedQuestIds()
@@ -260,4 +328,17 @@ public sealed class DialogueInterlocutorMetadataResolver
             _ => null,
         };
     }
+
+    /// <summary>
+    ///     Carries immutable managed resolver state across the database await boundary.
+    /// </summary>
+    /// <param name="LiveActors">The copied live actor snapshots.</param>
+    /// <param name="LocalPlayerName">The copied local player name.</param>
+    /// <param name="PlayerSexHint">The copied local player sex hint.</param>
+    /// <param name="MatchingRows">The copied accepted-quest dialogue matches.</param>
+    private sealed record ResolverCaptureSnapshot(
+        IReadOnlyList<LiveDialogueActorSnapshot> LiveActors,
+        string LocalPlayerName,
+        string? PlayerSexHint,
+        IReadOnlyList<(QuestProgressSnapshot Snapshot, QuestDialogueSheetEntry Entry)> MatchingRows);
 }

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -18,6 +18,7 @@ namespace Echoglossian;
 public sealed class DialogueInterlocutorMetadataResolver
 {
     private readonly Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors;
+    private readonly Func<LiveDialogueActorSnapshot?> captureTargetActor;
     private readonly Func<uint, byte> captureQuestSequence;
     private readonly Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync;
     private readonly Func<string> localPlayerName;
@@ -39,6 +40,7 @@ public sealed class DialogueInterlocutorMetadataResolver
             QuestDialogueMetadataDerivation.ReadDialogueEntries,
             plugin.FindQuestDialogueMetadataAsync,
             CaptureLiveActors,
+            CaptureTargetActor,
             CaptureLocalPlayerName,
             CapturePlayerSexHint,
             RunOnFrameworkThreadAsync)
@@ -54,6 +56,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     /// <param name="readDialogueEntries">The quest dialogue row reader.</param>
     /// <param name="findMetadataAsync">The exact persisted metadata lookup.</param>
     /// <param name="captureLiveActors">The managed live actor snapshot collector.</param>
+    /// <param name="captureTargetActor">The managed current target actor snapshot collector.</param>
     /// <param name="localPlayerName">The managed local player name reader.</param>
     /// <param name="playerSexHint">The managed local player sex hint reader.</param>
     /// <param name="runOnFrameworkThreadAsync">The native capture scheduler.</param>
@@ -64,6 +67,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         Func<QuestProgressSnapshot, CancellationToken, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries,
         Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync,
         Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors,
+        Func<LiveDialogueActorSnapshot?> captureTargetActor,
         Func<string> localPlayerName,
         Func<string?> playerSexHint,
         Func<Action, CancellationToken, Task>? runOnFrameworkThreadAsync = null)
@@ -74,6 +78,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         this.readDialogueEntries = readDialogueEntries;
         this.findMetadataAsync = findMetadataAsync;
         this.captureLiveActors = captureLiveActors;
+        this.captureTargetActor = captureTargetActor;
         this.localPlayerName = localPlayerName;
         this.playerSexHint = playerSexHint;
         this.runOnFrameworkThreadAsync = runOnFrameworkThreadAsync ?? RunInlineAsync;
@@ -108,6 +113,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         }
 
         var liveActors = captureSnapshot.LiveActors;
+        var targetActor = captureSnapshot.TargetActor;
         var localPlayerName = captureSnapshot.LocalPlayerName;
         var playerSexHint = captureSnapshot.PlayerSexHint;
         var matchingRows = this.FindMatchingRows(
@@ -140,11 +146,15 @@ public sealed class DialogueInterlocutorMetadataResolver
             return BuildVisibleSpeakerLiveActorFallback(
                 request.VisibleSpeakerName,
                 liveActors,
+                targetActor,
                 localPlayerName,
                 playerSexHint);
         }
 
-        var speakerActor = FindUniqueLiveActor(liveActors, resolvedMetadata.SpeakerHint);
+        var speakerActor = FindMatchingTargetSpeaker(
+            targetActor,
+            request.VisibleSpeakerName,
+            resolvedMetadata.SpeakerHint) ?? FindUniqueLiveActor(liveActors, resolvedMetadata.SpeakerHint);
         var addresseeActor = FindUniqueLiveActor(liveActors, resolvedMetadata.AddresseeHint);
         var addresseeIsPlayer = string.Equals(
             resolvedMetadata.AddresseeHint,
@@ -185,6 +195,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     private ResolverCaptureSnapshot CaptureSnapshot()
     {
         var liveActors = this.captureLiveActors().ToArray();
+        var targetActor = this.captureTargetActor();
         var localPlayerName = this.localPlayerName();
         var playerSexHint = this.playerSexHint();
         var acceptedQuests = this.tryCollectAcceptedQuestIds()
@@ -194,6 +205,7 @@ public sealed class DialogueInterlocutorMetadataResolver
             .ToArray();
         return new ResolverCaptureSnapshot(
             liveActors,
+            targetActor,
             localPlayerName,
             playerSexHint,
             acceptedQuests);
@@ -321,16 +333,38 @@ public sealed class DialogueInterlocutorMetadataResolver
                 continue;
             }
 
-            var customize = character.CustomizeData;
-            actors.Add(new LiveDialogueActorSnapshot(
-                gameObject.Name.TextValue,
-                gameObject.BaseId,
-                NormalizeSexHint(customize.Sex.ToString()),
-                customize.Race.ToString().ToLowerInvariant(),
-                customize.BodyType.ToString().ToLowerInvariant()));
+            actors.Add(CaptureActorSnapshot(character));
         }
 
         return actors;
+    }
+
+    /// <summary>
+    ///     Captures the current target as immutable managed actor values.
+    /// </summary>
+    /// <returns>The captured target actor; otherwise, <see langword="null" />.</returns>
+    private static LiveDialogueActorSnapshot? CaptureTargetActor()
+    {
+        return Echoglossian.TargetManagerInterface?.Target is ICharacter target &&
+               !string.IsNullOrWhiteSpace(target.Name.TextValue)
+            ? CaptureActorSnapshot(target)
+            : null;
+    }
+
+    /// <summary>
+    ///     Copies one live character into immutable managed dialogue metadata values.
+    /// </summary>
+    /// <param name="character">The framework-thread character to copy.</param>
+    /// <returns>The immutable managed actor snapshot.</returns>
+    private static LiveDialogueActorSnapshot CaptureActorSnapshot(ICharacter character)
+    {
+        var customize = character.CustomizeData;
+        return new LiveDialogueActorSnapshot(
+            character.Name.TextValue,
+            character.BaseId,
+            NormalizeSexHint(customize.Sex.ToString()),
+            customize.Race.ToString().ToLowerInvariant(),
+            customize.BodyType.ToString().ToLowerInvariant());
     }
 
     private static QuestDialogueMetadata? SelectUniqueMetadata(
@@ -370,6 +404,26 @@ public sealed class DialogueInterlocutorMetadataResolver
     }
 
     /// <summary>
+    ///     Returns the current target only when it is confirmed as the visible
+    ///     and resolved dialogue speaker.
+    /// </summary>
+    /// <param name="targetActor">The captured current target actor.</param>
+    /// <param name="visibleSpeakerName">The speaker name displayed by the addon.</param>
+    /// <param name="resolvedSpeakerName">The speaker name resolved from metadata.</param>
+    /// <returns>The target speaker; otherwise, <see langword="null" />.</returns>
+    private static LiveDialogueActorSnapshot? FindMatchingTargetSpeaker(
+        LiveDialogueActorSnapshot? targetActor,
+        string? visibleSpeakerName,
+        string resolvedSpeakerName)
+    {
+        return targetActor != null &&
+               string.Equals(targetActor.Name, visibleSpeakerName, StringComparison.Ordinal) &&
+               string.Equals(targetActor.Name, resolvedSpeakerName, StringComparison.Ordinal)
+            ? targetActor
+            : null;
+    }
+
+    /// <summary>
     ///     Builds a live-actor-only fallback when the visible speaker uniquely
     ///     matches a loaded actor but exact persisted quest metadata is not yet
     ///     available.
@@ -382,6 +436,7 @@ public sealed class DialogueInterlocutorMetadataResolver
     private static DialogueInterlocutorMetadata? BuildVisibleSpeakerLiveActorFallback(
         string? visibleSpeakerName,
         IReadOnlyList<LiveDialogueActorSnapshot> liveActors,
+        LiveDialogueActorSnapshot? targetActor,
         string localPlayerName,
         string? playerSexHint)
     {
@@ -390,7 +445,10 @@ public sealed class DialogueInterlocutorMetadataResolver
             return null;
         }
 
-        var speakerActor = FindUniqueLiveActor(liveActors, visibleSpeakerName);
+        var speakerActor = FindMatchingTargetSpeaker(
+            targetActor,
+            visibleSpeakerName,
+            visibleSpeakerName) ?? FindUniqueLiveActor(liveActors, visibleSpeakerName);
         if (speakerActor == null)
         {
             return null;
@@ -436,11 +494,13 @@ public sealed class DialogueInterlocutorMetadataResolver
     ///     Carries immutable managed resolver state across the database await boundary.
     /// </summary>
     /// <param name="LiveActors">The copied live actor snapshots.</param>
+    /// <param name="TargetActor">The copied current target actor snapshot.</param>
     /// <param name="LocalPlayerName">The copied local player name.</param>
     /// <param name="PlayerSexHint">The copied local player sex hint.</param>
     /// <param name="AcceptedQuests">The copied accepted quest identifiers and sequences.</param>
     private sealed record ResolverCaptureSnapshot(
         IReadOnlyList<LiveDialogueActorSnapshot> LiveActors,
+        LiveDialogueActorSnapshot? TargetActor,
         string LocalPlayerName,
         string? PlayerSexHint,
         IReadOnlyList<AcceptedQuestCapture> AcceptedQuests);

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -15,7 +15,7 @@ namespace Echoglossian;
 /// </summary>
 public sealed class DialogueInterlocutorMetadataResolver
 {
-    private readonly Func<IReadOnlyDictionary<string, LiveDialogueActorSnapshot>> captureLiveActors;
+    private readonly Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors;
     private readonly Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync;
     private readonly Func<string> localPlayerName;
     private readonly Func<string?> playerSexHint;
@@ -54,7 +54,7 @@ public sealed class DialogueInterlocutorMetadataResolver
         Func<uint, QuestProgressSnapshot?> tryResolveQuestProgress,
         Func<QuestProgressSnapshot, IReadOnlyList<QuestDialogueSheetEntry>> readDialogueEntries,
         Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findMetadataAsync,
-        Func<IReadOnlyDictionary<string, LiveDialogueActorSnapshot>> captureLiveActors,
+        Func<IReadOnlyList<LiveDialogueActorSnapshot>> captureLiveActors,
         Func<string> localPlayerName,
         Func<string?> playerSexHint)
     {
@@ -134,8 +134,8 @@ public sealed class DialogueInterlocutorMetadataResolver
             return null;
         }
 
-        liveActors.TryGetValue(resolvedMetadata.SpeakerHint, out var speakerActor);
-        liveActors.TryGetValue(resolvedMetadata.AddresseeHint, out var addresseeActor);
+        var speakerActor = FindUniqueLiveActor(liveActors, resolvedMetadata.SpeakerHint);
+        var addresseeActor = FindUniqueLiveActor(liveActors, resolvedMetadata.AddresseeHint);
         var addresseeIsPlayer = string.Equals(
             resolvedMetadata.AddresseeHint,
             localPlayerName,
@@ -187,9 +187,9 @@ public sealed class DialogueInterlocutorMetadataResolver
         return NormalizeSexHint(Echoglossian.PlayerStateInterface?.Sex.ToString());
     }
 
-    private static IReadOnlyDictionary<string, LiveDialogueActorSnapshot> CaptureLiveActors()
+    private static IReadOnlyList<LiveDialogueActorSnapshot> CaptureLiveActors()
     {
-        Dictionary<string, LiveDialogueActorSnapshot> actors = new(StringComparer.Ordinal);
+        List<LiveDialogueActorSnapshot> actors = [];
         if (Echoglossian.ObjectTableInterface == null)
         {
             return actors;
@@ -204,7 +204,7 @@ public sealed class DialogueInterlocutorMetadataResolver
             }
 
             var customize = character.CustomizeData;
-            actors.TryAdd(gameObject.Name.TextValue, new LiveDialogueActorSnapshot(
+            actors.Add(new LiveDialogueActorSnapshot(
                 gameObject.Name.TextValue,
                 gameObject.BaseId,
                 NormalizeSexHint(customize.Sex.ToString()),
@@ -239,6 +239,16 @@ public sealed class DialogueInterlocutorMetadataResolver
                 StringComparison.Ordinal))
             .ToList();
         return speakerMatches.Count == 1 ? speakerMatches[0] : null;
+    }
+
+    private static LiveDialogueActorSnapshot? FindUniqueLiveActor(
+        IReadOnlyList<LiveDialogueActorSnapshot> liveActors,
+        string name)
+    {
+        var matches = liveActors
+            .Where(actor => string.Equals(actor.Name, name, StringComparison.Ordinal))
+            .ToList();
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     private static string? NormalizeSexHint(string? sex)

--- a/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
+++ b/NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs
@@ -425,7 +425,9 @@ public sealed class DialogueInterlocutorMetadataResolver
         return sex?.ToLowerInvariant() switch
         {
             "male" => "male",
+            "0" => "male",
             "female" => "female",
+            "1" => "female",
             _ => null,
         };
     }

--- a/NativeUI/Helpers/OwnedAsyncOperationSet.cs
+++ b/NativeUI/Helpers/OwnedAsyncOperationSet.cs
@@ -31,16 +31,21 @@ public sealed class OwnedAsyncOperationSet : IDisposable
     ///     Starts an operation owned by this set.
     /// </summary>
     /// <param name="operation">The operation to start with the shutdown-linked token.</param>
+    /// <param name="externalCancellationToken">
+    ///     An optional token that cancels the operation independently of shutdown.
+    /// </param>
     /// <returns>
     ///     <see langword="true" /> if the operation was accepted; otherwise,
     ///     <see langword="false" />.
     /// </returns>
-    public bool Run(Func<CancellationToken, Task> operation)
+    public bool Run(
+        Func<CancellationToken, Task> operation,
+        CancellationToken externalCancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(operation);
 
-        CancellationTokenSource? operationTokenSource = null;
-        Task? operationTask = null;
+        CancellationTokenSource operationTokenSource;
+        Task operationTask;
         lock (this.syncRoot)
         {
             if (this.disposed)
@@ -49,21 +54,14 @@ public sealed class OwnedAsyncOperationSet : IDisposable
             }
 
             operationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
-                this.shutdownTokenSource.Token);
-            try
-            {
-                operationTask = operation(operationTokenSource.Token);
-            }
-            catch (Exception exception)
-            {
-                operationTask = Task.FromException(exception);
-            }
-
-            if (operationTask is null)
-            {
-                operationTask = Task.FromException(
-                    new InvalidOperationException("Owned operation returned a null task."));
-            }
+                this.shutdownTokenSource.Token,
+                externalCancellationToken);
+            var operationToken = operationTokenSource.Token;
+            operationTask = Task.Run(
+                () => operation(operationToken) ?? Task.FromException(
+                    new InvalidOperationException(
+                        "Owned operation returned a null task.")),
+                operationToken);
 
             this.activeOperations.Add(operationTask);
         }

--- a/NativeUI/Helpers/OwnedAsyncOperationSet.cs
+++ b/NativeUI/Helpers/OwnedAsyncOperationSet.cs
@@ -75,6 +75,7 @@ public sealed class OwnedAsyncOperationSet : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
+        Exception? cancellationException = null;
         lock (this.syncRoot)
         {
             if (this.disposed)
@@ -83,7 +84,23 @@ public sealed class OwnedAsyncOperationSet : IDisposable
             }
 
             this.disposed = true;
-            this.shutdownTokenSource.Cancel();
+            try
+            {
+                this.shutdownTokenSource.Cancel();
+            }
+            catch (Exception exception)
+            {
+                cancellationException = exception;
+            }
+            finally
+            {
+                this.shutdownTokenSource.Dispose();
+            }
+        }
+
+        if (cancellationException is not null)
+        {
+            this.ReportUnexpectedException(cancellationException);
         }
     }
 
@@ -107,7 +124,7 @@ public sealed class OwnedAsyncOperationSet : IDisposable
         }
         catch (Exception exception)
         {
-            this.errorObserver?.Invoke(exception);
+            this.ReportUnexpectedException(exception);
         }
         finally
         {
@@ -117,6 +134,22 @@ public sealed class OwnedAsyncOperationSet : IDisposable
             }
 
             operationTokenSource.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///     Reports one unexpected exception without allowing observer failures
+    ///     to escape the owning runtime.
+    /// </summary>
+    /// <param name="exception">The exception to report.</param>
+    private void ReportUnexpectedException(Exception exception)
+    {
+        try
+        {
+            this.errorObserver?.Invoke(exception);
+        }
+        catch (Exception)
+        {
         }
     }
 }

--- a/NativeUI/Helpers/OwnedAsyncOperationSet.cs
+++ b/NativeUI/Helpers/OwnedAsyncOperationSet.cs
@@ -1,0 +1,122 @@
+// <copyright file="OwnedAsyncOperationSet.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.NativeUI.Helpers;
+
+/// <summary>
+///     Owns background operations that must stop when their native UI runtime
+///     is disposed.
+/// </summary>
+public sealed class OwnedAsyncOperationSet : IDisposable
+{
+    private readonly HashSet<Task> activeOperations = new();
+    private readonly Action<Exception>? errorObserver;
+    private readonly CancellationTokenSource shutdownTokenSource = new();
+    private readonly object syncRoot = new();
+    private bool disposed;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="OwnedAsyncOperationSet" />
+    ///     class.
+    /// </summary>
+    /// <param name="errorObserver">Optional observer for unexpected operation failures.</param>
+    public OwnedAsyncOperationSet(Action<Exception>? errorObserver = null)
+    {
+        this.errorObserver = errorObserver;
+    }
+
+    /// <summary>
+    ///     Starts an operation owned by this set.
+    /// </summary>
+    /// <param name="operation">The operation to start with the shutdown-linked token.</param>
+    /// <returns>
+    ///     <see langword="true" /> if the operation was accepted; otherwise,
+    ///     <see langword="false" />.
+    /// </returns>
+    public bool Run(Func<CancellationToken, Task> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        CancellationTokenSource? operationTokenSource = null;
+        Task? operationTask = null;
+        lock (this.syncRoot)
+        {
+            if (this.disposed)
+            {
+                return false;
+            }
+
+            operationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                this.shutdownTokenSource.Token);
+            try
+            {
+                operationTask = operation(operationTokenSource.Token);
+            }
+            catch (Exception exception)
+            {
+                operationTask = Task.FromException(exception);
+            }
+
+            if (operationTask is null)
+            {
+                operationTask = Task.FromException(
+                    new InvalidOperationException("Owned operation returned a null task."));
+            }
+
+            this.activeOperations.Add(operationTask);
+        }
+
+        _ = this.ObserveOperationAsync(operationTask, operationTokenSource);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        lock (this.syncRoot)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.shutdownTokenSource.Cancel();
+        }
+    }
+
+    /// <summary>
+    ///     Observes one operation and releases its owned cancellation source
+    ///     after it completes.
+    /// </summary>
+    /// <param name="operationTask">The operation being observed.</param>
+    /// <param name="operationTokenSource">The linked token source for the operation.</param>
+    /// <returns>A task representing observation of the operation.</returns>
+    private async Task ObserveOperationAsync(
+        Task operationTask,
+        CancellationTokenSource operationTokenSource)
+    {
+        try
+        {
+            await operationTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            this.errorObserver?.Invoke(exception);
+        }
+        finally
+        {
+            lock (this.syncRoot)
+            {
+                this.activeOperations.Remove(operationTask);
+            }
+
+            operationTokenSource.Dispose();
+        }
+    }
+}

--- a/NativeUI/Helpers/QuestContentHash.cs
+++ b/NativeUI/Helpers/QuestContentHash.cs
@@ -20,6 +20,21 @@ namespace Echoglossian;
 internal static class QuestContentHash
 {
     /// <summary>
+    ///     Computes the stable fingerprint for one exact quest text row.
+    /// </summary>
+    /// <param name="sourceRowKey">The canonical quest text row key.</param>
+    /// <param name="sourceText">The evaluated source text.</param>
+    /// <returns>A 16-character lowercase hex string fingerprint.</returns>
+    public static string ComputeLine(string sourceRowKey, string sourceText)
+    {
+        var input = $"{sourceRowKey}={sourceText}";
+        var inputBytes = Encoding.UTF8.GetBytes(input);
+        var hashBytes = SHA256.HashData(inputBytes);
+
+        return Convert.ToHexString(hashBytes, 0, 8).ToLowerInvariant();
+    }
+
+    /// <summary>
     ///     Computes the content hash from classified quest text rows.
     /// </summary>
     /// <param name="seqRows">SEQ (journal summary) rows.</param>

--- a/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
+++ b/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
@@ -27,6 +27,21 @@ internal static partial class QuestDialogueMetadataDerivation
     public static IReadOnlyList<QuestDialogueSheetEntry> ReadDialogueEntries(
         QuestProgressSnapshot questProgressSnapshot)
     {
+        return ReadDialogueEntries(questProgressSnapshot, CancellationToken.None);
+    }
+
+    /// <summary>
+    ///     Reads populated dialogue and speaker-name rows while observing
+    ///     cancellation during sheet traversal.
+    /// </summary>
+    /// <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+    /// <param name="cancellationToken">The token that cancels sheet traversal.</param>
+    /// <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+    internal static IReadOnlyList<QuestDialogueSheetEntry> ReadDialogueEntries(
+        QuestProgressSnapshot questProgressSnapshot,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrWhiteSpace(questProgressSnapshot.QuestSheetName))
         {
             return [];
@@ -45,6 +60,7 @@ internal static partial class QuestDialogueMetadataDerivation
         var rowCount = Convert.ToInt32(questTextSheet.Count, CultureInfo.InvariantCulture);
         for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var row = questTextSheet.GetRow((uint)rowIndex);
             var rowKey = EvaluateQuestText(row.ReadStringColumn(0), evaluator);
             var text = EvaluateQuestText(row.ReadStringColumn(1), evaluator);
@@ -56,7 +72,10 @@ internal static partial class QuestDialogueMetadataDerivation
             rawEntries.Add(new QuestDialogueSheetEntry(rowKey, text, rowIndex, 0));
         }
 
-        return ReadDialogueEntries(questProgressSnapshot, rawEntries);
+        return ReadDialogueEntries(
+            questProgressSnapshot,
+            rawEntries,
+            cancellationToken);
     }
 
     /// <summary>
@@ -70,12 +89,33 @@ internal static partial class QuestDialogueMetadataDerivation
         QuestProgressSnapshot questProgressSnapshot,
         IReadOnlyList<QuestDialogueSheetEntry> rawEntries)
     {
+        return ReadDialogueEntries(
+            questProgressSnapshot,
+            rawEntries,
+            CancellationToken.None);
+    }
+
+    /// <summary>
+    ///     Filters evaluated raw quest rows while observing cancellation during
+    ///     source-ordered traversal.
+    /// </summary>
+    /// <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+    /// <param name="rawEntries">The source-ordered evaluated raw sheet rows.</param>
+    /// <param name="cancellationToken">The token that cancels row traversal.</param>
+    /// <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+    internal static IReadOnlyList<QuestDialogueSheetEntry> ReadDialogueEntries(
+        QuestProgressSnapshot questProgressSnapshot,
+        IReadOnlyList<QuestDialogueSheetEntry> rawEntries,
+        CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(rawEntries);
+        cancellationToken.ThrowIfCancellationRequested();
 
         List<QuestDialogueSheetEntry> dialogueEntries = [];
         ushort questSequence = 0;
         foreach (var entry in rawEntries.OrderBy(entry => entry.SourceOrder))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (TryGetSequence(entry.RowKey, out var sequence))
             {
                 questSequence = sequence;
@@ -111,21 +151,60 @@ internal static partial class QuestDialogueMetadataDerivation
         string derivationVersion,
         DateTime observedAtUtc)
     {
-        var turns = ReadNamedTurns(dialogueEntries);
+        return BuildEntries(
+            questProgressSnapshot,
+            dialogueEntries,
+            sourceLanguageCode,
+            gameVersion,
+            derivationVersion,
+            observedAtUtc,
+            CancellationToken.None);
+    }
+
+    /// <summary>
+    ///     Builds persistent metadata rows while observing cancellation during
+    ///     dialogue pairing and candidate scans.
+    /// </summary>
+    /// <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+    /// <param name="dialogueEntries">The source-ordered quest sheet entries.</param>
+    /// <param name="sourceLanguageCode">The source language code.</param>
+    /// <param name="gameVersion">The game version that supplied the rows.</param>
+    /// <param name="derivationVersion">The derivation algorithm version.</param>
+    /// <param name="observedAtUtc">The UTC timestamp for the derived rows.</param>
+    /// <param name="cancellationToken">The token that cancels metadata derivation.</param>
+    /// <returns>The derived metadata rows for paired dialogue text entries.</returns>
+    internal static IReadOnlyList<QuestDialogueMetadata> BuildEntries(
+        QuestProgressSnapshot questProgressSnapshot,
+        IReadOnlyList<QuestDialogueSheetEntry> dialogueEntries,
+        string sourceLanguageCode,
+        string gameVersion,
+        string derivationVersion,
+        DateTime observedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var turns = ReadNamedTurns(dialogueEntries, cancellationToken);
         var questSheetId = GetQuestSheetId(questProgressSnapshot.QuestSheetName);
         List<QuestDialogueMetadata> results = [];
 
         foreach (var turn in turns)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var nextSpeaker = turns.FirstOrDefault(candidate =>
-                candidate.QuestSequence == turn.QuestSequence &&
-                candidate.SourceOrder > turn.SourceOrder &&
-                !string.Equals(candidate.SpeakerHint, turn.SpeakerHint, StringComparison.Ordinal));
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return candidate.QuestSequence == turn.QuestSequence &&
+                       candidate.SourceOrder > turn.SourceOrder &&
+                       !string.Equals(candidate.SpeakerHint, turn.SpeakerHint, StringComparison.Ordinal);
+            });
             var previousSpeaker = nextSpeaker == default
                 ? turns.LastOrDefault(candidate =>
-                    candidate.QuestSequence == turn.QuestSequence &&
-                    candidate.SourceOrder < turn.SourceOrder &&
-                    !string.Equals(candidate.SpeakerHint, turn.SpeakerHint, StringComparison.Ordinal))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return candidate.QuestSequence == turn.QuestSequence &&
+                           candidate.SourceOrder < turn.SourceOrder &&
+                           !string.Equals(candidate.SpeakerHint, turn.SpeakerHint, StringComparison.Ordinal);
+                })
                 : default;
             var addresseeHint = nextSpeaker != default
                 ? nextSpeaker.SpeakerHint
@@ -158,12 +237,20 @@ internal static partial class QuestDialogueMetadataDerivation
     }
 
     private static List<QuestDialogueNamedTurn> ReadNamedTurns(
-        IReadOnlyList<QuestDialogueSheetEntry> dialogueEntries)
+        IReadOnlyList<QuestDialogueSheetEntry> dialogueEntries,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var namesBySequenceAndSuffix = new Dictionary<(ushort Sequence, string Suffix), string>();
         var textEntries = new List<(QuestDialogueSheetEntry Entry, ushort Sequence)>();
-        foreach (var entry in dialogueEntries.OrderBy(entry => entry.SourceOrder))
+        var orderedEntries = dialogueEntries.OrderBy(entry =>
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            return entry.SourceOrder;
+        });
+        foreach (var entry in orderedEntries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             if (TryGetSequence(entry.RowKey, out var sequence))
             {
                 continue;
@@ -189,6 +276,7 @@ internal static partial class QuestDialogueMetadataDerivation
         List<QuestDialogueNamedTurn> turns = [];
         foreach (var (entry, sequence) in textEntries)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!TryGetDialogueSuffix(entry.RowKey, out var suffix) ||
                 !namesBySequenceAndSuffix.TryGetValue((sequence, suffix), out var speakerHint))
             {

--- a/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
+++ b/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
@@ -340,7 +340,8 @@ internal static partial class QuestDialogueMetadataDerivation
         ReadOnlySeString text,
         ISeStringEvaluator? evaluator)
     {
-        if (evaluator == null)
+        if (evaluator == null ||
+            Echoglossian.FrameworkInterface?.IsInFrameworkUpdateThread != true)
         {
             return text.ExtractText();
         }

--- a/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
+++ b/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
@@ -1,0 +1,265 @@
+// <copyright file="QuestDialogueMetadataDerivation.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Text.RegularExpressions;
+
+using Echoglossian.EFCoreSqlite.Models.Journal;
+
+using Lumina.Excel;
+using Lumina.Text.ReadOnly;
+
+namespace Echoglossian;
+
+/// <summary>
+///     Derives deterministic speaker and addressee metadata from one quest's
+///     raw dialogue sheet rows.
+/// </summary>
+internal static partial class QuestDialogueMetadataDerivation
+{
+    /// <summary>
+    ///     Reads populated dialogue and speaker-name rows from the quest text
+    ///     sheet in their original source order.
+    /// </summary>
+    /// <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+    /// <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+    public static IReadOnlyList<QuestDialogueSheetEntry> ReadDialogueEntries(
+        QuestProgressSnapshot questProgressSnapshot)
+    {
+        if (string.IsNullOrWhiteSpace(questProgressSnapshot.QuestSheetName))
+        {
+            return [];
+        }
+
+        var dataManager = Echoglossian.DManager;
+        var questTextSheet = dataManager?.GameData.GetExcelSheet<RawRow>(
+            name: questProgressSnapshot.QuestSheetName);
+        if (questTextSheet == null || questTextSheet.Count == 0)
+        {
+            return [];
+        }
+
+        var entries = new List<QuestDialogueSheetEntry>();
+        var evaluator = Echoglossian.SeStringEvaluator;
+        var rowCount = Convert.ToInt32(questTextSheet.Count, CultureInfo.InvariantCulture);
+        for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
+        {
+            var row = questTextSheet.GetRow((uint)rowIndex);
+            var rowKey = EvaluateQuestText(row.ReadStringColumn(0), evaluator);
+            var text = EvaluateQuestText(row.ReadStringColumn(1), evaluator);
+            if (rowKey.Length == 0 || text.Length == 0 || IsNonDialogueRow(rowKey))
+            {
+                continue;
+            }
+
+            entries.Add(new QuestDialogueSheetEntry(rowKey, text, rowIndex));
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    ///     Builds persistent metadata rows from source-ordered quest sheet entries.
+    /// </summary>
+    /// <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+    /// <param name="dialogueEntries">The source-ordered quest sheet entries.</param>
+    /// <param name="sourceLanguageCode">The source language code.</param>
+    /// <param name="gameVersion">The game version that supplied the rows.</param>
+    /// <param name="derivationVersion">The derivation algorithm version.</param>
+    /// <param name="observedAtUtc">The UTC timestamp for the derived rows.</param>
+    /// <returns>The derived metadata rows for paired dialogue text entries.</returns>
+    public static IReadOnlyList<QuestDialogueMetadata> BuildEntries(
+        QuestProgressSnapshot questProgressSnapshot,
+        IReadOnlyList<QuestDialogueSheetEntry> dialogueEntries,
+        string sourceLanguageCode,
+        string gameVersion,
+        string derivationVersion,
+        DateTime observedAtUtc)
+    {
+        var turns = ReadNamedTurns(dialogueEntries);
+        var questSheetId = GetQuestSheetId(questProgressSnapshot.QuestSheetName);
+        List<QuestDialogueMetadata> results = [];
+
+        foreach (var turn in turns)
+        {
+            var nextSpeaker = turns.FirstOrDefault(candidate =>
+                candidate.QuestSequence == turn.QuestSequence &&
+                candidate.SourceOrder > turn.SourceOrder &&
+                !string.Equals(candidate.SpeakerHint, turn.SpeakerHint, StringComparison.Ordinal));
+            var previousSpeaker = nextSpeaker == default
+                ? turns.LastOrDefault(candidate =>
+                    candidate.QuestSequence == turn.QuestSequence &&
+                    candidate.SourceOrder < turn.SourceOrder &&
+                    !string.Equals(candidate.SpeakerHint, turn.SpeakerHint, StringComparison.Ordinal))
+                : default;
+            var addresseeHint = nextSpeaker != default
+                ? nextSpeaker.SpeakerHint
+                : previousSpeaker.SpeakerHint ?? string.Empty;
+
+            results.Add(new QuestDialogueMetadata
+            {
+                QuestId = questProgressSnapshot.QuestId,
+                QuestSequence = turn.QuestSequence,
+                SourceLanguageCode = sourceLanguageCode,
+                GameVersion = gameVersion,
+                QuestSheetId = questSheetId,
+                QuestTextSheetName = questProgressSnapshot.QuestSheetName,
+                SourceRowKey = turn.RowKey,
+                SourceTextHash = QuestContentHash.ComputeLine(turn.RowKey, turn.Text),
+                SourceTextPreview = turn.Text,
+                SpeakerHint = turn.SpeakerHint,
+                AddresseeHint = addresseeHint,
+                SpeakerRoleHint = "npc",
+                AddresseeRoleHint = addresseeHint.Length == 0 ? string.Empty : "npc",
+                Provenance = "QuestSheetDerived",
+                ConfidenceTier = nextSpeaker != default ? 2 : previousSpeaker != default ? 1 : 0,
+                DerivationVersion = derivationVersion,
+                CreatedAtUtc = observedAtUtc,
+                UpdatedAtUtc = observedAtUtc,
+            });
+        }
+
+        return results;
+    }
+
+    private static List<QuestDialogueNamedTurn> ReadNamedTurns(
+        IReadOnlyList<QuestDialogueSheetEntry> dialogueEntries)
+    {
+        var namesBySequenceAndSuffix = new Dictionary<(ushort Sequence, string Suffix), string>();
+        var textEntries = new List<(QuestDialogueSheetEntry Entry, ushort Sequence)>();
+        ushort questSequence = 0;
+
+        foreach (var entry in dialogueEntries.OrderBy(entry => entry.SourceOrder))
+        {
+            if (TryGetSequence(entry.RowKey, out var sequence))
+            {
+                questSequence = sequence;
+                continue;
+            }
+
+            if (!TryGetDialogueSuffix(entry.RowKey, out var suffix))
+            {
+                continue;
+            }
+
+            if (IsNameRow(entry.RowKey))
+            {
+                namesBySequenceAndSuffix[(questSequence, suffix)] = entry.Text;
+                continue;
+            }
+
+            if (!IsNonDialogueRow(entry.RowKey))
+            {
+                textEntries.Add((entry, questSequence));
+            }
+        }
+
+        List<QuestDialogueNamedTurn> turns = [];
+        foreach (var (entry, sequence) in textEntries)
+        {
+            if (!TryGetDialogueSuffix(entry.RowKey, out var suffix) ||
+                !namesBySequenceAndSuffix.TryGetValue((sequence, suffix), out var speakerHint))
+            {
+                continue;
+            }
+
+            turns.Add(new QuestDialogueNamedTurn(
+                entry.RowKey,
+                entry.Text,
+                entry.SourceOrder,
+                sequence,
+                speakerHint));
+        }
+
+        return turns;
+    }
+
+    private static bool IsNonDialogueRow(string rowKey)
+    {
+        return rowKey.Contains("_SEQ_", StringComparison.Ordinal) ||
+               rowKey.Contains("_TODO_", StringComparison.Ordinal) ||
+               rowKey.Contains("_SYSTEM_", StringComparison.Ordinal);
+    }
+
+    private static bool IsNameRow(string rowKey)
+    {
+        return rowKey.Contains("_NAME_", StringComparison.Ordinal);
+    }
+
+    private static bool TryGetSequence(string rowKey, out ushort sequence)
+    {
+        sequence = 0;
+        var match = SequenceRowPattern().Match(rowKey);
+        return match.Success && ushort.TryParse(
+            match.Groups[1].Value,
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out sequence);
+    }
+
+    private static bool TryGetDialogueSuffix(string rowKey, out string suffix)
+    {
+        suffix = string.Empty;
+        var match = DialogueSuffixPattern().Match(rowKey);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        suffix = match.Value;
+        return true;
+    }
+
+    private static string GetQuestSheetId(string questSheetName)
+    {
+        var separatorIndex = questSheetName.LastIndexOf('/');
+        return separatorIndex < 0 ? questSheetName : questSheetName[(separatorIndex + 1)..];
+    }
+
+    private static string EvaluateQuestText(
+        ReadOnlySeString text,
+        ISeStringEvaluator? evaluator)
+    {
+        if (evaluator == null)
+        {
+            return text.ExtractText();
+        }
+
+        try
+        {
+            return evaluator.Evaluate(
+                    text,
+                    language: Echoglossian.ClientStateInterface.ClientLanguage)
+                .ExtractText();
+        }
+        catch (Exception)
+        {
+            return text.ExtractText();
+        }
+    }
+
+    [GeneratedRegex(@"_SEQ_(\d+)$", RegexOptions.CultureInvariant)]
+    private static partial Regex SequenceRowPattern();
+
+    [GeneratedRegex(@"\d{3}_\d{3}$", RegexOptions.CultureInvariant)]
+    private static partial Regex DialogueSuffixPattern();
+
+    private readonly record struct QuestDialogueNamedTurn(
+        string RowKey,
+        string Text,
+        int SourceOrder,
+        ushort QuestSequence,
+        string SpeakerHint);
+}
+
+/// <summary>
+///     Represents one evaluated quest dialogue sheet row in source order.
+/// </summary>
+/// <param name="RowKey">The evaluated source row key.</param>
+/// <param name="Text">The evaluated source text.</param>
+/// <param name="SourceOrder">The zero-based source row order.</param>
+internal readonly record struct QuestDialogueSheetEntry(
+    string RowKey,
+    string Text,
+    int SourceOrder);

--- a/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
+++ b/NativeUI/Helpers/QuestDialogueMetadataDerivation.cs
@@ -40,7 +40,7 @@ internal static partial class QuestDialogueMetadataDerivation
             return [];
         }
 
-        var entries = new List<QuestDialogueSheetEntry>();
+        var rawEntries = new List<QuestDialogueSheetEntry>();
         var evaluator = Echoglossian.SeStringEvaluator;
         var rowCount = Convert.ToInt32(questTextSheet.Count, CultureInfo.InvariantCulture);
         for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
@@ -48,15 +48,49 @@ internal static partial class QuestDialogueMetadataDerivation
             var row = questTextSheet.GetRow((uint)rowIndex);
             var rowKey = EvaluateQuestText(row.ReadStringColumn(0), evaluator);
             var text = EvaluateQuestText(row.ReadStringColumn(1), evaluator);
-            if (rowKey.Length == 0 || text.Length == 0 || IsNonDialogueRow(rowKey))
+            if (rowKey.Length == 0 || text.Length == 0)
             {
                 continue;
             }
 
-            entries.Add(new QuestDialogueSheetEntry(rowKey, text, rowIndex));
+            rawEntries.Add(new QuestDialogueSheetEntry(rowKey, text, rowIndex, 0));
         }
 
-        return entries;
+        return ReadDialogueEntries(questProgressSnapshot, rawEntries);
+    }
+
+    /// <summary>
+    ///     Filters evaluated raw quest rows while carrying each latest SEQ
+    ///     boundary onto retained dialogue and speaker-name rows.
+    /// </summary>
+    /// <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+    /// <param name="rawEntries">The source-ordered evaluated raw sheet rows.</param>
+    /// <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+    internal static IReadOnlyList<QuestDialogueSheetEntry> ReadDialogueEntries(
+        QuestProgressSnapshot questProgressSnapshot,
+        IReadOnlyList<QuestDialogueSheetEntry> rawEntries)
+    {
+        ArgumentNullException.ThrowIfNull(rawEntries);
+
+        List<QuestDialogueSheetEntry> dialogueEntries = [];
+        ushort questSequence = 0;
+        foreach (var entry in rawEntries.OrderBy(entry => entry.SourceOrder))
+        {
+            if (TryGetSequence(entry.RowKey, out var sequence))
+            {
+                questSequence = sequence;
+                continue;
+            }
+
+            if (entry.RowKey.Length == 0 || entry.Text.Length == 0 || IsNonDialogueRow(entry.RowKey))
+            {
+                continue;
+            }
+
+            dialogueEntries.Add(entry with { QuestSequence = questSequence });
+        }
+
+        return dialogueEntries;
     }
 
     /// <summary>
@@ -128,13 +162,10 @@ internal static partial class QuestDialogueMetadataDerivation
     {
         var namesBySequenceAndSuffix = new Dictionary<(ushort Sequence, string Suffix), string>();
         var textEntries = new List<(QuestDialogueSheetEntry Entry, ushort Sequence)>();
-        ushort questSequence = 0;
-
         foreach (var entry in dialogueEntries.OrderBy(entry => entry.SourceOrder))
         {
             if (TryGetSequence(entry.RowKey, out var sequence))
             {
-                questSequence = sequence;
                 continue;
             }
 
@@ -145,13 +176,13 @@ internal static partial class QuestDialogueMetadataDerivation
 
             if (IsNameRow(entry.RowKey))
             {
-                namesBySequenceAndSuffix[(questSequence, suffix)] = entry.Text;
+                namesBySequenceAndSuffix[(entry.QuestSequence, suffix)] = entry.Text;
                 continue;
             }
 
             if (!IsNonDialogueRow(entry.RowKey))
             {
-                textEntries.Add((entry, questSequence));
+                textEntries.Add((entry, entry.QuestSequence));
             }
         }
 
@@ -259,7 +290,9 @@ internal static partial class QuestDialogueMetadataDerivation
 /// <param name="RowKey">The evaluated source row key.</param>
 /// <param name="Text">The evaluated source text.</param>
 /// <param name="SourceOrder">The zero-based source row order.</param>
+/// <param name="QuestSequence">The latest preceding SEQ boundary value.</param>
 internal readonly record struct QuestDialogueSheetEntry(
     string RowKey,
     string Text,
-    int SourceOrder);
+    int SourceOrder,
+    ushort QuestSequence);

--- a/NativeUI/Helpers/QuestProgressResolver.cs
+++ b/NativeUI/Helpers/QuestProgressResolver.cs
@@ -372,7 +372,8 @@ internal static class QuestProgressResolver
         ISeStringEvaluator? evaluator,
         ClientLanguage clientLanguage)
     {
-        if (evaluator == null)
+        if (evaluator == null ||
+            Echoglossian.FrameworkInterface?.IsInFrameworkUpdateThread != true)
         {
             return text.ExtractText();
         }

--- a/NativeUI/Helpers/QuestProgressResolver.cs
+++ b/NativeUI/Helpers/QuestProgressResolver.cs
@@ -203,6 +203,32 @@ internal static class QuestProgressResolver
             return false;
         }
 
+        var runtimeQuestId = (ushort)(questId & 0xFFFF);
+        return TryResolveQuestProgress(
+            new QuestProgressCapture(
+                questId,
+                QuestManager.GetQuestSequence(runtimeQuestId),
+                Echoglossian.ClientStateInterface.ClientLanguage),
+            CancellationToken.None,
+            out snapshot);
+    }
+
+    /// <summary>
+    ///     Resolves a managed quest progression snapshot from native values
+    ///     captured before the worker handoff.
+    /// </summary>
+    /// <param name="capture">The captured quest identity, sequence, and client language.</param>
+    /// <param name="cancellationToken">The token that cancels sheet traversal.</param>
+    /// <param name="snapshot">The resolved managed progression snapshot, if any.</param>
+    /// <returns><see langword="true" /> when progression data could be resolved.</returns>
+    internal static bool TryResolveQuestProgress(
+        QuestProgressCapture capture,
+        CancellationToken cancellationToken,
+        out QuestProgressSnapshot snapshot)
+    {
+        snapshot = default;
+        cancellationToken.ThrowIfCancellationRequested();
+
         var dataManager = Echoglossian.DManager;
         if (dataManager == null)
         {
@@ -210,20 +236,19 @@ internal static class QuestProgressResolver
         }
 
         var questSheet =
-            dataManager.GetExcelSheet<Quest>(Echoglossian.ClientStateInterface.ClientLanguage);
+            dataManager.GetExcelSheet<Quest>(capture.ClientLanguage);
         if (questSheet == null ||
             !TryResolveQuestRow(
                 questSheet,
-                questId,
+                capture.QuestId,
                 out var resolvedQuestRowId,
                 out var questRow))
         {
             return false;
         }
 
-        var runtimeQuestId = (ushort)(resolvedQuestRowId & 0xFFFF);
-        var questSequence = QuestManager.GetQuestSequence(runtimeQuestId);
-        var cacheKey = $"{resolvedQuestRowId}:{questSequence}";
+        cancellationToken.ThrowIfCancellationRequested();
+        var cacheKey = $"{resolvedQuestRowId}:{capture.QuestSequence}";
         if (QuestProgressCache.TryGetValue(cacheKey, out snapshot))
         {
             return true;
@@ -243,17 +268,21 @@ internal static class QuestProgressResolver
         }
 
         var questName = QuestLuminaResolver.GetQuestNameText(questRow);
-        var (questSteps, questSeqs, questSystemTexts) = ReadQuestTextRows(questTextSheet);
+        var (questSteps, questSeqs, questSystemTexts) = ReadQuestTextRows(
+            questTextSheet,
+            capture.ClientLanguage,
+            cancellationToken);
         if (questSteps.Count == 0 && questSeqs.Count == 0)
         {
             return false;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var contentHash = QuestContentHash.Compute(questSeqs, questSteps, questSystemTexts);
 
         snapshot = new QuestProgressSnapshot(
             resolvedQuestRowId,
-            questSequence,
+            capture.QuestSequence,
             questName,
             questSheetName,
             questSteps,
@@ -294,7 +323,9 @@ internal static class QuestProgressResolver
     }
 
     private static (List<QuestProgressEntry> Steps, List<QuestProgressEntry> Seqs, List<QuestProgressEntry> SystemTexts) ReadQuestTextRows(
-        ExcelSheet<RawRow> questTextSheet)
+        ExcelSheet<RawRow> questTextSheet,
+        ClientLanguage clientLanguage,
+        CancellationToken cancellationToken)
     {
         var steps = new List<QuestProgressEntry>();
         var seqs = new List<QuestProgressEntry>();
@@ -304,12 +335,13 @@ internal static class QuestProgressResolver
         var rowCount = Convert.ToInt32(questTextSheet.Count, CultureInfo.InvariantCulture);
         for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var row = questTextSheet.GetRow((uint)rowIndex);
 
             ReadOnlySeString rawKey = row.ReadStringColumn(0);
             ReadOnlySeString rawValue = row.ReadStringColumn(1);
-            var keyText = EvaluateQuestText(rawKey, evaluator);
-            var valueText = EvaluateQuestText(rawValue, evaluator);
+            var keyText = EvaluateQuestText(rawKey, evaluator, clientLanguage);
+            var valueText = EvaluateQuestText(rawValue, evaluator, clientLanguage);
 
             if (keyText.Length == 0 || valueText.Length == 0)
             {
@@ -337,7 +369,8 @@ internal static class QuestProgressResolver
 
     private static string EvaluateQuestText(
         ReadOnlySeString text,
-        ISeStringEvaluator? evaluator)
+        ISeStringEvaluator? evaluator,
+        ClientLanguage clientLanguage)
     {
         if (evaluator == null)
         {
@@ -348,7 +381,7 @@ internal static class QuestProgressResolver
         {
             return evaluator.Evaluate(
                     text,
-                    language: Echoglossian.ClientStateInterface.ClientLanguage)
+                    language: clientLanguage)
                 .ExtractText();
         }
         catch (Exception)
@@ -369,6 +402,17 @@ internal static class QuestProgressResolver
         return $"quest/{dir}/{questId}";
     }
 }
+
+/// <summary>
+///     Carries lightweight native quest values across a worker handoff.
+/// </summary>
+/// <param name="QuestId">The accepted quest identifier.</param>
+/// <param name="QuestSequence">The accepted quest sequence captured from the quest manager.</param>
+/// <param name="ClientLanguage">The client language captured with the quest state.</param>
+internal readonly record struct QuestProgressCapture(
+    uint QuestId,
+    byte QuestSequence,
+    ClientLanguage ClientLanguage);
 
 /// <summary>
 ///     Represents a quest progression snapshot derived from Lumina and the

--- a/PluginUI/EngineConfigUI/ChatGptEngineUI.cs
+++ b/PluginUI/EngineConfigUI/ChatGptEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.OpenAI;
 
 namespace Echoglossian.PluginUI.EngineConfigUI;
@@ -71,16 +72,34 @@ public static class ChatGPTEngineUI
             runtimeActionsAvailable);
         changed |= DrawModelSelection(config, settings);
 
+        settings = OpenAiProviderVariantHelper.ResolveActiveSettings(config);
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.ChatGPT,
+            settings.ProviderName,
+            settings.BaseUrl,
+            settings.Model);
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
         var temp = config.ChatGptTemperature;
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
         if (ImGui.SliderFloat(
                 Resources.Temperature,
                 ref temp,
-                0.1f,
-                1.0f,
+                sliderState.MinValue,
+                sliderState.MaxValue,
                 "%.1f"))
         {
             config.ChatGptTemperature = temp;
             changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
         }
 
         PromptEditorUI.Draw(

--- a/PluginUI/EngineConfigUI/ClaudeEngineUI.cs
+++ b/PluginUI/EngineConfigUI/ClaudeEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Claude;
 
 namespace Echoglossian.PluginUI.EngineConfigUI;
@@ -121,11 +122,37 @@ public static class ClaudeEngineUI
             "Claude",
             tooltips);
 
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.Claude,
+            "Anthropic",
+            string.IsNullOrWhiteSpace(config.ClaudeBaseUrl)
+                ? "https://api.anthropic.com"
+                : config.ClaudeBaseUrl,
+            string.IsNullOrWhiteSpace(config.ClaudeModel)
+                ? "claude-sonnet-4-20250514"
+                : config.ClaudeModel);
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
         var temp = config.ClaudeTemperature;
-        if (ImGui.SliderFloat(Resources.Temperature, ref temp, 0.1f, 1.0f, "%.1f"))
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
+        if (ImGui.SliderFloat(
+                Resources.Temperature,
+                ref temp,
+                sliderState.MinValue,
+                sliderState.MaxValue,
+                "%.1f"))
         {
             config.ClaudeTemperature = temp;
             changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
         }
 
         PromptEditorUI.Draw(

--- a/PluginUI/EngineConfigUI/DeepSeekEngineUI.cs
+++ b/PluginUI/EngineConfigUI/DeepSeekEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.DeepSeek;
 
 namespace Echoglossian.PluginUI.EngineConfigUI;
@@ -104,6 +105,35 @@ public static class DeepSeekEngineUI
             "DeepSeek",
             tooltips);
         config.DeepSeekModel = model;
+
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.DeepSeek,
+            "DeepSeek",
+            config.DeepSeekBaseUrl ?? "https://api.deepseek.com/v1",
+            config.DeepSeekModel ?? "deepseek-chat");
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
+        var temp = config.DeepSeekTemperature;
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
+        if (ImGui.SliderFloat(
+                Resources.Temperature,
+                ref temp,
+                sliderState.MinValue,
+                sliderState.MaxValue,
+                "%.1f"))
+        {
+            config.DeepSeekTemperature = temp;
+            changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
+        }
 
         PromptEditorUI.Draw(
             promptManager,

--- a/PluginUI/EngineConfigUI/GeminiEngineUI.cs
+++ b/PluginUI/EngineConfigUI/GeminiEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Gemini;
 
 namespace Echoglossian.PluginUI.EngineConfigUI;
@@ -91,6 +92,35 @@ public static class GeminiEngineUI
             "Gemini",
             tooltips);
         config.GeminiModel = config.GeminiModelId;
+
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.Gemini,
+            "Gemini",
+            "https://generativelanguage.googleapis.com",
+            config.GeminiModel ?? "gemini-2.5-flash");
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
+        var temp = config.GeminiTemperature;
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
+        if (ImGui.SliderFloat(
+                Resources.Temperature,
+                ref temp,
+                sliderState.MinValue,
+                sliderState.MaxValue,
+                "%.1f"))
+        {
+            config.GeminiTemperature = temp;
+            changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
+        }
 
         PromptEditorUI.Draw(
             promptManager,

--- a/PluginUI/EngineConfigUI/LlmCapabilityUiHelper.cs
+++ b/PluginUI/EngineConfigUI/LlmCapabilityUiHelper.cs
@@ -1,0 +1,60 @@
+// <copyright file="LlmCapabilityUiHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators.Capabilities;
+
+namespace Echoglossian.PluginUI.EngineConfigUI;
+
+/// <summary>
+///     Resolves LLM configuration control state from the shared capability
+///     policy used for provider request payloads.
+/// </summary>
+public static class LlmCapabilityUiHelper
+{
+    /// <summary>
+    ///     Gets the temperature slider state for the active LLM capability
+    ///     scope.
+    /// </summary>
+    /// <param name="scope">The active capability lookup scope.</param>
+    /// <param name="fallbackMin">The engine-specific default minimum value.</param>
+    /// <param name="fallbackMax">The engine-specific default maximum value.</param>
+    /// <returns>The effective slider state and disabled-control explanation.</returns>
+    public static LlmCapabilitySliderState GetTemperatureSliderState(
+        LlmCapabilityScope scope,
+        float fallbackMin,
+        float fallbackMax)
+    {
+        var decision = LlmCapabilityPolicyService.GetSnapshot(scope)
+            .GetDecision(LlmCapabilityParameterName.Temperature);
+        var minValue = decision.MinValue ?? fallbackMin;
+        var maxValue = decision.MaxValue ?? fallbackMax;
+
+        if (decision.SupportState == LlmCapabilitySupportState.Supported &&
+            !decision.OmitWhenDefaultOnly)
+        {
+            return new LlmCapabilitySliderState(true, minValue, maxValue, string.Empty);
+        }
+
+        var tooltipText = decision.OmitWhenDefaultOnly
+            ? Resources.TemperatureControlDefaultOnlyTooltip
+            : decision.SupportState == LlmCapabilitySupportState.Unknown
+                ? Resources.TemperatureControlUnknownTooltip
+                : Resources.TemperatureControlUnsupportedTooltip;
+        return new LlmCapabilitySliderState(false, minValue, maxValue, tooltipText);
+    }
+}
+
+/// <summary>
+///     Describes the effective UI state for an LLM temperature slider.
+/// </summary>
+/// <param name="IsEnabled">Whether the control may accept user input.</param>
+/// <param name="MinValue">The inclusive slider minimum value.</param>
+/// <param name="MaxValue">The inclusive slider maximum value.</param>
+/// <param name="TooltipText">The explanation shown for a disabled control.</param>
+public readonly record struct LlmCapabilitySliderState(
+    bool IsEnabled,
+    float MinValue,
+    float MaxValue,
+    string TooltipText);

--- a/PluginUI/EngineConfigUI/LmStudioEngineUI.cs
+++ b/PluginUI/EngineConfigUI/LmStudioEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.LmStudio;
 using Echoglossian.Translators.OpenAI;
 
@@ -107,16 +108,33 @@ public static class LmStudioEngineUI
             models,
             "LmStudio");
 
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.LmStudio,
+            "LmStudio",
+            config.LmStudioBaseUrl?.TrimEnd('/') ?? "http://localhost:1234/v1",
+            config.LmStudioModel ?? "llama3");
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
         var temp = config.LmStudioTemperature;
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
         if (ImGui.SliderFloat(
                 Resources.Temperature,
                 ref temp,
-                0.1f,
-                1.0f,
+                sliderState.MinValue,
+                sliderState.MaxValue,
                 "%.1f"))
         {
             config.LmStudioTemperature = temp;
             changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
         }
 
         PromptEditorUI.Draw(

--- a/PluginUI/EngineConfigUI/OllamaEngineUI.cs
+++ b/PluginUI/EngineConfigUI/OllamaEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Ollama;
 
 namespace Echoglossian.PluginUI.EngineConfigUI;
@@ -89,11 +90,33 @@ public static class OllamaEngineUI
             "Ollama",
             OllamaModelManager.GetTooltips());
 
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.Ollama,
+            "Ollama",
+            config.OllamaUrl?.TrimEnd('/') ?? "http://localhost:11434",
+            config.OllamaModel ?? "llama3");
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
         var temp = config.OllamaTemperature;
-        if (ImGui.SliderFloat(Resources.Temperature, ref temp, 0.1f, 1.0f, "%.1f"))
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
+        if (ImGui.SliderFloat(
+                Resources.Temperature,
+                ref temp,
+                sliderState.MinValue,
+                sliderState.MaxValue,
+                "%.1f"))
         {
             config.OllamaTemperature = temp;
             changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
         }
 
         PromptEditorUI.Draw(

--- a/PluginUI/EngineConfigUI/OpenRouterEngineUI.cs
+++ b/PluginUI/EngineConfigUI/OpenRouterEngineUI.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.PluginUI.Components;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.OpenAI;
 using Echoglossian.Translators.OpenRouter;
 
@@ -100,11 +101,35 @@ public static class OpenRouterEngineUI
             "OpenRouter");
         config.OpenRouterModel = model;
 
+        var scope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.OpenRouter,
+            "OpenRouter",
+            string.IsNullOrWhiteSpace(config.OpenRouterBaseUrl)
+                ? "https://openrouter.ai/api/v1"
+                : config.OpenRouterBaseUrl,
+            config.OpenRouterModel ?? "mistral");
+        var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+            scope,
+            0.1f,
+            1.0f);
         var temp = config.OpenRouterTemperature;
-        if (ImGui.SliderFloat(Resources.Temperature, ref temp, 0.1f, 1.0f, "%.1f"))
+        ImGui.BeginDisabled(!sliderState.IsEnabled);
+        if (ImGui.SliderFloat(
+                Resources.Temperature,
+                ref temp,
+                sliderState.MinValue,
+                sliderState.MaxValue,
+                "%.1f"))
         {
             config.OpenRouterTemperature = temp;
             changed = true;
+        }
+
+        ImGui.EndDisabled();
+        if (!sliderState.IsEnabled &&
+            ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip(sliderState.TooltipText);
         }
 
         PromptEditorUI.Draw(

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -3573,6 +3573,39 @@ namespace Echoglossian.Properties
                 return ResourceManager.GetString("Temperature", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///     Looks up a localized string similar to Temperature is unavailable because the selected model requires the provider default-only setting..
+        /// </summary>
+        public static string TemperatureControlDefaultOnlyTooltip
+        {
+            get
+            {
+                return ResourceManager.GetString("TemperatureControlDefaultOnlyTooltip", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///     Looks up a localized string similar to Temperature support for the selected model is unknown, so the setting is disabled and omitted from requests..
+        /// </summary>
+        public static string TemperatureControlUnknownTooltip
+        {
+            get
+            {
+                return ResourceManager.GetString("TemperatureControlUnknownTooltip", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///     Looks up a localized string similar to Temperature is unavailable for the selected model..
+        /// </summary>
+        public static string TemperatureControlUnsupportedTooltip
+        {
+            get
+            {
+                return ResourceManager.GetString("TemperatureControlUnsupportedTooltip", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///     Pesquisa uma cadeia de caracteres localizada semelhante a Tip: Double-click a row to edit..

--- a/Properties/Resources.en-US.resx
+++ b/Properties/Resources.en-US.resx
@@ -649,6 +649,15 @@
   <data name="Temperature" xml:space="preserve">
     <value>Temperature</value>
   </data>
+  <data name="TemperatureControlDefaultOnlyTooltip" xml:space="preserve">
+    <value>Temperature is unavailable because the selected model requires the provider default-only setting.</value>
+  </data>
+  <data name="TemperatureControlUnknownTooltip" xml:space="preserve">
+    <value>Temperature support for the selected model is unknown, so the setting is disabled and omitted from requests.</value>
+  </data>
+  <data name="TemperatureControlUnsupportedTooltip" xml:space="preserve">
+    <value>Temperature is unavailable for the selected model.</value>
+  </data>
   <data name="NoSettingsForEngine" xml:space="preserve">
     <value>No settings required for this engine</value>
   </data>

--- a/Properties/Resources.pt-BR.resx
+++ b/Properties/Resources.pt-BR.resx
@@ -649,6 +649,15 @@
   <data name="Temperature" xml:space="preserve">
     <value>Temperature</value>
   </data>
+  <data name="TemperatureControlDefaultOnlyTooltip" xml:space="preserve">
+    <value>A temperatura não está disponível porque o modelo selecionado exige a configuração padrão do provedor.</value>
+  </data>
+  <data name="TemperatureControlUnknownTooltip" xml:space="preserve">
+    <value>O suporte à temperatura do modelo selecionado é desconhecido, portanto a configuração está desativada e será omitida das solicitações.</value>
+  </data>
+  <data name="TemperatureControlUnsupportedTooltip" xml:space="preserve">
+    <value>A temperatura não está disponível para o modelo selecionado.</value>
+  </data>
   <data name="NoSettingsForEngine" xml:space="preserve">
     <value>No settings required for this engine</value>
   </data>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -649,6 +649,15 @@
   <data name="Temperature" xml:space="preserve">
     <value>Temperature</value>
   </data>
+  <data name="TemperatureControlDefaultOnlyTooltip" xml:space="preserve">
+    <value>Temperature is unavailable because the selected model requires the provider default-only setting.</value>
+  </data>
+  <data name="TemperatureControlUnknownTooltip" xml:space="preserve">
+    <value>Temperature support for the selected model is unknown, so the setting is disabled and omitted from requests.</value>
+  </data>
+  <data name="TemperatureControlUnsupportedTooltip" xml:space="preserve">
+    <value>Temperature is unavailable for the selected model.</value>
+  </data>
   <data name="NoSettingsForEngine" xml:space="preserve">
     <value>No settings required for this engine</value>
   </data>

--- a/Translators/Capabilities/LlmCapabilityErrorClassifier.cs
+++ b/Translators/Capabilities/LlmCapabilityErrorClassifier.cs
@@ -1,0 +1,131 @@
+// <copyright file="LlmCapabilityErrorClassifier.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Text.RegularExpressions;
+
+using Newtonsoft.Json.Linq;
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Classifies provider failures without retaining raw response bodies.
+/// </summary>
+public static partial class LlmCapabilityErrorClassifier
+{
+    /// <summary>
+    ///     Classifies a provider response as an exact-model promotable failure,
+    ///     an observation-only client error, or an unclassified failure.
+    /// </summary>
+    /// <param name="scope">The capability scope associated with the request.</param>
+    /// <param name="parameterName">The parameter sent in the failed request.</param>
+    /// <param name="statusCode">The provider response status code.</param>
+    /// <param name="responseText">The provider response body.</param>
+    /// <returns>A bounded, sanitized failure classification.</returns>
+    public static LlmCapabilityFailureClassification TryClassify(
+        LlmCapabilityScope scope,
+        LlmCapabilityParameterName parameterName,
+        int? statusCode,
+        string? responseText)
+    {
+        _ = scope;
+
+        if (statusCode != 400)
+        {
+            return new LlmCapabilityFailureClassification(
+                false,
+                false,
+                "unclassified",
+                string.Empty,
+                string.Empty);
+        }
+
+        var (providerErrorCode, message) = ExtractResponseDetails(responseText);
+        var parameterToken = GetParameterToken(parameterName);
+        var explicitlyUnsupported = !string.IsNullOrEmpty(parameterToken) &&
+            ContainsParameter(message, parameterToken) &&
+            (message.Contains("unsupported", StringComparison.OrdinalIgnoreCase) ||
+             message.Contains("does not support", StringComparison.OrdinalIgnoreCase) ||
+             providerErrorCode.Contains("unsupported", StringComparison.OrdinalIgnoreCase));
+
+        return explicitlyUnsupported
+            ? new LlmCapabilityFailureClassification(
+                true,
+                true,
+                "unsupported-parameter",
+                providerErrorCode,
+                $"Provider rejected parameter '{parameterToken}'.")
+            : new LlmCapabilityFailureClassification(
+                true,
+                false,
+                "ambiguous-client-error",
+                providerErrorCode,
+                "Provider returned an unclassified 400 response.");
+    }
+
+    private static (string ProviderErrorCode, string Message) ExtractResponseDetails(
+        string? responseText)
+    {
+        var providerErrorCode = string.Empty;
+        var message = responseText ?? string.Empty;
+
+        try
+        {
+            var root = JObject.Parse(responseText ?? string.Empty);
+            var error = root["error"] ?? root;
+            providerErrorCode = error.Value<string>("code") ?? string.Empty;
+            message = error.Value<string>("message") ?? message;
+        }
+        catch (Newtonsoft.Json.JsonReaderException)
+        {
+            // Non-JSON providers retain only a sanitized bounded excerpt.
+        }
+
+        return (SanitizeProviderErrorCode(providerErrorCode), Sanitize(message));
+    }
+
+    private static bool ContainsParameter(string message, string parameterToken)
+    {
+        return message.Contains(parameterToken, StringComparison.OrdinalIgnoreCase) ||
+            message.Contains(parameterToken.Replace("_", "-", StringComparison.Ordinal), StringComparison.OrdinalIgnoreCase) ||
+            message.Contains(parameterToken.Replace("_", " ", StringComparison.Ordinal), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetParameterToken(LlmCapabilityParameterName parameterName)
+    {
+        return parameterName switch
+        {
+            LlmCapabilityParameterName.Temperature => "temperature",
+            LlmCapabilityParameterName.TopP => "top_p",
+            LlmCapabilityParameterName.TopK => "top_k",
+            LlmCapabilityParameterName.PresencePenalty => "presence_penalty",
+            LlmCapabilityParameterName.FrequencyPenalty => "frequency_penalty",
+            LlmCapabilityParameterName.ReasoningEffort => "reasoning_effort",
+            LlmCapabilityParameterName.StructuredToolCalling => "tool",
+            _ => string.Empty,
+        };
+    }
+
+    private static string Sanitize(string value)
+    {
+        var redacted = SensitiveValueRegex().Replace(value, "$1=[redacted]");
+        var normalized = WhitespaceRegex().Replace(redacted, " ").Trim();
+        return normalized.Length <= 256 ? normalized : normalized[..256];
+    }
+
+    private static string SanitizeProviderErrorCode(string value)
+    {
+        var sanitized = Sanitize(value);
+        return ProviderErrorCodeRegex().IsMatch(sanitized) ? sanitized : string.Empty;
+    }
+
+    [GeneratedRegex("(?i)\\b(api[_-]?key|authorization|bearer|token|password|secret)\\s*[:=]\\s*[^\\s,;]+")]
+    private static partial Regex SensitiveValueRegex();
+
+    [GeneratedRegex("\\s+")]
+    private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex("^[A-Za-z0-9_-]{1,64}$")]
+    private static partial Regex ProviderErrorCodeRegex();
+}

--- a/Translators/Capabilities/LlmCapabilityErrorClassifier.cs
+++ b/Translators/Capabilities/LlmCapabilityErrorClassifier.cs
@@ -46,6 +46,7 @@ public static partial class LlmCapabilityErrorClassifier
         var explicitlyUnsupported = !string.IsNullOrEmpty(parameterToken) &&
             ContainsParameter(message, parameterToken) &&
             (message.Contains("unsupported", StringComparison.OrdinalIgnoreCase) ||
+             message.Contains("not supported", StringComparison.OrdinalIgnoreCase) ||
              message.Contains("does not support", StringComparison.OrdinalIgnoreCase) ||
              providerErrorCode.Contains("unsupported", StringComparison.OrdinalIgnoreCase));
 

--- a/Translators/Capabilities/LlmCapabilityFailureClassification.cs
+++ b/Translators/Capabilities/LlmCapabilityFailureClassification.cs
@@ -1,0 +1,21 @@
+// <copyright file="LlmCapabilityFailureClassification.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Describes the safe, bounded interpretation of a provider failure.
+/// </summary>
+/// <param name="ObservationRecorded">Whether the failure is eligible for an audit observation.</param>
+/// <param name="RulePromoted">Whether the failure is eligible for exact-model rule promotion.</param>
+/// <param name="FailureKind">The bounded failure classification.</param>
+/// <param name="ProviderErrorCode">The sanitized provider error code.</param>
+/// <param name="MessageExcerpt">The sanitized provider error excerpt.</param>
+public readonly record struct LlmCapabilityFailureClassification(
+    bool ObservationRecorded,
+    bool RulePromoted,
+    string FailureKind,
+    string ProviderErrorCode,
+    string MessageExcerpt);

--- a/Translators/Capabilities/LlmCapabilityParameterDecision.cs
+++ b/Translators/Capabilities/LlmCapabilityParameterDecision.cs
@@ -1,0 +1,26 @@
+// <copyright file="LlmCapabilityParameterDecision.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Describes the resolved policy for one LLM capability parameter.
+/// </summary>
+/// <param name="SupportState">The resolved support state.</param>
+/// <param name="MinValue">The inclusive lower bound, when known.</param>
+/// <param name="MaxValue">The inclusive upper bound, when known.</param>
+/// <param name="OmitWhenDefaultOnly">
+///     Whether the parameter must be omitted when only its implicit default is
+///     allowed.
+/// </param>
+/// <param name="Source">The source that supplied the resolved decision.</param>
+/// <param name="Reason">The reason supplied by the resolved decision source.</param>
+public readonly record struct LlmCapabilityParameterDecision(
+    LlmCapabilitySupportState SupportState,
+    float? MinValue,
+    float? MaxValue,
+    bool OmitWhenDefaultOnly,
+    string Source,
+    string Reason);

--- a/Translators/Capabilities/LlmCapabilityParameterName.cs
+++ b/Translators/Capabilities/LlmCapabilityParameterName.cs
@@ -1,0 +1,47 @@
+// <copyright file="LlmCapabilityParameterName.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Identifies an LLM request parameter governed by the capability matrix.
+/// </summary>
+public enum LlmCapabilityParameterName
+{
+  /// <summary>
+  ///     Identifies the temperature parameter.
+  /// </summary>
+  Temperature = 0,
+
+  /// <summary>
+  ///     Identifies the top-p parameter.
+  /// </summary>
+  TopP = 1,
+
+  /// <summary>
+  ///     Identifies the top-k parameter.
+  /// </summary>
+  TopK = 2,
+
+  /// <summary>
+  ///     Identifies the presence-penalty parameter.
+  /// </summary>
+  PresencePenalty = 3,
+
+  /// <summary>
+  ///     Identifies the frequency-penalty parameter.
+  /// </summary>
+  FrequencyPenalty = 4,
+
+  /// <summary>
+  ///     Identifies the reasoning-effort parameter.
+  /// </summary>
+  ReasoningEffort = 5,
+
+  /// <summary>
+  ///     Identifies structured tool calling support.
+  /// </summary>
+  StructuredToolCalling = 6,
+}

--- a/Translators/Capabilities/LlmCapabilityPolicyService.cs
+++ b/Translators/Capabilities/LlmCapabilityPolicyService.cs
@@ -99,6 +99,14 @@ public static class LlmCapabilityPolicyService
         string? responseText)
     {
         var normalizedScope = NormalizeScope(scope);
+        if (string.IsNullOrWhiteSpace(normalizedScope.ModelId))
+        {
+            return new LlmCapabilityLearningResult(
+                false,
+                false,
+                "unclassified");
+        }
+
         var classification = LlmCapabilityErrorClassifier.TryClassify(
             normalizedScope,
             parameterName,

--- a/Translators/Capabilities/LlmCapabilityPolicyService.cs
+++ b/Translators/Capabilities/LlmCapabilityPolicyService.cs
@@ -1,0 +1,191 @@
+// <copyright file="LlmCapabilityPolicyService.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Cache;
+using Echoglossian.DBHelpers;
+using Echoglossian.EFCoreSqlite.Models;
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Provides the shared runtime policy path for LLM capability decisions.
+/// </summary>
+public static class LlmCapabilityPolicyService
+{
+    /// <summary>
+    ///     Creates a conservatively normalized capability lookup scope.
+    /// </summary>
+    /// <param name="engine">The active translation engine.</param>
+    /// <param name="providerScope">The provider identity within the engine.</param>
+    /// <param name="endpointScope">The endpoint identity within the provider.</param>
+    /// <param name="modelId">The selected model identifier.</param>
+    /// <returns>A normalized capability lookup scope.</returns>
+    public static LlmCapabilityScope CreateScope(
+        Echoglossian.TransEngines engine,
+        string? providerScope,
+        string? endpointScope,
+        string? modelId)
+    {
+        return new LlmCapabilityScope(
+            engine,
+            providerScope?.Trim() ?? string.Empty,
+            endpointScope?.Trim().TrimEnd('/') ?? string.Empty,
+            modelId?.Trim() ?? string.Empty);
+    }
+
+    /// <summary>
+    ///     Gets the effective capability snapshot without querying SQLite.
+    /// </summary>
+    /// <param name="scope">The active capability lookup scope.</param>
+    /// <returns>The resolved capability snapshot.</returns>
+    public static LlmCapabilitySnapshot GetSnapshot(LlmCapabilityScope scope)
+    {
+        return LlmCapabilityResolver.Resolve(
+            NormalizeScope(scope),
+            LlmCapabilityCacheManager.GetRuleDefinitions());
+    }
+
+    /// <summary>
+    ///     Resolves a temperature value for provider payload use.
+    /// </summary>
+    /// <param name="scope">The active capability lookup scope.</param>
+    /// <param name="configuredValue">The configured temperature value.</param>
+    /// <param name="sanitizedValue">When this method returns, contains the safe value when it may be sent. This parameter is treated as uninitialized.</param>
+    /// <param name="decision">When this method returns, contains the resolved temperature decision. This parameter is treated as uninitialized.</param>
+    /// <returns><see langword="true" /> if the value may be sent; otherwise, <see langword="false" />.</returns>
+    public static bool TryResolveTemperature(
+        LlmCapabilityScope scope,
+        float configuredValue,
+        out float sanitizedValue,
+        out LlmCapabilityParameterDecision decision)
+    {
+        decision = GetSnapshot(scope).GetDecision(LlmCapabilityParameterName.Temperature);
+        sanitizedValue = configuredValue;
+
+        if (decision.SupportState != LlmCapabilitySupportState.Supported ||
+            decision.OmitWhenDefaultOnly)
+        {
+            sanitizedValue = default;
+            return false;
+        }
+
+        if (decision.MinValue.HasValue && configuredValue < decision.MinValue.Value)
+        {
+            sanitizedValue = decision.MinValue.Value;
+        }
+
+        if (decision.MaxValue.HasValue && configuredValue > decision.MaxValue.Value)
+        {
+            sanitizedValue = decision.MaxValue.Value;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Learns from a bounded, classified provider failure.
+    /// </summary>
+    /// <param name="scope">The capability scope associated with the request.</param>
+    /// <param name="parameterName">The parameter sent in the failed request.</param>
+    /// <param name="statusCode">The provider response status code.</param>
+    /// <param name="responseText">The provider response body.</param>
+    /// <returns>The persisted observation and promotion outcome.</returns>
+    public static LlmCapabilityLearningResult LearnFromProviderFailure(
+        LlmCapabilityScope scope,
+        LlmCapabilityParameterName parameterName,
+        int? statusCode,
+        string? responseText)
+    {
+        var normalizedScope = NormalizeScope(scope);
+        var classification = LlmCapabilityErrorClassifier.TryClassify(
+            normalizedScope,
+            parameterName,
+            statusCode,
+            responseText);
+        if (!classification.ObservationRecorded ||
+            string.IsNullOrWhiteSpace(Echoglossian.ConfigDirectory))
+        {
+            return new LlmCapabilityLearningResult(
+                false,
+                false,
+                classification.FailureKind);
+        }
+
+        var observation = new LlmModelCapabilityObservation
+        {
+            Engine = normalizedScope.Engine.ToString(),
+            ProviderScope = normalizedScope.ProviderScope,
+            EndpointScope = normalizedScope.EndpointScope,
+            ModelId = normalizedScope.ModelId,
+            ParameterName = parameterName.ToString(),
+            StatusCode = statusCode ?? 0,
+            ProviderErrorCode = classification.ProviderErrorCode,
+            MessageExcerpt = classification.MessageExcerpt,
+        };
+
+        try
+        {
+            LlmCapabilityPersistenceHelper.RecordObservation(
+                Echoglossian.ConfigDirectory,
+                observation);
+            LlmCapabilityCacheManager.PublishObservation(observation);
+
+            if (!classification.RulePromoted)
+            {
+                return new LlmCapabilityLearningResult(
+                    true,
+                    false,
+                    classification.FailureKind);
+            }
+
+            var rule = LlmModelCapabilityRule.CreateExactModel(
+                normalizedScope.Engine.ToString(),
+                normalizedScope.ProviderScope,
+                normalizedScope.EndpointScope,
+                normalizedScope.ModelId,
+                parameterName,
+                LlmCapabilitySupportState.Unsupported,
+                source: "Observed400",
+                reason: "Provider returned a classified unsupported parameter response.");
+            LlmCapabilityPersistenceHelper.UpsertRules(
+                Echoglossian.ConfigDirectory,
+                [rule]);
+            LlmCapabilityCacheManager.PublishRule(rule.ToDefinition());
+            return new LlmCapabilityLearningResult(
+                true,
+                true,
+                classification.FailureKind);
+        }
+        catch (Exception ex)
+        {
+            PluginRuntimeLog.Warning(
+                $"[LlmCapabilityPolicyService] Failed to persist {classification.FailureKind} capability feedback: {ex.GetType().Name}");
+            return new LlmCapabilityLearningResult(
+                false,
+                false,
+                "persistence-failed");
+        }
+    }
+
+    private static LlmCapabilityScope NormalizeScope(LlmCapabilityScope scope)
+    {
+        return CreateScope(
+            scope.Engine,
+            scope.ProviderScope,
+            scope.EndpointScope,
+            scope.ModelId);
+    }
+}
+
+/// <summary>
+///     Describes the persisted outcome of provider failure learning.
+/// </summary>
+/// <param name="ObservationRecorded">Whether a sanitized observation was persisted.</param>
+/// <param name="RulePromoted">Whether an exact-model rule was persisted.</param>
+/// <param name="FailureKind">The bounded failure classification.</param>
+public readonly record struct LlmCapabilityLearningResult(
+    bool ObservationRecorded,
+    bool RulePromoted,
+    string FailureKind);

--- a/Translators/Capabilities/LlmCapabilityRefreshPromoter.cs
+++ b/Translators/Capabilities/LlmCapabilityRefreshPromoter.cs
@@ -31,55 +31,55 @@ public static class LlmCapabilityRefreshPromoter
         IReadOnlyList<string> modelIds,
         DateTime observedAtUtc)
     {
-        if (string.IsNullOrWhiteSpace(Echoglossian.ConfigDirectory))
-        {
-            return;
-        }
-
-        var promotedRules = new List<LlmModelCapabilityRule>();
-        foreach (var modelId in modelIds.Where(static model => !string.IsNullOrWhiteSpace(model)).Distinct(StringComparer.Ordinal))
-        {
-            var scope = LlmCapabilityPolicyService.CreateScope(
-                engine,
-                providerScope,
-                endpointScope,
-                modelId);
-            var staticSnapshot = LlmCapabilityResolver.Resolve(
-                scope,
-                Array.Empty<LlmCapabilityRuleDefinition>());
-
-            foreach (var parameterName in Enum.GetValues<LlmCapabilityParameterName>())
-            {
-                var decision = staticSnapshot.GetDecision(parameterName);
-                if (decision.SupportState == LlmCapabilitySupportState.Unknown)
-                {
-                    continue;
-                }
-
-                var rule = LlmModelCapabilityRule.CreateExactModel(
-                    scope.Engine.ToString(),
-                    scope.ProviderScope,
-                    scope.EndpointScope,
-                    scope.ModelId,
-                    parameterName,
-                    decision.SupportState,
-                    decision.MinValue,
-                    decision.MaxValue,
-                    decision.OmitWhenDefaultOnly,
-                    "LiveRefresh",
-                    decision.Reason);
-                rule.ObservedAtUtc = observedAtUtc;
-                promotedRules.Add(rule);
-            }
-        }
-
-        if (promotedRules.Count == 0)
-        {
-            return;
-        }
-
         try
         {
+            if (string.IsNullOrWhiteSpace(Echoglossian.ConfigDirectory))
+            {
+                return;
+            }
+
+            var promotedRules = new List<LlmModelCapabilityRule>();
+            foreach (var modelId in modelIds.Where(static model => !string.IsNullOrWhiteSpace(model)).Distinct(StringComparer.Ordinal))
+            {
+                var scope = LlmCapabilityPolicyService.CreateScope(
+                    engine,
+                    providerScope,
+                    endpointScope,
+                    modelId);
+                var staticSnapshot = LlmCapabilityResolver.Resolve(
+                    scope,
+                    Array.Empty<LlmCapabilityRuleDefinition>());
+
+                foreach (var parameterName in Enum.GetValues<LlmCapabilityParameterName>())
+                {
+                    var decision = staticSnapshot.GetDecision(parameterName);
+                    if (decision.SupportState == LlmCapabilitySupportState.Unknown)
+                    {
+                        continue;
+                    }
+
+                    var rule = LlmModelCapabilityRule.CreateExactModel(
+                        scope.Engine.ToString(),
+                        scope.ProviderScope,
+                        scope.EndpointScope,
+                        scope.ModelId,
+                        parameterName,
+                        decision.SupportState,
+                        decision.MinValue,
+                        decision.MaxValue,
+                        decision.OmitWhenDefaultOnly,
+                        "LiveRefresh",
+                        decision.Reason);
+                    rule.ObservedAtUtc = observedAtUtc;
+                    promotedRules.Add(rule);
+                }
+            }
+
+            if (promotedRules.Count == 0)
+            {
+                return;
+            }
+
             LlmCapabilityPersistenceHelper.UpsertRules(
                 Echoglossian.ConfigDirectory,
                 promotedRules);
@@ -91,7 +91,7 @@ public static class LlmCapabilityRefreshPromoter
         catch (Exception ex)
         {
             PluginRuntimeLog.Warning(
-                $"[LlmCapabilityRefreshPromoter] Failed to persist refreshed capability overlays: {ex.GetType().Name}");
+                $"[LlmCapabilityRefreshPromoter] Failed to promote refreshed capability overlays: {ex.GetType().Name}");
         }
     }
 }

--- a/Translators/Capabilities/LlmCapabilityRefreshPromoter.cs
+++ b/Translators/Capabilities/LlmCapabilityRefreshPromoter.cs
@@ -1,0 +1,97 @@
+// <copyright file="LlmCapabilityRefreshPromoter.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Cache;
+using Echoglossian.DBHelpers;
+using Echoglossian.EFCoreSqlite.Models;
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Promotes discovered model identifiers into exact-model capability
+///     overlays derived from known family policy.
+/// </summary>
+public static class LlmCapabilityRefreshPromoter
+{
+    /// <summary>
+    ///     Persists exact-model overlays for discovered models that match known
+    ///     static family policy.
+    /// </summary>
+    /// <param name="engine">The active translation engine.</param>
+    /// <param name="providerScope">The provider identity within the engine.</param>
+    /// <param name="endpointScope">The endpoint identity within the provider.</param>
+    /// <param name="modelIds">The discovered model identifiers.</param>
+    /// <param name="observedAtUtc">The UTC refresh observation time.</param>
+    public static void PromoteDiscoveredModels(
+        Echoglossian.TransEngines engine,
+        string providerScope,
+        string endpointScope,
+        IReadOnlyList<string> modelIds,
+        DateTime observedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(Echoglossian.ConfigDirectory))
+        {
+            return;
+        }
+
+        var promotedRules = new List<LlmModelCapabilityRule>();
+        foreach (var modelId in modelIds.Where(static model => !string.IsNullOrWhiteSpace(model)).Distinct(StringComparer.Ordinal))
+        {
+            var scope = LlmCapabilityPolicyService.CreateScope(
+                engine,
+                providerScope,
+                endpointScope,
+                modelId);
+            var staticSnapshot = LlmCapabilityResolver.Resolve(
+                scope,
+                Array.Empty<LlmCapabilityRuleDefinition>());
+
+            foreach (var parameterName in Enum.GetValues<LlmCapabilityParameterName>())
+            {
+                var decision = staticSnapshot.GetDecision(parameterName);
+                if (decision.SupportState == LlmCapabilitySupportState.Unknown)
+                {
+                    continue;
+                }
+
+                var rule = LlmModelCapabilityRule.CreateExactModel(
+                    scope.Engine.ToString(),
+                    scope.ProviderScope,
+                    scope.EndpointScope,
+                    scope.ModelId,
+                    parameterName,
+                    decision.SupportState,
+                    decision.MinValue,
+                    decision.MaxValue,
+                    decision.OmitWhenDefaultOnly,
+                    "LiveRefresh",
+                    decision.Reason);
+                rule.ObservedAtUtc = observedAtUtc;
+                promotedRules.Add(rule);
+            }
+        }
+
+        if (promotedRules.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            LlmCapabilityPersistenceHelper.UpsertRules(
+                Echoglossian.ConfigDirectory,
+                promotedRules);
+            foreach (var rule in promotedRules)
+            {
+                LlmCapabilityCacheManager.PublishRule(rule.ToDefinition());
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginRuntimeLog.Warning(
+                $"[LlmCapabilityRefreshPromoter] Failed to persist refreshed capability overlays: {ex.GetType().Name}");
+        }
+    }
+}

--- a/Translators/Capabilities/LlmCapabilityRequestPayloadSanitizer.cs
+++ b/Translators/Capabilities/LlmCapabilityRequestPayloadSanitizer.cs
@@ -1,0 +1,41 @@
+// <copyright file="LlmCapabilityRequestPayloadSanitizer.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Applies shared LLM capability decisions to mutable provider payloads.
+/// </summary>
+public static class LlmCapabilityRequestPayloadSanitizer
+{
+    /// <summary>
+    ///     Adds the configured temperature to a provider payload only when the
+    ///     shared policy permits the parameter for the active scope.
+    /// </summary>
+    /// <param name="payload">The mutable provider request payload.</param>
+    /// <param name="scope">The active capability scope.</param>
+    /// <param name="configuredTemperature">The configured temperature value.</param>
+    /// <returns>
+    ///     <see langword="true" /> when temperature was added; otherwise,
+    ///     <see langword="false" />.
+    /// </returns>
+    public static bool TryAddTemperature(
+        IDictionary<string, object> payload,
+        LlmCapabilityScope scope,
+        float configuredTemperature)
+    {
+        if (!LlmCapabilityPolicyService.TryResolveTemperature(
+                scope,
+                configuredTemperature,
+                out var sanitizedTemperature,
+                out _))
+        {
+            return false;
+        }
+
+        payload.Add("temperature", sanitizedTemperature);
+        return true;
+    }
+}

--- a/Translators/Capabilities/LlmCapabilityResolver.cs
+++ b/Translators/Capabilities/LlmCapabilityResolver.cs
@@ -1,0 +1,27 @@
+// <copyright file="LlmCapabilityResolver.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Resolves static defaults and persisted overlays into one capability
+///     snapshot.
+/// </summary>
+public static class LlmCapabilityResolver
+{
+  /// <summary>
+  ///     Resolves the effective capability policy for a scope.
+  /// </summary>
+  /// <param name="scope">The active capability lookup scope.</param>
+  /// <param name="overlayRules">The persisted capability overlay rules.</param>
+  /// <returns>The resolved capability snapshot.</returns>
+  public static LlmCapabilitySnapshot Resolve(
+      LlmCapabilityScope scope,
+      IReadOnlyList<LlmCapabilityRuleDefinition> overlayRules)
+  {
+    var definitions = LlmCapabilityStaticCatalog.GetDefinitions(scope.Engine);
+    return LlmCapabilitySnapshot.Create(scope, definitions, overlayRules);
+  }
+}

--- a/Translators/Capabilities/LlmCapabilityRuleDefinition.cs
+++ b/Translators/Capabilities/LlmCapabilityRuleDefinition.cs
@@ -1,0 +1,131 @@
+// <copyright file="LlmCapabilityRuleDefinition.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Defines one static or persisted LLM capability rule.
+/// </summary>
+/// <param name="Engine">The engine identifier to match.</param>
+/// <param name="ProviderScope">The provider identity to match.</param>
+/// <param name="EndpointScope">The endpoint identity to match.</param>
+/// <param name="MatchType">The model matching strategy.</param>
+/// <param name="MatchValue">The model identifier or family prefix to match.</param>
+/// <param name="ParameterName">The governed capability parameter.</param>
+/// <param name="SupportState">The known support state.</param>
+/// <param name="MinValue">The inclusive lower bound, when known.</param>
+/// <param name="MaxValue">The inclusive upper bound, when known.</param>
+/// <param name="OmitWhenDefaultOnly">
+///     Whether the parameter must be omitted when only its implicit default is
+///     allowed.
+/// </param>
+/// <param name="Source">The source that established the rule.</param>
+/// <param name="Reason">The explanation for the rule.</param>
+public readonly record struct LlmCapabilityRuleDefinition(
+    string Engine,
+    string ProviderScope,
+    string EndpointScope,
+    LlmCapabilityRuleMatchType MatchType,
+    string MatchValue,
+    LlmCapabilityParameterName ParameterName,
+    LlmCapabilitySupportState SupportState,
+    float? MinValue,
+    float? MaxValue,
+    bool OmitWhenDefaultOnly,
+    string Source,
+    string Reason)
+{
+  /// <summary>
+  ///     Creates a rule that applies to one complete model identifier.
+  /// </summary>
+  /// <param name="engine">The engine identifier to match.</param>
+  /// <param name="providerScope">The provider identity to match.</param>
+  /// <param name="endpointScope">The endpoint identity to match.</param>
+  /// <param name="modelId">The complete model identifier to match.</param>
+  /// <param name="parameterName">The governed capability parameter.</param>
+  /// <param name="supportState">The known support state.</param>
+  /// <param name="minValue">The inclusive lower bound, when known.</param>
+  /// <param name="maxValue">The inclusive upper bound, when known.</param>
+  /// <param name="omitWhenDefaultOnly">
+  ///     <see langword="true" /> to omit the parameter when only its implicit
+  ///     default is allowed; otherwise, <see langword="false" />.
+  /// </param>
+  /// <param name="source">The source that established the rule.</param>
+  /// <param name="reason">The explanation for the rule.</param>
+  /// <returns>An exact-model capability rule.</returns>
+  public static LlmCapabilityRuleDefinition ExactModel(
+      string engine,
+      string providerScope,
+      string endpointScope,
+      string modelId,
+      LlmCapabilityParameterName parameterName,
+      LlmCapabilitySupportState supportState,
+      float? minValue = null,
+      float? maxValue = null,
+      bool omitWhenDefaultOnly = false,
+      string source = "",
+      string reason = "")
+  {
+    return new LlmCapabilityRuleDefinition(
+        engine,
+        providerScope,
+        endpointScope,
+        LlmCapabilityRuleMatchType.ExactModel,
+        modelId,
+        parameterName,
+        supportState,
+        minValue,
+        maxValue,
+        omitWhenDefaultOnly,
+        source,
+        reason);
+  }
+
+  /// <summary>
+  ///     Creates a rule that applies to models in one identifier family.
+  /// </summary>
+  /// <param name="engine">The engine identifier to match.</param>
+  /// <param name="providerScope">The provider identity to match.</param>
+  /// <param name="endpointScope">The endpoint identity to match.</param>
+  /// <param name="modelPrefix">The model identifier prefix to match.</param>
+  /// <param name="parameterName">The governed capability parameter.</param>
+  /// <param name="supportState">The known support state.</param>
+  /// <param name="minValue">The inclusive lower bound, when known.</param>
+  /// <param name="maxValue">The inclusive upper bound, when known.</param>
+  /// <param name="omitWhenDefaultOnly">
+  ///     <see langword="true" /> to omit the parameter when only its implicit
+  ///     default is allowed; otherwise, <see langword="false" />.
+  /// </param>
+  /// <param name="source">The source that established the rule.</param>
+  /// <param name="reason">The explanation for the rule.</param>
+  /// <returns>A family-prefix capability rule.</returns>
+  public static LlmCapabilityRuleDefinition FamilyPrefix(
+      string engine,
+      string providerScope,
+      string endpointScope,
+      string modelPrefix,
+      LlmCapabilityParameterName parameterName,
+      LlmCapabilitySupportState supportState,
+      float? minValue = null,
+      float? maxValue = null,
+      bool omitWhenDefaultOnly = false,
+      string source = "StaticDefault",
+      string reason = "")
+  {
+    return new LlmCapabilityRuleDefinition(
+        engine,
+        providerScope,
+        endpointScope,
+        LlmCapabilityRuleMatchType.FamilyPrefix,
+        modelPrefix,
+        parameterName,
+        supportState,
+        minValue,
+        maxValue,
+        omitWhenDefaultOnly,
+        source,
+        reason);
+  }
+}

--- a/Translators/Capabilities/LlmCapabilityRuleMatchType.cs
+++ b/Translators/Capabilities/LlmCapabilityRuleMatchType.cs
@@ -1,0 +1,22 @@
+// <copyright file="LlmCapabilityRuleMatchType.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Describes how a capability rule identifies an LLM model.
+/// </summary>
+public enum LlmCapabilityRuleMatchType
+{
+  /// <summary>
+  ///     Matches one complete model identifier.
+  /// </summary>
+  ExactModel = 0,
+
+  /// <summary>
+  ///     Matches model identifiers that begin with a family prefix.
+  /// </summary>
+  FamilyPrefix = 1,
+}

--- a/Translators/Capabilities/LlmCapabilityScope.cs
+++ b/Translators/Capabilities/LlmCapabilityScope.cs
@@ -1,0 +1,20 @@
+// <copyright file="LlmCapabilityScope.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Identifies the active engine, provider, endpoint, and model for a
+///     capability lookup.
+/// </summary>
+/// <param name="Engine">The active translation engine.</param>
+/// <param name="ProviderScope">The provider identity within the engine.</param>
+/// <param name="EndpointScope">The endpoint identity within the provider.</param>
+/// <param name="ModelId">The active model identifier.</param>
+public readonly record struct LlmCapabilityScope(
+    Echoglossian.TransEngines Engine,
+    string ProviderScope,
+    string EndpointScope,
+    string ModelId);

--- a/Translators/Capabilities/LlmCapabilitySnapshot.cs
+++ b/Translators/Capabilities/LlmCapabilitySnapshot.cs
@@ -1,0 +1,176 @@
+// <copyright file="LlmCapabilitySnapshot.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Represents the immutable resolved capability policy for one LLM scope.
+/// </summary>
+public sealed class LlmCapabilitySnapshot
+{
+  private static readonly LlmCapabilityParameterDecision UnknownDecision = new(
+      LlmCapabilitySupportState.Unknown,
+      null,
+      null,
+      false,
+      "None",
+      "No matching capability rule.");
+
+  private readonly IReadOnlyDictionary<LlmCapabilityParameterName,
+      LlmCapabilityParameterDecision> decisions;
+
+  private LlmCapabilitySnapshot(
+      IReadOnlyDictionary<LlmCapabilityParameterName,
+          LlmCapabilityParameterDecision> decisions)
+  {
+    this.decisions = decisions;
+  }
+
+  /// <summary>
+  ///     Gets the resolved decision for a capability parameter.
+  /// </summary>
+  /// <param name="parameterName">The capability parameter.</param>
+  /// <returns>The resolved parameter decision.</returns>
+  public LlmCapabilityParameterDecision GetDecision(
+      LlmCapabilityParameterName parameterName)
+  {
+    return this.decisions.TryGetValue(parameterName, out var decision)
+        ? decision
+        : UnknownDecision;
+  }
+
+  /// <summary>
+  ///     Creates a snapshot from matching static definitions and overlay rules.
+  /// </summary>
+  /// <param name="scope">The active capability lookup scope.</param>
+  /// <param name="staticDefinitions">The committed static capability rules.</param>
+  /// <param name="overlayRules">The persisted capability overlay rules.</param>
+  /// <returns>The resolved capability snapshot.</returns>
+  internal static LlmCapabilitySnapshot Create(
+      LlmCapabilityScope scope,
+      IEnumerable<LlmCapabilityRuleDefinition> staticDefinitions,
+      IReadOnlyList<LlmCapabilityRuleDefinition> overlayRules)
+  {
+    var resolvedDecisions = new Dictionary<LlmCapabilityParameterName,
+        LlmCapabilityParameterDecision>();
+    var matchingStaticRules = staticDefinitions
+        .Where(rule => IsMatch(scope, rule))
+        .ToArray();
+    var matchingOverlayRules = overlayRules
+        .Where(rule => IsMatch(scope, rule))
+        .ToArray();
+
+    foreach (var parameterName in Enum.GetValues<LlmCapabilityParameterName>())
+    {
+      var decision = ResolveParameter(
+          parameterName,
+          matchingStaticRules,
+          matchingOverlayRules);
+      resolvedDecisions.Add(parameterName, decision);
+    }
+
+    return new LlmCapabilitySnapshot(resolvedDecisions);
+  }
+
+  private static bool IsMatch(
+      LlmCapabilityScope scope,
+      LlmCapabilityRuleDefinition rule)
+  {
+    if (!string.Equals(rule.Engine, scope.Engine.ToString(),
+            StringComparison.Ordinal) ||
+        !string.Equals(rule.ProviderScope, scope.ProviderScope,
+            StringComparison.Ordinal) ||
+        !string.Equals(rule.EndpointScope, scope.EndpointScope,
+            StringComparison.Ordinal))
+    {
+      return false;
+    }
+
+    return rule.MatchType == LlmCapabilityRuleMatchType.ExactModel
+        ? string.Equals(rule.MatchValue, scope.ModelId, StringComparison.Ordinal)
+        : scope.ModelId.StartsWith(rule.MatchValue, StringComparison.Ordinal);
+  }
+
+  private static LlmCapabilityParameterDecision ResolveParameter(
+      LlmCapabilityParameterName parameterName,
+      IReadOnlyList<LlmCapabilityRuleDefinition> staticRules,
+      IReadOnlyList<LlmCapabilityRuleDefinition> overlayRules)
+  {
+    var matchingStaticRules = staticRules
+        .Where(rule => rule.ParameterName == parameterName)
+        .ToArray();
+    var matchingOverlayRules = overlayRules
+        .Where(rule => rule.ParameterName == parameterName)
+        .ToArray();
+    var specificity = Math.Max(
+        GetHighestSpecificity(matchingStaticRules),
+        GetHighestSpecificity(matchingOverlayRules));
+
+    if (specificity == 0)
+    {
+      return UnknownDecision;
+    }
+
+    var matchingOverlayAtSpecificity = matchingOverlayRules
+        .Where(rule => GetSpecificity(rule) == specificity)
+        .ToArray();
+    var rulesToResolve = matchingOverlayAtSpecificity.Length > 0
+        ? matchingOverlayAtSpecificity
+        : matchingStaticRules
+            .Where(rule => GetSpecificity(rule) == specificity)
+            .ToArray();
+    var conservativeRule = rulesToResolve
+        .OrderBy(rule => GetConservativeSupportRank(rule.SupportState))
+        .First();
+
+    return new LlmCapabilityParameterDecision(
+        conservativeRule.SupportState,
+        GetNarrowestMinimum(rulesToResolve),
+        GetNarrowestMaximum(rulesToResolve),
+        rulesToResolve.Any(rule => rule.OmitWhenDefaultOnly),
+        conservativeRule.Source,
+        conservativeRule.Reason);
+  }
+
+  private static int GetHighestSpecificity(
+      IReadOnlyList<LlmCapabilityRuleDefinition> rules)
+  {
+    return rules.Count == 0 ? 0 : rules.Max(GetSpecificity);
+  }
+
+  private static int GetSpecificity(LlmCapabilityRuleDefinition rule)
+  {
+    return rule.MatchType == LlmCapabilityRuleMatchType.ExactModel ? 2 : 1;
+  }
+
+  private static int GetConservativeSupportRank(
+      LlmCapabilitySupportState supportState)
+  {
+    return supportState switch
+    {
+      LlmCapabilitySupportState.Unsupported => 0,
+      LlmCapabilitySupportState.Unknown => 1,
+      _ => 2,
+    };
+  }
+
+  private static float? GetNarrowestMinimum(
+      IReadOnlyList<LlmCapabilityRuleDefinition> rules)
+  {
+    var minimums = rules.Where(rule => rule.MinValue.HasValue)
+        .Select(rule => rule.MinValue!.Value)
+        .ToArray();
+    return minimums.Length > 0 ? minimums.Max() : null;
+  }
+
+  private static float? GetNarrowestMaximum(
+      IReadOnlyList<LlmCapabilityRuleDefinition> rules)
+  {
+    var maximums = rules.Where(rule => rule.MaxValue.HasValue)
+        .Select(rule => rule.MaxValue!.Value)
+        .ToArray();
+    return maximums.Length > 0 ? maximums.Min() : null;
+  }
+}

--- a/Translators/Capabilities/LlmCapabilitySnapshot.cs
+++ b/Translators/Capabilities/LlmCapabilitySnapshot.cs
@@ -88,9 +88,17 @@ public sealed class LlmCapabilitySnapshot
       return false;
     }
 
-    return rule.MatchType == LlmCapabilityRuleMatchType.ExactModel
-        ? string.Equals(rule.MatchValue, scope.ModelId, StringComparison.Ordinal)
-        : scope.ModelId.StartsWith(rule.MatchValue, StringComparison.Ordinal);
+    return rule.MatchType switch
+    {
+      LlmCapabilityRuleMatchType.ExactModel => string.Equals(
+          rule.MatchValue,
+          scope.ModelId,
+          StringComparison.Ordinal),
+      LlmCapabilityRuleMatchType.FamilyPrefix => !string.IsNullOrEmpty(
+              rule.MatchValue) &&
+          scope.ModelId.StartsWith(rule.MatchValue, StringComparison.Ordinal),
+      _ => false,
+    };
   }
 
   private static LlmCapabilityParameterDecision ResolveParameter(
@@ -125,11 +133,30 @@ public sealed class LlmCapabilitySnapshot
         .OrderBy(rule => GetConservativeSupportRank(rule.SupportState))
         .First();
 
+    var minValue = GetNarrowestMinimum(rulesToResolve);
+    var maxValue = GetNarrowestMaximum(rulesToResolve);
+    var omitWhenDefaultOnly = rulesToResolve
+        .Any(rule => rule.OmitWhenDefaultOnly);
+
+    if (minValue.HasValue && maxValue.HasValue &&
+        minValue.Value > maxValue.Value)
+    {
+      return new LlmCapabilityParameterDecision(
+          conservativeRule.SupportState == LlmCapabilitySupportState.Supported
+              ? LlmCapabilitySupportState.Unknown
+              : conservativeRule.SupportState,
+          null,
+          null,
+          omitWhenDefaultOnly,
+          "ConservativeResolver",
+          "Matching capability rules do not share a valid value range.");
+    }
+
     return new LlmCapabilityParameterDecision(
         conservativeRule.SupportState,
-        GetNarrowestMinimum(rulesToResolve),
-        GetNarrowestMaximum(rulesToResolve),
-        rulesToResolve.Any(rule => rule.OmitWhenDefaultOnly),
+        minValue,
+        maxValue,
+        omitWhenDefaultOnly,
         conservativeRule.Source,
         conservativeRule.Reason);
   }
@@ -142,7 +169,12 @@ public sealed class LlmCapabilitySnapshot
 
   private static int GetSpecificity(LlmCapabilityRuleDefinition rule)
   {
-    return rule.MatchType == LlmCapabilityRuleMatchType.ExactModel ? 2 : 1;
+    return rule.MatchType switch
+    {
+      LlmCapabilityRuleMatchType.ExactModel => int.MaxValue,
+      LlmCapabilityRuleMatchType.FamilyPrefix => rule.MatchValue.Length,
+      _ => 0,
+    };
   }
 
   private static int GetConservativeSupportRank(

--- a/Translators/Capabilities/LlmCapabilityStaticCatalog.cs
+++ b/Translators/Capabilities/LlmCapabilityStaticCatalog.cs
@@ -1,0 +1,34 @@
+// <copyright file="LlmCapabilityStaticCatalog.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Provides committed conservative capability defaults by LLM engine.
+/// </summary>
+public static class LlmCapabilityStaticCatalog
+{
+  /// <summary>
+  ///     Gets the static capability definitions for an engine.
+  /// </summary>
+  /// <param name="engine">The translation engine.</param>
+  /// <returns>The static capability definitions for <paramref name="engine" />.</returns>
+  internal static IEnumerable<LlmCapabilityRuleDefinition> GetDefinitions(
+      Echoglossian.TransEngines engine)
+  {
+    if (engine == Echoglossian.TransEngines.ChatGPT)
+    {
+      yield return LlmCapabilityRuleDefinition.FamilyPrefix(
+          "ChatGPT",
+          "OpenAI",
+          "https://api.openai.com/v1",
+          "gpt-5.6-",
+          LlmCapabilityParameterName.Temperature,
+          LlmCapabilitySupportState.Unsupported,
+          omitWhenDefaultOnly: true,
+          reason: "OpenAI chat-completions reasoning models accept only the implicit default temperature.");
+    }
+  }
+}

--- a/Translators/Capabilities/LlmCapabilityStaticCatalog.cs
+++ b/Translators/Capabilities/LlmCapabilityStaticCatalog.cs
@@ -30,5 +30,18 @@ public static class LlmCapabilityStaticCatalog
           omitWhenDefaultOnly: true,
           reason: "OpenAI chat-completions reasoning models accept only the implicit default temperature.");
     }
+
+    if (engine == Echoglossian.TransEngines.Gemini)
+    {
+      yield return LlmCapabilityRuleDefinition.FamilyPrefix(
+          "Gemini",
+          "Gemini",
+          "https://generativelanguage.googleapis.com",
+          "gemini-3",
+          LlmCapabilityParameterName.Temperature,
+          LlmCapabilitySupportState.Unsupported,
+          omitWhenDefaultOnly: true,
+          reason: "Gemini 3 generation requests omit unsupported sampling parameters.");
+    }
   }
 }

--- a/Translators/Capabilities/LlmCapabilityStaticCatalog.cs
+++ b/Translators/Capabilities/LlmCapabilityStaticCatalog.cs
@@ -29,6 +29,15 @@ public static class LlmCapabilityStaticCatalog
           LlmCapabilitySupportState.Unsupported,
           omitWhenDefaultOnly: true,
           reason: "OpenAI chat-completions reasoning models accept only the implicit default temperature.");
+
+      yield return LlmCapabilityRuleDefinition.FamilyPrefix(
+          "ChatGPT",
+          "OpenAI",
+          "https://api.openai.com/v1",
+          "gpt-5.6-",
+          LlmCapabilityParameterName.ReasoningEffort,
+          LlmCapabilitySupportState.Unsupported,
+          reason: "OpenAI chat-completions tool calls require reasoning_effort=none for gpt-5.6 models.");
     }
 
     if (engine == Echoglossian.TransEngines.Gemini)

--- a/Translators/Capabilities/LlmCapabilitySupportState.cs
+++ b/Translators/Capabilities/LlmCapabilitySupportState.cs
@@ -1,0 +1,27 @@
+// <copyright file="LlmCapabilitySupportState.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+namespace Echoglossian.Translators.Capabilities;
+
+/// <summary>
+///     Describes the known support state for an LLM capability parameter.
+/// </summary>
+public enum LlmCapabilitySupportState
+{
+  /// <summary>
+  ///     Indicates that support has not been established.
+  /// </summary>
+  Unknown = 0,
+
+  /// <summary>
+  ///     Indicates that the parameter is supported.
+  /// </summary>
+  Supported = 1,
+
+  /// <summary>
+  ///     Indicates that the parameter is unsupported.
+  /// </summary>
+  Unsupported = 2,
+}

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -395,7 +395,13 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                         ? StructuredDialogueCapabilityEmissionMode.ExplicitDisable
                         : reasoningEffortWasSent
                             ? StructuredDialogueCapabilityEmissionMode.SentConfigured
-                            : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+                            : reasoningDecision.OmitWhenDefaultOnly
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                                : reasoningDecision.SupportState == LlmCapabilitySupportState.Supported
+                                    ? StructuredDialogueCapabilityEmissionMode.OmittedSupported
+                                    : reasoningDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                        ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                        : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
             ];
 
             var messages = new List<ChatMessage>
@@ -443,7 +449,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 PluginRuntimeLog.Debug(
                     this.pluginLog,
                     StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
-                        "ChatGPT",
+                        this.capabilityScope.ProviderScope,
                         this.model,
                         StructuredDialogueProviderCapability.JsonSchema,
                         "validation",
@@ -452,7 +458,8 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                         endpointScope: this.capabilityScope.EndpointScope,
                         route: "chat/completions",
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -489,7 +496,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             PluginRuntimeLog.Debug(
                 this.pluginLog,
                 StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
-                    "ChatGPT",
+                    this.capabilityScope.ProviderScope,
                     this.model,
                     StructuredDialogueProviderCapability.JsonSchema,
                     "validation",
@@ -497,7 +504,8 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                     endpointScope: this.capabilityScope.EndpointScope,
                     route: "chat/completions",
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)
@@ -517,19 +525,25 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
+            int? statusCode = ex is ClientResultException clientResultException
+                ? clientResultException.Status
+                : ex is HttpRequestException httpRequestException &&
+                httpRequestException.StatusCode.HasValue
+                    ? (int)httpRequestException.StatusCode.Value
+                    : null;
+            var responseExcerpt = ex is ClientResultException responseException
+                ? responseException.GetRawResponse()?.Content?.ToString()
+                : ex.Message;
             PluginRuntimeLog.Debug(
                 this.pluginLog,
                 StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
-                    "ChatGPT",
+                    this.capabilityScope.ProviderScope,
                     this.model,
                     StructuredDialogueProviderCapability.JsonSchema,
                     "exception",
                     ex.Message,
-                    ex is HttpRequestException httpRequestException &&
-                    httpRequestException.StatusCode.HasValue
-                        ? (int)httpRequestException.StatusCode.Value
-                        : null,
-                    ex.Message,
+                    statusCode,
+                    responseExcerpt,
                     this.capabilityScope.EndpointScope,
                     "chat/completions",
                     capabilityDecisionTokens,

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -6,6 +6,7 @@
 using System.ClientModel;
 using System.Text;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Helpers;
 using Echoglossian.Translators.OpenAI;
 using OpenAI;
@@ -15,6 +16,7 @@ namespace Echoglossian.Translators;
 
 public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
 {
+    private readonly LlmCapabilityScope capabilityScope;
     private readonly ChatClient? chatClient;
     private readonly string model;
     private readonly IPluginLog pluginLog;
@@ -41,6 +43,11 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         var baseUrl = providerSettings.BaseUrl;
         var apiKey = providerSettings.ApiKey;
         this.model = providerSettings.Model;
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.ChatGPT,
+            providerSettings.ProviderName,
+            baseUrl,
+            this.model);
         this.unavailableMessage =
             OpenAiProviderVariantHelper.ResolveUnavailableMessage(
                 providerSettings.Variant);
@@ -244,12 +251,19 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             targetLanguage,
             dialogueContext);
 
+        var temperatureWasSent = false;
         try
         {
-            var chatCompletionOptions = new ChatCompletionOptions
+            var chatCompletionOptions = new ChatCompletionOptions();
+            temperatureWasSent = LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _);
+            if (temperatureWasSent)
             {
-                Temperature = this.temperature,
-            };
+                chatCompletionOptions.Temperature = sanitizedTemperature;
+            }
 
             var messages = new List<ChatMessage>
             {
@@ -278,6 +292,11 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         }
         catch (Exception ex)
         {
+            if (temperatureWasSent)
+            {
+                this.LearnTemperatureFailure(ex);
+            }
+
             PluginRuntimeLog.Error(this.pluginLog, $"{Resources.TranslationError} {ex.Message}");
             return $"[{Resources.TranslationError} {ex.Message}]";
         }
@@ -316,6 +335,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        var temperatureWasSent = false;
         try
         {
             var normalizedText = FixText(text);
@@ -344,10 +364,18 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
 
             var chatCompletionOptions = new ChatCompletionOptions
             {
-                Temperature = this.temperature,
                 ToolChoice = ChatToolChoice.CreateFunctionChoice(
                     StructuredDialogueOpenAiToolHelper.ToolFunctionName),
             };
+            temperatureWasSent = LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _);
+            if (temperatureWasSent)
+            {
+                chatCompletionOptions.Temperature = sanitizedTemperature;
+            }
             chatCompletionOptions.Tools.Add(structuredTool);
 
             var messages = new List<ChatMessage>
@@ -375,9 +403,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(
-                    this.pluginLog,
-                    $"ChatGPT structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(this.pluginLog, $"ChatGPT structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
                 return null;
             }
 
@@ -404,14 +430,17 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         }
         catch (Exception ex)
         {
+            if (temperatureWasSent)
+            {
+                this.LearnTemperatureFailure(ex);
+            }
+
             TranslatorMetricsCollector.RecordStructuredAttempt(
                 (int)Echoglossian.TransEngines.ChatGPT,
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(
-                this.pluginLog,
-                $"ChatGPT structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(this.pluginLog, $"ChatGPT structured dialogue path failed and will fall back to plain-text: {ex.Message}");
             return null;
         }
     }
@@ -449,6 +478,24 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         }
 
         return builder.ToString().Trim();
+    }
+
+    private void LearnTemperatureFailure(Exception exception)
+    {
+        int? statusCode = exception is ClientResultException clientResultException
+            ? clientResultException.Status
+            : exception is HttpRequestException httpRequestException &&
+            httpRequestException.StatusCode.HasValue
+                ? (int)httpRequestException.StatusCode.Value
+                : null;
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            statusCode,
+            exception.Message);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 
     private string BuildPrompt(

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -486,6 +486,18 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "ChatGPT",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: "chat/completions",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -329,6 +329,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         var usedGlossary = glossaryEntries.Count > 0;
         var temperatureWasSent = false;
         var reasoningEffortWasSent = false;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             var normalizedText = FixText(text);
@@ -365,10 +366,59 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 chatCompletionOptions);
             chatCompletionOptions.Tools.Add(structuredTool);
 
+            var capabilitySnapshot = LlmCapabilityPolicyService.GetSnapshot(
+                this.capabilityScope);
+            var temperatureDecision = capabilitySnapshot.GetDecision(
+                LlmCapabilityParameterName.Temperature);
+            var reasoningDecision = capabilitySnapshot.GetDecision(
+                LlmCapabilityParameterName.ReasoningEffort);
+#pragma warning disable OPENAI001
+            var reasoningEffortExplicitlyDisabled = reasoningEffortWasSent &&
+                chatCompletionOptions.ReasoningEffortLevel == ChatReasoningEffortLevel.None;
+#pragma warning restore OPENAI001
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.ReasoningEffort,
+                    reasoningDecision,
+                    reasoningEffortExplicitlyDisabled
+                        ? StructuredDialogueCapabilityEmissionMode.ExplicitDisable
+                        : reasoningEffortWasSent
+                            ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                            : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
+
             var messages = new List<ChatMessage>
             {
                 ChatMessage.CreateUserMessage(structuredPrompt),
             };
+
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    "chat/completions",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    null,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
 
             ChatCompletion completion =
                 await this.chatClient!.CompleteChatAsync(
@@ -390,7 +440,19 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(this.pluginLog, $"ChatGPT structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "ChatGPT",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: "chat/completions",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -405,6 +467,17 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 this.translationCache.Remember(
                     cacheKey,
                     translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        "chat/completions",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload.Length,
+                        translatedText.Length,
+                        rawStructuredPayload,
+                        translatedText));
                 return translatedText;
             }
 
@@ -432,7 +505,23 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(this.pluginLog, $"ChatGPT structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "ChatGPT",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    "chat/completions",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }
@@ -502,8 +591,8 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
     /// <param name="options">The completion options to sanitize.</param>
     /// <returns>
     ///     <see langword="true" /> when a configured reasoning-effort value
-    ///     remains eligible for provider transmission; otherwise,
-    ///     <see langword="false" />.
+    ///     or an explicit provider disable remains eligible for transmission;
+    ///     otherwise, <see langword="false" />.
     /// </returns>
     internal bool ApplyStructuredReasoningEffortPolicy(
         ChatCompletionOptions options)
@@ -520,11 +609,20 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
 #pragma warning restore OPENAI001
         }
 
+        if (decision.SupportState == LlmCapabilitySupportState.Unsupported)
+        {
+#pragma warning disable OPENAI001
+            options.ReasoningEffortLevel = ChatReasoningEffortLevel.None;
+#pragma warning restore OPENAI001
+            return true;
+        }
+
 #pragma warning disable OPENAI001
         options.ReasoningEffortLevel = null;
 #pragma warning restore OPENAI001
         return false;
     }
+
     /// <summary>
     ///     Records a sanitized exact-model temperature observation from an
     ///     OpenAI SDK request failure.
@@ -576,6 +674,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             this.pluginLog,
             $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
+
     private string BuildPrompt(
         string text,
         string sourceLanguage,

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -255,15 +255,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         try
         {
             var chatCompletionOptions = new ChatCompletionOptions();
-            temperatureWasSent = LlmCapabilityPolicyService.TryResolveTemperature(
-                this.capabilityScope,
-                this.temperature,
-                out var sanitizedTemperature,
-                out _);
-            if (temperatureWasSent)
-            {
-                chatCompletionOptions.Temperature = sanitizedTemperature;
-            }
+            temperatureWasSent = this.ApplyTemperaturePolicy(chatCompletionOptions);
 
             var messages = new List<ChatMessage>
             {
@@ -367,15 +359,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                 ToolChoice = ChatToolChoice.CreateFunctionChoice(
                     StructuredDialogueOpenAiToolHelper.ToolFunctionName),
             };
-            temperatureWasSent = LlmCapabilityPolicyService.TryResolveTemperature(
-                this.capabilityScope,
-                this.temperature,
-                out var sanitizedTemperature,
-                out _);
-            if (temperatureWasSent)
-            {
-                chatCompletionOptions.Temperature = sanitizedTemperature;
-            }
+            temperatureWasSent = this.ApplyTemperaturePolicy(chatCompletionOptions);
             chatCompletionOptions.Tools.Add(structuredTool);
 
             var messages = new List<ChatMessage>
@@ -480,6 +464,34 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         return builder.ToString().Trim();
     }
 
+    /// <summary>
+    ///     Applies the shared temperature decision to an OpenAI SDK request.
+    /// </summary>
+    /// <param name="options">The completion options to sanitize.</param>
+    /// <returns>
+    ///     <see langword="true" /> when temperature was added; otherwise,
+    ///     <see langword="false" />.
+    /// </returns>
+    internal bool ApplyTemperaturePolicy(ChatCompletionOptions options)
+    {
+        if (!LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _))
+        {
+            return false;
+        }
+
+        options.Temperature = sanitizedTemperature;
+        return true;
+    }
+
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from an
+    ///     OpenAI SDK request failure.
+    /// </summary>
+    /// <param name="exception">The provider exception associated with the request.</param>
     private void LearnTemperatureFailure(Exception exception)
     {
         int? statusCode = exception is ClientResultException clientResultException
@@ -488,11 +500,14 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             httpRequestException.StatusCode.HasValue
                 ? (int)httpRequestException.StatusCode.Value
                 : null;
+        var responseText = exception is ClientResultException responseException
+            ? responseException.GetRawResponse()?.Content?.ToString()
+            : null;
         var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
             this.capabilityScope,
             LlmCapabilityParameterName.Temperature,
             statusCode,
-            exception.Message);
+            responseText ?? exception.Message);
         PluginRuntimeLog.Debug(
             this.pluginLog,
             $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -328,6 +328,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
         var temperatureWasSent = false;
+        var reasoningEffortWasSent = false;
         try
         {
             var normalizedText = FixText(text);
@@ -354,17 +355,14 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                     StructuredDialogueOpenAiToolHelper.BuildFunctionParametersSchemaJson()),
                 true);
 
-            // The OpenAI SDK marks reasoning effort experimental, but the
-            // structured tool path must explicitly request no reasoning.
-#pragma warning disable OPENAI001
             var chatCompletionOptions = new ChatCompletionOptions
             {
                 ToolChoice = ChatToolChoice.CreateFunctionChoice(
                     StructuredDialogueOpenAiToolHelper.ToolFunctionName),
-                ReasoningEffortLevel = ChatReasoningEffortLevel.None,
             };
-#pragma warning restore OPENAI001
             temperatureWasSent = this.ApplyTemperaturePolicy(chatCompletionOptions);
+            reasoningEffortWasSent = this.ApplyStructuredReasoningEffortPolicy(
+                chatCompletionOptions);
             chatCompletionOptions.Tools.Add(structuredTool);
 
             var messages = new List<ChatMessage>
@@ -419,7 +417,11 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         }
         catch (Exception ex)
         {
-            this.LearnReasoningEffortFailure(ex);
+            if (reasoningEffortWasSent)
+            {
+                this.LearnReasoningEffortFailure(ex);
+            }
+
             if (temperatureWasSent)
             {
                 this.LearnTemperatureFailure(ex);
@@ -493,6 +495,36 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         return true;
     }
 
+    /// <summary>
+    ///     Applies the effective structured reasoning-effort capability policy
+    ///     to an OpenAI SDK completion request.
+    /// </summary>
+    /// <param name="options">The completion options to sanitize.</param>
+    /// <returns>
+    ///     <see langword="true" /> when a configured reasoning-effort value
+    ///     remains eligible for provider transmission; otherwise,
+    ///     <see langword="false" />.
+    /// </returns>
+    internal bool ApplyStructuredReasoningEffortPolicy(
+        ChatCompletionOptions options)
+    {
+        var decision = LlmCapabilityPolicyService.GetSnapshot(
+                this.capabilityScope)
+            .GetDecision(LlmCapabilityParameterName.ReasoningEffort);
+
+        if (decision.SupportState == LlmCapabilitySupportState.Supported &&
+            !decision.OmitWhenDefaultOnly)
+        {
+#pragma warning disable OPENAI001
+            return options.ReasoningEffortLevel is not null;
+#pragma warning restore OPENAI001
+        }
+
+#pragma warning disable OPENAI001
+        options.ReasoningEffortLevel = null;
+#pragma warning restore OPENAI001
+        return false;
+    }
     /// <summary>
     ///     Records a sanitized exact-model temperature observation from an
     ///     OpenAI SDK request failure.

--- a/Translators/ChatGPTTranslator.cs
+++ b/Translators/ChatGPTTranslator.cs
@@ -354,11 +354,16 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
                     StructuredDialogueOpenAiToolHelper.BuildFunctionParametersSchemaJson()),
                 true);
 
+            // The OpenAI SDK marks reasoning effort experimental, but the
+            // structured tool path must explicitly request no reasoning.
+#pragma warning disable OPENAI001
             var chatCompletionOptions = new ChatCompletionOptions
             {
                 ToolChoice = ChatToolChoice.CreateFunctionChoice(
                     StructuredDialogueOpenAiToolHelper.ToolFunctionName),
+                ReasoningEffortLevel = ChatReasoningEffortLevel.None,
             };
+#pragma warning restore OPENAI001
             temperatureWasSent = this.ApplyTemperaturePolicy(chatCompletionOptions);
             chatCompletionOptions.Tools.Add(structuredTool);
 
@@ -414,6 +419,7 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
         }
         catch (Exception ex)
         {
+            this.LearnReasoningEffortFailure(ex);
             if (temperatureWasSent)
             {
                 this.LearnTemperatureFailure(ex);
@@ -513,6 +519,31 @@ public class ChatGPTTranslator : ITranslator, IDialogueContextAwareTranslator
             $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 
+    /// <summary>
+    ///     Records exact-model reasoning-effort feedback from a structured
+    ///     OpenAI SDK request failure.
+    /// </summary>
+    /// <param name="exception">The provider exception associated with the request.</param>
+    private void LearnReasoningEffortFailure(Exception exception)
+    {
+        int? statusCode = exception is ClientResultException clientResultException
+            ? clientResultException.Status
+            : exception is HttpRequestException httpRequestException &&
+            httpRequestException.StatusCode.HasValue
+                ? (int)httpRequestException.StatusCode.Value
+                : null;
+        var responseText = exception is ClientResultException responseException
+            ? responseException.GetRawResponse()?.Content?.ToString()
+            : null;
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.ReasoningEffort,
+            statusCode,
+            responseText ?? exception.Message);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
+    }
     private string BuildPrompt(
         string text,
         string sourceLanguage,

--- a/Translators/Claude/ClaudeModelManager.cs
+++ b/Translators/Claude/ClaudeModelManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.OpenAI;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators.Claude;
 
@@ -122,6 +123,13 @@ public static class ClaudeModelManager
             {
                 CurrentModelList = ordered;
             }
+
+            LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                Echoglossian.TransEngines.Claude,
+                "Anthropic",
+                baseUrl,
+                ordered.Select(static model => model.Id).ToArray(),
+                DateTime.UtcNow);
         }
         catch
         {

--- a/Translators/ClaudeTranslator.cs
+++ b/Translators/ClaudeTranslator.cs
@@ -200,7 +200,10 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 },
             },
         };
-        var temperatureWasSent = this.TryAddTemperature(requestData);
+        var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+            requestData,
+            this.capabilityScope,
+            this.temperature);
 
         try
         {
@@ -338,7 +341,10 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                     name = StructuredDialogueAnthropicToolHelper.ToolName,
                 },
             };
-            var temperatureWasSent = this.TryAddTemperature(requestData);
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                requestData,
+                this.capabilityScope,
+                this.temperature);
 
             string jsonContent = JsonConvert.SerializeObject(requestData);
             using StringContent httpContent = new(
@@ -427,21 +433,12 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             FixText);
     }
 
-    private bool TryAddTemperature(Dictionary<string, object> request)
-    {
-        if (!LlmCapabilityPolicyService.TryResolveTemperature(
-                this.capabilityScope,
-                this.temperature,
-                out var sanitizedTemperature,
-                out _))
-        {
-            return false;
-        }
-
-        request.Add("temperature", sanitizedTemperature);
-        return true;
-    }
-
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from a
+    ///     failed Anthropic request that included temperature.
+    /// </summary>
+    /// <param name="response">The provider response associated with the request.</param>
+    /// <param name="temperatureWasSent">Whether the request included temperature.</param>
     private async Task LearnTemperatureFailureAsync(
         HttpResponseMessage response,
         bool temperatureWasSent)

--- a/Translators/ClaudeTranslator.cs
+++ b/Translators/ClaudeTranslator.cs
@@ -422,7 +422,8 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                         endpointScope: this.capabilityScope.EndpointScope,
                         route: "v1/messages",
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -465,7 +466,8 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                     endpointScope: this.capabilityScope.EndpointScope,
                     route: "v1/messages",
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)

--- a/Translators/ClaudeTranslator.cs
+++ b/Translators/ClaudeTranslator.cs
@@ -413,7 +413,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 PluginRuntimeLog.Debug(
                     this.pluginLog,
                     StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
-                        "Claude",
+                        this.capabilityScope.ProviderScope,
                         this.model,
                         StructuredDialogueProviderCapability.JsonSchema,
                         "validation",
@@ -457,7 +457,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             PluginRuntimeLog.Debug(
                 this.pluginLog,
                 StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
-                    "Claude",
+                    this.capabilityScope.ProviderScope,
                     this.model,
                     StructuredDialogueProviderCapability.JsonSchema,
                     "validation",
@@ -478,7 +478,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             PluginRuntimeLog.Debug(
                 this.pluginLog,
                 StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
-                    "Claude",
+                    this.capabilityScope.ProviderScope,
                     this.model,
                     StructuredDialogueProviderCapability.JsonSchema,
                     "exception",

--- a/Translators/ClaudeTranslator.cs
+++ b/Translators/ClaudeTranslator.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Helpers;
 
 namespace Echoglossian.Translators;
@@ -13,6 +14,7 @@ namespace Echoglossian.Translators;
 /// </summary>
 public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
 {
+    private readonly LlmCapabilityScope capabilityScope;
     private const string AnthropicVersion = "2023-06-01";
     private const string DefaultBaseUrl = "https://api.anthropic.com";
     private const string DefaultModel = "claude-sonnet-4-20250514";
@@ -42,6 +44,11 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
         this.model = string.IsNullOrWhiteSpace(config.ClaudeModel)
             ? DefaultModel
             : config.ClaudeModel;
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.Claude,
+            "Anthropic",
+            this.baseUrl,
+            this.model);
         this.temperature = config.ClaudeTemperature;
         this.promptTemplate = string.IsNullOrWhiteSpace(config.ClaudePrompt)
             ? PromptTemplateManager.DefaultPrompt
@@ -180,12 +187,11 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             targetLanguage,
             dialogueContext);
 
-        var requestData = new
+        var requestData = new Dictionary<string, object>
         {
-            model = this.model,
-            max_tokens = MaxOutputTokens,
-            temperature = this.temperature,
-            messages = new[]
+            ["model"] = this.model,
+            ["max_tokens"] = MaxOutputTokens,
+            ["messages"] = new[]
             {
                 new
                 {
@@ -194,6 +200,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 },
             },
         };
+        var temperatureWasSent = this.TryAddTemperature(requestData);
 
         try
         {
@@ -206,6 +213,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             using HttpResponseMessage response = await this.httpClient.PostAsync(
                 "v1/messages",
                 httpContent).ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             string responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -302,12 +310,11 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                     basePrompt,
                     structuredRequest);
 
-            var requestData = new
+            var requestData = new Dictionary<string, object>
             {
-                model = this.model,
-                max_tokens = MaxOutputTokens,
-                temperature = this.temperature,
-                messages = new[]
+                ["model"] = this.model,
+                ["max_tokens"] = MaxOutputTokens,
+                ["messages"] = new[]
                 {
                     new
                     {
@@ -315,7 +322,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                         content = structuredPrompt,
                     },
                 },
-                tools = new[]
+                ["tools"] = new[]
                 {
                     new
                     {
@@ -325,12 +332,13 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                             StructuredDialogueAnthropicToolHelper.BuildInputSchemaJson()),
                     },
                 },
-                tool_choice = new
+                ["tool_choice"] = new
                 {
                     type = "tool",
                     name = StructuredDialogueAnthropicToolHelper.ToolName,
                 },
             };
+            var temperatureWasSent = this.TryAddTemperature(requestData);
 
             string jsonContent = JsonConvert.SerializeObject(requestData);
             using StringContent httpContent = new(
@@ -341,6 +349,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             using HttpResponseMessage response = await this.httpClient!.PostAsync(
                 "v1/messages",
                 httpContent).ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             string responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -361,9 +370,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(
-                    this.pluginLog,
-                    $"Claude structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(this.pluginLog, $"Claude structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
                 return null;
             }
 
@@ -393,9 +400,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(
-                this.pluginLog,
-                $"Claude structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(this.pluginLog, $"Claude structured dialogue path failed and will fall back to plain-text: {ex.Message}");
             return null;
         }
     }
@@ -420,5 +425,40 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
             prompt,
             dialogueContext.Value,
             FixText);
+    }
+
+    private bool TryAddTemperature(Dictionary<string, object> request)
+    {
+        if (!LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _))
+        {
+            return false;
+        }
+
+        request.Add("temperature", sanitizedTemperature);
+        return true;
+    }
+
+    private async Task LearnTemperatureFailureAsync(
+        HttpResponseMessage response,
+        bool temperatureWasSent)
+    {
+        if (response.IsSuccessStatusCode || !temperatureWasSent)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            (int)response.StatusCode,
+            responseText);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 }

--- a/Translators/ClaudeTranslator.cs
+++ b/Translators/ClaudeTranslator.cs
@@ -293,6 +293,7 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 sourceLanguage,
                 targetLanguage);
         bool usedGlossary = glossaryEntries.Count > 0;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             string normalizedText = FixText(text);
@@ -345,12 +346,45 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 requestData,
                 this.capabilityScope,
                 this.temperature);
+            var temperatureDecision = LlmCapabilityPolicyService.GetSnapshot(
+                    this.capabilityScope)
+                .GetDecision(LlmCapabilityParameterName.Temperature);
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
 
             string jsonContent = JsonConvert.SerializeObject(requestData);
             using StringContent httpContent = new(
                 jsonContent,
                 Encoding.UTF8,
                 "application/json");
+
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    "v1/messages",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    jsonContent.Length,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
 
             using HttpResponseMessage response = await this.httpClient!.PostAsync(
                 "v1/messages",
@@ -376,7 +410,19 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(this.pluginLog, $"Claude structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "Claude",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: "v1/messages",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -389,6 +435,17 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                     true,
                     usedGlossary);
                 this.translationCache.Remember(cacheKey, translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        "v1/messages",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload?.Length ?? 0,
+                        translatedText.Length,
+                        rawStructuredPayload ?? string.Empty,
+                        translatedText));
                 return translatedText;
             }
 
@@ -397,6 +454,18 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "Claude",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: "v1/messages",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)
@@ -406,7 +475,23 @@ public class ClaudeTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(this.pluginLog, $"Claude structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "Claude",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    "v1/messages",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }

--- a/Translators/DeepSeek/DeepSeekModelManager.cs
+++ b/Translators/DeepSeek/DeepSeekModelManager.cs
@@ -109,22 +109,9 @@ public static class DeepSeekModelManager
                         "DeepSeek"));
             }
 
-            lock (SyncLock)
-            {
-                if (models.Count > 0)
-                {
-                    CurrentModelList = models;
-                }
-            }
-
             if (models.Count > 0)
             {
-                LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
-                    Echoglossian.TransEngines.DeepSeek,
-                    "DeepSeek",
-                    baseUrl,
-                    models.Select(static model => model.Id).ToArray(),
-                    DateTime.UtcNow);
+                ApplyRefreshSuccess(baseUrl, models, DateTime.UtcNow);
                 return;
             }
 
@@ -144,5 +131,30 @@ public static class DeepSeekModelManager
     internal static string BuildModelsEndpoint(string baseUrl)
     {
         return $"{baseUrl.Trim().TrimEnd('/')}/models";
+    }
+
+    /// <summary>
+    ///     Applies a successful DeepSeek model discovery result and promotes
+    ///     any known capability overlays without risking the discovered list.
+    /// </summary>
+    /// <param name="baseUrl">The configured DeepSeek base URL.</param>
+    /// <param name="models">The discovered supported model list.</param>
+    /// <param name="observedAtUtc">The UTC discovery observation time.</param>
+    internal static void ApplyRefreshSuccess(
+        string baseUrl,
+        IReadOnlyList<LlmTextModel> models,
+        DateTime observedAtUtc)
+    {
+        lock (SyncLock)
+        {
+            CurrentModelList = models.ToList();
+        }
+
+        LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+            Echoglossian.TransEngines.DeepSeek,
+            "DeepSeek",
+            baseUrl,
+            models.Select(static model => model.Id).ToArray(),
+            observedAtUtc);
     }
 }

--- a/Translators/DeepSeek/DeepSeekModelManager.cs
+++ b/Translators/DeepSeek/DeepSeekModelManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.OpenAI;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators.DeepSeek;
 
@@ -113,8 +114,18 @@ public static class DeepSeekModelManager
                 if (models.Count > 0)
                 {
                     CurrentModelList = models;
-                    return;
                 }
+            }
+
+            if (models.Count > 0)
+            {
+                LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                    Echoglossian.TransEngines.DeepSeek,
+                    "DeepSeek",
+                    baseUrl,
+                    models.Select(static model => model.Id).ToArray(),
+                    DateTime.UtcNow);
+                return;
             }
 
             ResetToDefault();

--- a/Translators/DeepSeekTranslator.cs
+++ b/Translators/DeepSeekTranslator.cs
@@ -5,11 +5,13 @@
 
 using Echoglossian.Translators.Helpers;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators;
 
 public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
 {
+    private readonly LlmCapabilityScope capabilityScope;
     private readonly string apiKey;
     private readonly string baseUrl;
     private readonly HttpClient? httpClient;
@@ -29,6 +31,11 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
         this.baseUrl = config.DeepSeekBaseUrl ?? "https://api.deepseek.com/v1";
         this.apiKey = config.DeepSeekTranslatorApiKey ?? string.Empty;
         this.model = config.DeepSeekModel ?? "deepseek-chat";
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.DeepSeek,
+            "DeepSeek",
+            this.baseUrl,
+            this.model);
         this.temperature = config.DeepSeekTemperature;
         this.promptTemplate = string.IsNullOrWhiteSpace(config.DeepSeekPrompt)
             ? PromptTemplateManager.GetDefaultPrompt(Echoglossian.PromptType.DeepSeek)
@@ -188,10 +195,10 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
 
         try
         {
-            var requestData = new
+            var requestData = new Dictionary<string, object>
             {
-                this.model,
-                messages = new[]
+                ["model"] = this.model,
+                ["messages"] = new[]
                 {
                     new
                     {
@@ -199,8 +206,8 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                         content = prompt,
                     },
                 },
-                this.temperature,
             };
+            var temperatureWasSent = this.TryAddTemperature(requestData);
 
             var jsonContent = JsonConvert.SerializeObject(requestData);
             var httpContent = new StringContent(
@@ -211,6 +218,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
             var response = await this.httpClient.PostAsync(
                 "chat/completions",
                 httpContent);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -306,10 +314,10 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                         sourceLanguage,
                         targetLanguage),
                     structuredRequest);
-            var requestData = new
+            var requestData = new Dictionary<string, object>
             {
-                this.model,
-                messages = new[]
+                ["model"] = this.model,
+                ["messages"] = new[]
                 {
                     new
                     {
@@ -317,8 +325,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                         content = structuredPrompt,
                     },
                 },
-                this.temperature,
-                tools = new[]
+                ["tools"] = new[]
                 {
                     new
                     {
@@ -333,7 +340,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                         },
                     },
                 },
-                tool_choice = new
+                ["tool_choice"] = new
                 {
                     type = "function",
                     function = new
@@ -342,6 +349,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
+            var temperatureWasSent = this.TryAddTemperature(requestData);
 
             var jsonContent = JsonConvert.SerializeObject(requestData);
             var httpContent = new StringContent(
@@ -352,6 +360,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
             var response = await this.httpClient!.PostAsync(
                 "chat/completions",
                 httpContent).ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var responseString =
@@ -373,9 +382,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(
-                    this.pluginLog,
-                    $"DeepSeek structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(this.pluginLog, $"DeepSeek structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
                 return null;
             }
 
@@ -407,9 +414,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(
-                this.pluginLog,
-                $"DeepSeek structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(this.pluginLog, $"DeepSeek structured dialogue path failed and will fall back to plain-text: {ex.Message}");
             return null;
         }
     }
@@ -435,5 +440,40 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
             prompt,
             dialogueContext.Value,
             FixText);
+    }
+
+    private bool TryAddTemperature(Dictionary<string, object> request)
+    {
+        if (!LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _))
+        {
+            return false;
+        }
+
+        request.Add("temperature", sanitizedTemperature);
+        return true;
+    }
+
+    private async Task LearnTemperatureFailureAsync(
+        HttpResponseMessage response,
+        bool temperatureWasSent)
+    {
+        if (response.IsSuccessStatusCode || !temperatureWasSent)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            (int)response.StatusCode,
+            responseText);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 }

--- a/Translators/DeepSeekTranslator.cs
+++ b/Translators/DeepSeekTranslator.cs
@@ -298,6 +298,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             var normalizedText = FixText(text);
@@ -356,12 +357,45 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                 requestData,
                 this.capabilityScope,
                 this.temperature);
+            var temperatureDecision = LlmCapabilityPolicyService.GetSnapshot(
+                    this.capabilityScope)
+                .GetDecision(LlmCapabilityParameterName.Temperature);
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
 
             var jsonContent = JsonConvert.SerializeObject(requestData);
             var httpContent = new StringContent(
                 jsonContent,
                 Encoding.UTF8,
                 "application/json");
+
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    "chat/completions",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    jsonContent.Length,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
 
             var response = await this.httpClient!.PostAsync(
                 "chat/completions",
@@ -388,7 +422,19 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(this.pluginLog, $"DeepSeek structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "DeepSeek",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: "chat/completions",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -403,6 +449,17 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                 this.translationCache.Remember(
                     cacheKey,
                     translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        "chat/completions",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload.Length,
+                        translatedText.Length,
+                        rawStructuredPayload,
+                        translatedText));
                 return translatedText;
             }
 
@@ -420,7 +477,23 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(this.pluginLog, $"DeepSeek structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "DeepSeek",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    "chat/completions",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }

--- a/Translators/DeepSeekTranslator.cs
+++ b/Translators/DeepSeekTranslator.cs
@@ -468,6 +468,18 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "DeepSeek",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: "chat/completions",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)

--- a/Translators/DeepSeekTranslator.cs
+++ b/Translators/DeepSeekTranslator.cs
@@ -207,7 +207,10 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
-            var temperatureWasSent = this.TryAddTemperature(requestData);
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                requestData,
+                this.capabilityScope,
+                this.temperature);
 
             var jsonContent = JsonConvert.SerializeObject(requestData);
             var httpContent = new StringContent(
@@ -349,7 +352,10 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
-            var temperatureWasSent = this.TryAddTemperature(requestData);
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                requestData,
+                this.capabilityScope,
+                this.temperature);
 
             var jsonContent = JsonConvert.SerializeObject(requestData);
             var httpContent = new StringContent(
@@ -442,21 +448,12 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
             FixText);
     }
 
-    private bool TryAddTemperature(Dictionary<string, object> request)
-    {
-        if (!LlmCapabilityPolicyService.TryResolveTemperature(
-                this.capabilityScope,
-                this.temperature,
-                out var sanitizedTemperature,
-                out _))
-        {
-            return false;
-        }
-
-        request.Add("temperature", sanitizedTemperature);
-        return true;
-    }
-
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from a
+    ///     failed DeepSeek request that included temperature.
+    /// </summary>
+    /// <param name="response">The provider response associated with the request.</param>
+    /// <param name="temperatureWasSent">Whether the request included temperature.</param>
     private async Task LearnTemperatureFailureAsync(
         HttpResponseMessage response,
         bool temperatureWasSent)

--- a/Translators/DeepSeekTranslator.cs
+++ b/Translators/DeepSeekTranslator.cs
@@ -60,7 +60,7 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
 
                 this.httpClient = new HttpClient
                 {
-                    BaseAddress = new Uri(this.baseUrl),
+                    BaseAddress = new Uri(this.baseUrl.TrimEnd('/') + "/"),
                 };
                 this.httpClient.DefaultRequestHeaders.Authorization =
                     new AuthenticationHeaderValue("Bearer", this.apiKey);
@@ -434,7 +434,8 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                         endpointScope: this.capabilityScope.EndpointScope,
                         route: "chat/completions",
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -479,7 +480,8 @@ public class DeepSeekTranslator : ITranslator, IDialogueContextAwareTranslator
                     endpointScope: this.capabilityScope.EndpointScope,
                     route: "chat/completions",
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)

--- a/Translators/DialogueTranslationContext.cs
+++ b/Translators/DialogueTranslationContext.cs
@@ -13,8 +13,22 @@ namespace Echoglossian.Translators;
 /// <param name="SessionKey">The runtime session key within that namespace.</param>
 /// <param name="SpeakerName">The visible speaker name when available.</param>
 /// <param name="PriorTurns">The rolling source-side history preceding the current request.</param>
+/// <param name="SpeakerRoleHint">The resolved current speaker role hint.</param>
+/// <param name="SpeakerGenderHint">The resolved current speaker gender hint.</param>
+/// <param name="AddresseeHint">The resolved current addressee name hint.</param>
+/// <param name="AddresseeRoleHint">The resolved current addressee role hint.</param>
+/// <param name="AddresseeGenderHint">The resolved current addressee gender hint.</param>
+/// <param name="MetadataProvenance">The source that resolved the current metadata.</param>
+/// <param name="MetadataConfidenceTier">The confidence tier of the current metadata.</param>
 public readonly record struct DialogueTranslationContext(
     string SessionNamespace,
     string SessionKey,
     string SpeakerName,
-    IReadOnlyList<DialogueTranslationTurn> PriorTurns);
+    IReadOnlyList<DialogueTranslationTurn> PriorTurns,
+    string? SpeakerRoleHint = null,
+    string? SpeakerGenderHint = null,
+    string? AddresseeHint = null,
+    string? AddresseeRoleHint = null,
+    string? AddresseeGenderHint = null,
+    string? MetadataProvenance = null,
+    string? MetadataConfidenceTier = null);

--- a/Translators/DialogueTranslationContext.cs
+++ b/Translators/DialogueTranslationContext.cs
@@ -31,4 +31,4 @@ public readonly record struct DialogueTranslationContext(
     string? AddresseeRoleHint = null,
     string? AddresseeGenderHint = null,
     string? MetadataProvenance = null,
-    string? MetadataConfidenceTier = null);
+    int? MetadataConfidenceTier = null);

--- a/Translators/DialogueTranslationSessionStore.cs
+++ b/Translators/DialogueTranslationSessionStore.cs
@@ -40,6 +40,7 @@ public static class DialogueTranslationSessionStore
   /// <param name="historyLimit">The maximum number of prior turns to retain.</param>
   /// <param name="ttl">The maximum session idle age.</param>
   /// <param name="observedAtUtc">Optional explicit observation time for tests.</param>
+  /// <param name="interlocutorHints">Optional resolved hints for only the current request.</param>
   /// <returns>The current runtime-only dialogue context.</returns>
   public static DialogueTranslationContext BuildContext(
       string sessionNamespace,
@@ -48,7 +49,8 @@ public static class DialogueTranslationSessionStore
       string sourceText,
       int historyLimit,
       TimeSpan ttl,
-      DateTime? observedAtUtc = null)
+      DateTime? observedAtUtc = null,
+      DialogueInterlocutorHints? interlocutorHints = null)
   {
     var now = observedAtUtc ?? DateTime.UtcNow;
     var normalizedNamespace = sessionNamespace ?? string.Empty;
@@ -81,7 +83,14 @@ public static class DialogueTranslationSessionStore
           normalizedNamespace,
           normalizedKey,
           normalizedSpeakerName,
-          priorTurns);
+          priorTurns,
+          interlocutorHints?.SpeakerRoleHint,
+          interlocutorHints?.SpeakerGenderHint,
+          interlocutorHints?.AddresseeHint,
+          interlocutorHints?.AddresseeRoleHint,
+          interlocutorHints?.AddresseeGenderHint,
+          interlocutorHints?.MetadataProvenance,
+          interlocutorHints?.MetadataConfidenceTier);
     }
   }
 

--- a/Translators/Gemini/GeminiModelManager.cs
+++ b/Translators/Gemini/GeminiModelManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.OpenAI;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators.Gemini;
 
@@ -109,6 +110,16 @@ public static class GeminiModelManager
                 {
                     CurrentModelList = models;
                 }
+            }
+
+            if (models.Count > 0)
+            {
+                LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                    Echoglossian.TransEngines.Gemini,
+                    "Gemini",
+                    "https://generativelanguage.googleapis.com",
+                    models.Select(static model => model.Id).ToArray(),
+                    DateTime.UtcNow);
             }
         }
         catch

--- a/Translators/GeminiTranslator.cs
+++ b/Translators/GeminiTranslator.cs
@@ -334,6 +334,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        var route = $"v1beta/models/{this.model}:generateContent";
         IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
@@ -414,13 +415,13 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 Encoding.UTF8,
                 "application/json");
             var baseUrl =
-                $"https://generativelanguage.googleapis.com/v1beta/models/{this.model}:generateContent?key={this.apiKey}";
+                $"https://generativelanguage.googleapis.com/{route}?key={this.apiKey}";
 
             PluginRuntimeLog.Debug(
                 this.pluginLog,
                 StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
                     this.capabilityScope,
-                    $"models/{this.model}:generateContent",
+                    route,
                     StructuredDialogueProviderCapability.JsonSchema,
                     dialogueContext.SessionNamespace,
                     dialogueContext.PriorTurns.Count,
@@ -468,9 +469,10 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                         structuredValidation.FailureReason ??
                         "unknown-structured-dialogue-failure",
                         endpointScope: this.capabilityScope.EndpointScope,
-                        route: $"models/{this.model}:generateContent",
+                        route: route,
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -489,7 +491,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                     this.pluginLog,
                     StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
                         this.capabilityScope,
-                        $"models/{this.model}:generateContent",
+                        route,
                         StructuredDialogueProviderCapability.JsonSchema,
                         usedGlossary,
                         rawStructuredPayload?.Length ?? 0,
@@ -513,9 +515,10 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                     "validation",
                     "non-persistable-structured-result",
                     endpointScope: this.capabilityScope.EndpointScope,
-                    route: $"models/{this.model}:generateContent",
+                    route: route,
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)
@@ -539,7 +542,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                         : null,
                     ex.Message,
                     this.capabilityScope.EndpointScope,
-                    $"models/{this.model}:generateContent",
+                    route,
                     capabilityDecisionTokens,
                     usedGlossary));
             return null;

--- a/Translators/GeminiTranslator.cs
+++ b/Translators/GeminiTranslator.cs
@@ -334,6 +334,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             var normalizedText = FixText(text);
@@ -373,6 +374,22 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 generationConfig,
                 this.capabilityScope,
                 this.temperature);
+            var temperatureDecision = LlmCapabilityPolicyService.GetSnapshot(
+                    this.capabilityScope)
+                .GetDecision(LlmCapabilityParameterName.Temperature);
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
             var requestData = new Dictionary<string, object>
             {
                 ["contents"] = new[]
@@ -398,6 +415,23 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 "application/json");
             var baseUrl =
                 $"https://generativelanguage.googleapis.com/v1beta/models/{this.model}:generateContent?key={this.apiKey}";
+
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    $"models/{this.model}:generateContent",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    jsonContent.Length,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
 
             var response =
                 await this.httpClient!.PostAsync(baseUrl, httpContent)
@@ -426,7 +460,17 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                     "unknown-structured-dialogue-failure");
                 PluginRuntimeLog.Debug(
                     this.pluginLog,
-                    $"Gemini structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "Gemini",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: $"models/{this.model}:generateContent",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -441,6 +485,17 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 this.translationCache.Remember(
                     cacheKey,
                     translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        $"models/{this.model}:generateContent",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload?.Length ?? 0,
+                        translatedText.Length,
+                        rawStructuredPayload ?? string.Empty,
+                        translatedText));
                 return translatedText;
             }
 
@@ -449,6 +504,18 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "Gemini",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: $"models/{this.model}:generateContent",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)
@@ -460,7 +527,21 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 ex.Message);
             PluginRuntimeLog.Debug(
                 this.pluginLog,
-                $"Gemini structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "Gemini",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    $"models/{this.model}:generateContent",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }

--- a/Translators/GeminiTranslator.cs
+++ b/Translators/GeminiTranslator.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.Translators.Helpers;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators;
 
@@ -17,6 +18,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
     private readonly string model;
     private readonly IPluginLog pluginLog;
     private readonly string promptTemplate;
+    private readonly LlmCapabilityScope capabilityScope;
     private readonly float temperature = 0.1f;
     private readonly ConcurrentTranslationRequestCache translationCache = new();
 
@@ -24,6 +26,11 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
     {
         this.apiKey = config.GeminiTranslatorApiKey ?? string.Empty;
         this.model = config.GeminiModel ?? "gemini-2.5-flash";
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.Gemini,
+            "Gemini",
+            "https://generativelanguage.googleapis.com",
+            this.model);
         this.temperature = config.GeminiTemperature;
         this.promptTemplate = string.IsNullOrWhiteSpace(config.GeminiPrompt)
             ? PromptTemplateManager.GetDefaultPrompt(Echoglossian.PromptType.Gemini)
@@ -178,9 +185,14 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
         {
             try
             {
-                var requestData = new
+                var generationConfig = new Dictionary<string, object>();
+                var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                    generationConfig,
+                    this.capabilityScope,
+                    this.temperature);
+                var requestData = new Dictionary<string, object>
                 {
-                    contents = new[]
+                    ["contents"] = new[]
                     {
                         new
                         {
@@ -193,10 +205,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                             },
                         },
                     },
-                    generationConfig = new
-                    {
-                        this.temperature,
-                    },
+                    ["generationConfig"] = generationConfig,
                 };
 
                 var jsonContent = JsonConvert.SerializeObject(requestData);
@@ -213,6 +222,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
 
                 if (!response.IsSuccessStatusCode)
                 {
+                    await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
                     if (retry < this.maxRetries)
                     {
                         var backoff = this.initialBackoff * Math.Pow(2, retry);
@@ -347,9 +357,25 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                 "Structured dialogue request JSON:\n" +
                 StructuredDialogueOpenAiToolHelper.SerializeRequestPayload(
                     structuredRequest);
-            var requestData = new
+            var generationConfig = new Dictionary<string, object>
             {
-                contents = new[]
+                ["responseFormat"] = new
+                {
+                    text = new
+                    {
+                        mimeType = "application/json",
+                        schema = JObject.Parse(
+                            StructuredDialogueOpenAiToolHelper.BuildFunctionParametersSchemaJson()),
+                    },
+                },
+            };
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                generationConfig,
+                this.capabilityScope,
+                this.temperature);
+            var requestData = new Dictionary<string, object>
+            {
+                ["contents"] = new[]
                 {
                     new
                     {
@@ -362,19 +388,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
                         },
                     },
                 },
-                generationConfig = new
-                {
-                    this.temperature,
-                    responseFormat = new
-                    {
-                        text = new
-                        {
-                            mimeType = "application/json",
-                            schema = JObject.Parse(
-                                StructuredDialogueOpenAiToolHelper.BuildFunctionParametersSchemaJson()),
-                        },
-                    },
-                },
+                ["generationConfig"] = generationConfig,
             };
 
             var jsonContent = JsonConvert.SerializeObject(requestData);
@@ -388,6 +402,7 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
             var response =
                 await this.httpClient!.PostAsync(baseUrl, httpContent)
                     .ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var responseString =
@@ -471,5 +486,31 @@ public class GeminiTranslator : ITranslator, IDialogueContextAwareTranslator
             prompt,
             dialogueContext.Value,
             FixText);
+    }
+
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from a
+    ///     failed Gemini request that included temperature.
+    /// </summary>
+    /// <param name="response">The provider response associated with the request.</param>
+    /// <param name="temperatureWasSent">Whether the request included temperature.</param>
+    private async Task LearnTemperatureFailureAsync(
+        HttpResponseMessage response,
+        bool temperatureWasSent)
+    {
+        if (response.IsSuccessStatusCode || !temperatureWasSent)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            (int)response.StatusCode,
+            responseText);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 }

--- a/Translators/Helpers/DialogueContextPromptHelper.cs
+++ b/Translators/Helpers/DialogueContextPromptHelper.cs
@@ -28,6 +28,64 @@ public static class DialogueContextPromptHelper
     }
 
     /// <summary>
+    ///     Returns whether the captured context contains any actual speaker,
+    ///     hint, or history metadata beyond a bare dialogue session identity.
+    /// </summary>
+    /// <param name="dialogueContext">The dialogue context to inspect.</param>
+    /// <returns>
+    ///     <see langword="true" /> when the context carries speaker, hint, or
+    ///     history metadata; otherwise <see langword="false" />.
+    /// </returns>
+    public static bool HasMaterialDialogueMetadata(DialogueTranslationContext dialogueContext)
+    {
+        return !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName) ||
+               dialogueContext.PriorTurns.Count > 0 ||
+               !string.IsNullOrWhiteSpace(dialogueContext.SpeakerRoleHint) ||
+               !string.IsNullOrWhiteSpace(dialogueContext.SpeakerGenderHint) ||
+               !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint) ||
+               !string.IsNullOrWhiteSpace(dialogueContext.AddresseeRoleHint) ||
+               !string.IsNullOrWhiteSpace(dialogueContext.AddresseeGenderHint);
+    }
+
+    /// <summary>
+    ///     Builds a non-sensitive one-line diagnostic summary for the captured
+    ///     dialogue context without logging speaker names, addressee names, or
+    ///     prior dialogue text.
+    /// </summary>
+    /// <param name="dialogueContext">The dialogue context to summarize.</param>
+    /// <returns>The diagnostic summary line content.</returns>
+    public static string SummarizeDialogueContextForDiagnostics(DialogueTranslationContext dialogueContext)
+    {
+        var summaryValues = new List<string>
+        {
+            "dialogueContext=supplied",
+            $"metadata={(HasMaterialDialogueMetadata(dialogueContext) ? "populated" : "session-only")}",
+            $"sessionNamespace={dialogueContext.SessionNamespace}",
+            $"priorTurns={dialogueContext.PriorTurns.Count}",
+            $"speaker={FormatPresence(dialogueContext.SpeakerName)}",
+            $"speakerRole={FormatPresence(dialogueContext.SpeakerRoleHint)}",
+            $"speakerGender={FormatPresence(dialogueContext.SpeakerGenderHint)}",
+            $"addressee={FormatPresence(dialogueContext.AddresseeHint)}",
+            $"addresseeRole={FormatPresence(dialogueContext.AddresseeRoleHint)}",
+            $"addresseeGender={FormatPresence(dialogueContext.AddresseeGenderHint)}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(dialogueContext.MetadataProvenance))
+        {
+            summaryValues.Add(
+                $"metadataProvenance={dialogueContext.MetadataProvenance}");
+        }
+
+        if (dialogueContext.MetadataConfidenceTier.HasValue)
+        {
+            summaryValues.Add(
+                $"metadataConfidenceTier={dialogueContext.MetadataConfidenceTier.Value}");
+        }
+
+        return string.Join(", ", summaryValues);
+    }
+
+    /// <summary>
     ///     Builds a distinct cache key for a dialogue translation that depends
     ///     on prior runtime-only context.
     /// </summary>
@@ -123,5 +181,10 @@ public static class DialogueContextPromptHelper
         {
             lines.Add($"{label}: {value}");
         }
+    }
+
+    private static string FormatPresence(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "false" : "true";
     }
 }

--- a/Translators/Helpers/DialogueContextPromptHelper.cs
+++ b/Translators/Helpers/DialogueContextPromptHelper.cs
@@ -63,7 +63,11 @@ public static class DialogueContextPromptHelper
         AddNonEmptyCacheValue(cacheKeyValues, "AddresseeRoleHint", dialogueContext.AddresseeRoleHint);
         AddNonEmptyCacheValue(cacheKeyValues, "AddresseeGenderHint", dialogueContext.AddresseeGenderHint);
         AddNonEmptyCacheValue(cacheKeyValues, "MetadataProvenance", dialogueContext.MetadataProvenance);
-        AddNonEmptyCacheValue(cacheKeyValues, "MetadataConfidenceTier", dialogueContext.MetadataConfidenceTier);
+        if (dialogueContext.MetadataConfidenceTier.HasValue)
+        {
+            cacheKeyValues["MetadataConfidenceTier"] = dialogueContext.MetadataConfidenceTier.Value;
+        }
+
         return JsonConvert.SerializeObject(cacheKeyValues);
     }
 

--- a/Translators/Helpers/DialogueContextPromptHelper.cs
+++ b/Translators/Helpers/DialogueContextPromptHelper.cs
@@ -14,17 +14,17 @@ namespace Echoglossian.Translators.Helpers;
 public static class DialogueContextPromptHelper
 {
     /// <summary>
-    ///     Returns whether the provided dialogue context has prior turns that
-    ///     can materially influence a translation request.
+    ///     Returns whether the provided captured dialogue context can
+    ///     materially influence a translation request.
     /// </summary>
     /// <param name="dialogueContext">The dialogue context to inspect.</param>
     /// <returns>
-    ///     <see langword="true" /> when prior turns are available;
+    ///     <see langword="true" /> when captured dialogue context is available;
     ///     otherwise <see langword="false" />.
     /// </returns>
     public static bool HasUsableDialogueContext(DialogueTranslationContext dialogueContext)
     {
-        return dialogueContext.PriorTurns.Count > 0;
+        return true;
     }
 
     /// <summary>
@@ -47,6 +47,7 @@ public static class DialogueContextPromptHelper
             Scope = "dialogue",
             dialogueContext.SessionNamespace,
             dialogueContext.SessionKey,
+            CurrentSpeaker = dialogueContext.SpeakerName,
             Text = text,
             SourceLanguage = sourceLanguage,
             TargetLanguage = targetLanguage,
@@ -59,12 +60,13 @@ public static class DialogueContextPromptHelper
     }
 
     /// <summary>
-    ///     Appends bounded prior dialogue turns to an already-rendered prompt.
+    ///     Appends captured dialogue metadata and bounded prior dialogue turns
+    ///     to an already-rendered prompt.
     /// </summary>
     /// <param name="prompt">The already-rendered prompt for the current text.</param>
     /// <param name="dialogueContext">The dialogue context to append.</param>
     /// <param name="sanitizeText">A text sanitizer used on prior turns.</param>
-    /// <returns>The prompt, optionally enriched with prior-turn context.</returns>
+    /// <returns>The prompt, optionally enriched with dialogue context.</returns>
     public static string AppendDialogueContext(
         string prompt,
         DialogueTranslationContext dialogueContext,

--- a/Translators/Helpers/DialogueContextPromptHelper.cs
+++ b/Translators/Helpers/DialogueContextPromptHelper.cs
@@ -42,21 +42,29 @@ public static class DialogueContextPromptHelper
         string targetLanguage,
         DialogueTranslationContext dialogueContext)
     {
-        return JsonConvert.SerializeObject(new
+        var cacheKeyValues = new Dictionary<string, object?>
         {
-            Scope = "dialogue",
-            dialogueContext.SessionNamespace,
-            dialogueContext.SessionKey,
-            CurrentSpeaker = dialogueContext.SpeakerName,
-            Text = text,
-            SourceLanguage = sourceLanguage,
-            TargetLanguage = targetLanguage,
-            PriorTurns = dialogueContext.PriorTurns.Select(turn => new
+            ["Scope"] = "dialogue",
+            ["SessionNamespace"] = dialogueContext.SessionNamespace,
+            ["SessionKey"] = dialogueContext.SessionKey,
+            ["CurrentSpeaker"] = dialogueContext.SpeakerName,
+            ["Text"] = text,
+            ["SourceLanguage"] = sourceLanguage,
+            ["TargetLanguage"] = targetLanguage,
+            ["PriorTurns"] = dialogueContext.PriorTurns.Select(turn => new
             {
                 turn.SpeakerName,
                 turn.SourceText,
             }),
-        });
+        };
+        AddNonEmptyCacheValue(cacheKeyValues, "SpeakerRoleHint", dialogueContext.SpeakerRoleHint);
+        AddNonEmptyCacheValue(cacheKeyValues, "SpeakerGenderHint", dialogueContext.SpeakerGenderHint);
+        AddNonEmptyCacheValue(cacheKeyValues, "AddresseeHint", dialogueContext.AddresseeHint);
+        AddNonEmptyCacheValue(cacheKeyValues, "AddresseeRoleHint", dialogueContext.AddresseeRoleHint);
+        AddNonEmptyCacheValue(cacheKeyValues, "AddresseeGenderHint", dialogueContext.AddresseeGenderHint);
+        AddNonEmptyCacheValue(cacheKeyValues, "MetadataProvenance", dialogueContext.MetadataProvenance);
+        AddNonEmptyCacheValue(cacheKeyValues, "MetadataConfidenceTier", dialogueContext.MetadataConfidenceTier);
+        return JsonConvert.SerializeObject(cacheKeyValues);
     }
 
     /// <summary>
@@ -77,13 +85,39 @@ public static class DialogueContextPromptHelper
             return prompt;
         }
 
-        string priorTurns = string.Join(
-            Environment.NewLine,
-            dialogueContext.PriorTurns.Select(
-                (turn, index) =>
-                    $"[{index + 1}] {turn.SpeakerName}: {sanitizeText(turn.SourceText)}"));
+        var contextLines = new List<string>();
+        AddNonEmptyPromptLine(contextLines, "Current speaker", dialogueContext.SpeakerName);
+        AddNonEmptyPromptLine(contextLines, "Speaker role", dialogueContext.SpeakerRoleHint);
+        AddNonEmptyPromptLine(contextLines, "Speaker gender", dialogueContext.SpeakerGenderHint);
+        AddNonEmptyPromptLine(contextLines, "Addressee", dialogueContext.AddresseeHint);
+        AddNonEmptyPromptLine(contextLines, "Addressee role", dialogueContext.AddresseeRoleHint);
+        AddNonEmptyPromptLine(contextLines, "Addressee gender", dialogueContext.AddresseeGenderHint);
+        contextLines.AddRange(dialogueContext.PriorTurns.Select(
+            (turn, index) => $"[{index + 1}] {turn.SpeakerName}: {sanitizeText(turn.SourceText)}"));
 
         return
-            $"{prompt}{Environment.NewLine}{Environment.NewLine}Previous dialogue context for translation consistency only (translate only the current text, not the history):{Environment.NewLine}Current speaker: {dialogueContext.SpeakerName}{Environment.NewLine}{priorTurns}";
+            $"{prompt}{Environment.NewLine}{Environment.NewLine}Previous dialogue context for translation consistency only (translate only the current text, not the history):{Environment.NewLine}{string.Join(Environment.NewLine, contextLines)}";
+    }
+
+    private static void AddNonEmptyCacheValue(
+        IDictionary<string, object?> values,
+        string key,
+        string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            values[key] = value;
+        }
+    }
+
+    private static void AddNonEmptyPromptLine(
+        ICollection<string> lines,
+        string label,
+        string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            lines.Add($"{label}: {value}");
+        }
     }
 }

--- a/Translators/Helpers/DialogueGlossaryTermProtector.cs
+++ b/Translators/Helpers/DialogueGlossaryTermProtector.cs
@@ -1,0 +1,365 @@
+// <copyright file="DialogueGlossaryTermProtector.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Text;
+
+namespace Echoglossian.Translators.Helpers;
+
+/// <summary>
+///     Protects exact dialogue glossary terms with deterministic opaque markers
+///     before provider translation and restores configured targets after the
+///     provider returns those markers unchanged.
+/// </summary>
+public static class DialogueGlossaryTermProtector
+{
+    private const string BaseMarkerPrefix = "[[EGLO_GLOSS_";
+    private const string MarkerSuffix = "]]";
+
+    /// <summary>
+    ///     Captures the protected source text plus the marker-to-target mapping
+    ///     required to restore the final translated output.
+    /// </summary>
+    /// <param name="OriginalText">The original visible source text.</param>
+    /// <param name="ProtectedText">The source text rewritten with opaque markers.</param>
+    /// <param name="MarkerPrefix">The deterministic marker prefix chosen for the request.</param>
+    /// <param name="Occurrences">The protected glossary occurrences in source order.</param>
+    public readonly record struct ProtectionResult(
+        string OriginalText,
+        string ProtectedText,
+        string MarkerPrefix,
+        IReadOnlyList<ProtectedOccurrence> Occurrences);
+
+    /// <summary>
+    ///     Captures one protected glossary occurrence.
+    /// </summary>
+    /// <param name="Marker">The opaque marker inserted into the protected text.</param>
+    /// <param name="SourceText">The matched source glossary term.</param>
+    /// <param name="TargetText">The configured target glossary term.</param>
+    public readonly record struct ProtectedOccurrence(
+        string Marker,
+        string SourceText,
+        string TargetText);
+
+    /// <summary>
+    ///     Describes the outcome of restoring protected glossary markers from a
+    ///     provider response.
+    /// </summary>
+    /// <param name="Succeeded">Whether restoration succeeded.</param>
+    /// <param name="RestoredText">The restored text when successful.</param>
+    /// <param name="FailureReason">The stable failure reason when restoration failed.</param>
+    public readonly record struct RestoreResult(
+        bool Succeeded,
+        string RestoredText,
+        string? FailureReason);
+
+    /// <summary>
+    ///     Rewrites source glossary terms in the current source text to stable
+    ///     opaque markers using longest-match-first phrase matching.
+    /// </summary>
+    /// <param name="sourceText">The current visible source text.</param>
+    /// <param name="glossaryEntries">The glossary entries active for the request.</param>
+    /// <returns>The protected text plus the marker mapping required for restoration.</returns>
+    public static ProtectionResult Protect(
+        string sourceText,
+        IReadOnlyList<StructuredDialogueGlossaryEntry>? glossaryEntries)
+    {
+        if (string.IsNullOrEmpty(sourceText) ||
+            glossaryEntries == null ||
+            glossaryEntries.Count == 0)
+        {
+            return new ProtectionResult(
+                sourceText ?? string.Empty,
+                sourceText ?? string.Empty,
+                string.Empty,
+                []);
+        }
+
+        var candidates = glossaryEntries
+            .Select(
+                static (entry, index) => new IndexedGlossaryEntry(index, entry))
+            .Where(static indexed => !string.IsNullOrWhiteSpace(indexed.Entry.SourceText))
+            .Where(static indexed => !string.IsNullOrWhiteSpace(indexed.Entry.TargetText))
+            .OrderByDescending(static indexed => indexed.Entry.SourceText.Length)
+            .ThenBy(static indexed => indexed.Index)
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return new ProtectionResult(
+                sourceText,
+                sourceText,
+                string.Empty,
+                []);
+        }
+
+        var markerPrefix = ResolveMarkerPrefix(sourceText);
+        var builder = new StringBuilder(sourceText.Length);
+        var occurrences = new List<ProtectedOccurrence>();
+        var cursor = 0;
+        while (cursor < sourceText.Length)
+        {
+            var match = FindMatch(sourceText, cursor, candidates);
+            if (match == null)
+            {
+                builder.Append(sourceText[cursor]);
+                cursor++;
+                continue;
+            }
+
+            var matchedEntry = match.Value;
+            var marker = BuildMarker(markerPrefix, occurrences.Count);
+            builder.Append(marker);
+            occurrences.Add(
+                new ProtectedOccurrence(
+                    marker,
+                    matchedEntry.SourceText,
+                    matchedEntry.TargetText));
+            cursor += matchedEntry.SourceText.Length;
+        }
+
+        return new ProtectionResult(
+            sourceText,
+            builder.ToString(),
+            markerPrefix,
+            occurrences);
+    }
+
+    /// <summary>
+    ///     Restores configured glossary targets from one provider response that
+    ///     must preserve every required opaque marker exactly once.
+    /// </summary>
+    /// <param name="translatedText">The provider response text.</param>
+    /// <param name="protectionResult">The protection mapping for the request.</param>
+    /// <returns>The restoration result.</returns>
+    public static RestoreResult TryRestore(
+        string translatedText,
+        ProtectionResult protectionResult)
+    {
+        if (protectionResult.Occurrences.Count == 0)
+        {
+            return new RestoreResult(
+                true,
+                translatedText,
+                null);
+        }
+
+        foreach (var occurrence in protectionResult.Occurrences)
+        {
+            var markerCount = CountOccurrences(
+                translatedText,
+                occurrence.Marker);
+            if (markerCount == 0)
+            {
+                return new RestoreResult(
+                    false,
+                    string.Empty,
+                    "missing-required-marker");
+            }
+
+            if (markerCount > 1)
+            {
+                return new RestoreResult(
+                    false,
+                    string.Empty,
+                    "duplicated-required-marker");
+            }
+        }
+
+        var unmatchedMarkers = translatedText;
+        foreach (var occurrence in protectionResult.Occurrences)
+        {
+            unmatchedMarkers = unmatchedMarkers.Replace(
+                occurrence.Marker,
+                string.Empty,
+                StringComparison.Ordinal);
+        }
+
+        if (!string.IsNullOrEmpty(protectionResult.MarkerPrefix) &&
+            unmatchedMarkers.Contains(
+                protectionResult.MarkerPrefix,
+                StringComparison.Ordinal))
+        {
+            return new RestoreResult(
+                false,
+                string.Empty,
+                "unexpected-marker");
+        }
+
+        var restoredText = translatedText;
+        foreach (var occurrence in protectionResult.Occurrences)
+        {
+            restoredText = restoredText.Replace(
+                occurrence.Marker,
+                occurrence.TargetText,
+                StringComparison.Ordinal);
+        }
+
+        return new RestoreResult(
+            true,
+            restoredText,
+            null);
+    }
+
+    /// <summary>
+    ///     Holds one glossary row plus its original order so ties remain stable.
+    /// </summary>
+    /// <param name="Index">The original glossary row order.</param>
+    /// <param name="Entry">The glossary row.</param>
+    private readonly record struct IndexedGlossaryEntry(
+        int Index,
+        StructuredDialogueGlossaryEntry Entry);
+
+    /// <summary>
+    ///     Finds the longest glossary entry that matches the current cursor.
+    /// </summary>
+    /// <param name="sourceText">The current source text.</param>
+    /// <param name="cursor">The current cursor position.</param>
+    /// <param name="candidates">The ordered glossary candidates.</param>
+    /// <returns>The matching glossary entry, or <see langword="null"/>.</returns>
+    private static StructuredDialogueGlossaryEntry? FindMatch(
+        string sourceText,
+        int cursor,
+        IReadOnlyList<IndexedGlossaryEntry> candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            var sourceTerm = candidate.Entry.SourceText;
+            if (cursor + sourceTerm.Length > sourceText.Length)
+            {
+                continue;
+            }
+
+            if (!string.Equals(
+                    sourceText.Substring(cursor, sourceTerm.Length),
+                    sourceTerm,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!IsWholeTermMatch(sourceText, cursor, sourceTerm))
+            {
+                continue;
+            }
+
+            return candidate.Entry;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Determines whether a matching glossary term stays outside unrelated
+    ///     larger words.
+    /// </summary>
+    /// <param name="sourceText">The current source text.</param>
+    /// <param name="cursor">The match cursor.</param>
+    /// <param name="sourceTerm">The matched glossary term.</param>
+    /// <returns><see langword="true"/> when the match is safe to protect.</returns>
+    private static bool IsWholeTermMatch(
+        string sourceText,
+        int cursor,
+        string sourceTerm)
+    {
+        var requiresLeadingBoundary = IsWordLike(sourceTerm[0]);
+        var requiresTrailingBoundary = IsWordLike(sourceTerm[^1]);
+
+        if (requiresLeadingBoundary &&
+            cursor > 0 &&
+            IsWordLike(sourceText[cursor - 1]))
+        {
+            return false;
+        }
+
+        var trailingIndex = cursor + sourceTerm.Length;
+        if (requiresTrailingBoundary &&
+            trailingIndex < sourceText.Length &&
+            IsWordLike(sourceText[trailingIndex]))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Determines whether one character should participate in whole-term
+    ///     boundary checks.
+    /// </summary>
+    /// <param name="value">The character to inspect.</param>
+    /// <returns><see langword="true"/> when the character is word-like.</returns>
+    private static bool IsWordLike(char value)
+    {
+        return char.IsLetterOrDigit(value) || value == '_';
+    }
+
+    /// <summary>
+    ///     Chooses a deterministic marker prefix that does not already appear in
+    ///     the current source text.
+    /// </summary>
+    /// <param name="sourceText">The current source text.</param>
+    /// <returns>The unique marker prefix for this request.</returns>
+    private static string ResolveMarkerPrefix(string sourceText)
+    {
+        for (var nonce = 0; ; nonce++)
+        {
+            var candidate = $"{BaseMarkerPrefix}{nonce}_";
+            if (!sourceText.Contains(candidate, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Builds one deterministic marker from the chosen prefix and
+    ///     occurrence order.
+    /// </summary>
+    /// <param name="markerPrefix">The chosen request marker prefix.</param>
+    /// <param name="occurrenceIndex">The protected occurrence index.</param>
+    /// <returns>The marker text.</returns>
+    private static string BuildMarker(
+        string markerPrefix,
+        int occurrenceIndex)
+    {
+        return $"{markerPrefix}{occurrenceIndex:D4}{MarkerSuffix}";
+    }
+
+    /// <summary>
+    ///     Counts exact ordinal occurrences of one marker in one provider
+    ///     response string.
+    /// </summary>
+    /// <param name="translatedText">The provider response text.</param>
+    /// <param name="marker">The exact marker to count.</param>
+    /// <returns>The occurrence count.</returns>
+    private static int CountOccurrences(
+        string translatedText,
+        string marker)
+    {
+        if (string.IsNullOrEmpty(translatedText) ||
+            string.IsNullOrEmpty(marker))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        var searchStart = 0;
+        while (searchStart < translatedText.Length)
+        {
+            var markerIndex = translatedText.IndexOf(
+                marker,
+                searchStart,
+                StringComparison.Ordinal);
+            if (markerIndex < 0)
+            {
+                break;
+            }
+
+            count++;
+            searchStart = markerIndex + marker.Length;
+        }
+
+        return count;
+    }
+}

--- a/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
+++ b/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
@@ -34,6 +34,12 @@ internal enum StructuredDialogueCapabilityEmissionMode
     OmittedUnknown,
 
     /// <summary>
+    ///     The parameter is supported but no configured value was available
+    ///     to send for this request.
+    /// </summary>
+    OmittedSupported,
+
+    /// <summary>
     ///     The parameter was sent with its explicit disable value.
     /// </summary>
     ExplicitDisable,
@@ -82,6 +88,8 @@ internal static class StructuredDialogueCapabilityDecisionLogFormatter
                 => "omitted(unsupported)",
             StructuredDialogueCapabilityEmissionMode.OmittedUnknown when decision.SupportState == LlmCapabilitySupportState.Unknown
                 => "omitted(unknown)",
+            StructuredDialogueCapabilityEmissionMode.OmittedSupported when decision.SupportState == LlmCapabilitySupportState.Supported
+                => "omitted(unconfigured)",
             StructuredDialogueCapabilityEmissionMode.ExplicitDisable when
                 parameterName == LlmCapabilityParameterName.ReasoningEffort &&
                 decision.SupportState == LlmCapabilitySupportState.Unsupported

--- a/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
+++ b/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
@@ -1,0 +1,86 @@
+// <copyright file="StructuredDialogueCapabilityDecisionLogFormatter.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.Translators.Capabilities;
+
+namespace Echoglossian.Translators.Helpers;
+
+/// <summary>
+///     Identifies how a resolved capability parameter was represented in a
+///     provider request.
+/// </summary>
+internal enum StructuredDialogueCapabilityEmissionMode
+{
+    /// <summary>
+    ///     The configured parameter value was sent.
+    /// </summary>
+    SentConfigured,
+
+    /// <summary>
+    ///     The parameter was omitted because the provider does not support it.
+    /// </summary>
+    OmittedUnsupported,
+
+    /// <summary>
+    ///     The parameter was omitted because only its implicit default is allowed.
+    /// </summary>
+    OmittedDefaultOnly,
+
+    /// <summary>
+    ///     The parameter was omitted because its support state is unknown.
+    /// </summary>
+    OmittedUnknown,
+
+    /// <summary>
+    ///     The parameter was sent with its explicit disable value.
+    /// </summary>
+    ExplicitDisable,
+}
+
+/// <summary>
+///     Formats compact, provider-independent capability decision tokens for
+///     structured dialogue diagnostics.
+/// </summary>
+internal static class StructuredDialogueCapabilityDecisionLogFormatter
+{
+    /// <summary>
+    ///     Formats one capability decision using its effective request emission.
+    /// </summary>
+    /// <param name="parameterName">The governed provider request parameter.</param>
+    /// <param name="decision">The resolved capability decision.</param>
+    /// <param name="emissionMode">How the request represented the decision.</param>
+    /// <returns>The compact diagnostic token.</returns>
+    public static string Format(
+        LlmCapabilityParameterName parameterName,
+        LlmCapabilityParameterDecision decision,
+        StructuredDialogueCapabilityEmissionMode emissionMode)
+    {
+        var parameterToken = parameterName switch
+        {
+            LlmCapabilityParameterName.ReasoningEffort => "reasoning_effort",
+            LlmCapabilityParameterName.Temperature => "temperature",
+            _ => parameterName.ToString().ToLowerInvariant(),
+        };
+
+        var supportToken = decision.SupportState switch
+        {
+            LlmCapabilitySupportState.Unsupported => "unsupported",
+            LlmCapabilitySupportState.Supported => "configured",
+            _ => "unknown",
+        };
+
+        var emissionToken = emissionMode switch
+        {
+            StructuredDialogueCapabilityEmissionMode.SentConfigured => "sent(configured)",
+            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly => "omitted(default-only)",
+            StructuredDialogueCapabilityEmissionMode.OmittedUnsupported => "omitted(unsupported)",
+            StructuredDialogueCapabilityEmissionMode.ExplicitDisable when parameterName == LlmCapabilityParameterName.ReasoningEffort
+                => "explicit-none(unsupported)",
+            _ => $"omitted({supportToken})",
+        };
+
+        return $"{parameterToken}={emissionToken}";
+    }
+}

--- a/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
+++ b/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
@@ -64,21 +64,32 @@ internal static class StructuredDialogueCapabilityDecisionLogFormatter
             _ => parameterName.ToString().ToLowerInvariant(),
         };
 
-        var supportToken = decision.SupportState switch
+        if (!Enum.IsDefined(emissionMode))
         {
-            LlmCapabilitySupportState.Unsupported => "unsupported",
-            LlmCapabilitySupportState.Supported => "configured",
-            _ => "unknown",
-        };
+            throw new ArgumentOutOfRangeException(
+                nameof(emissionMode),
+                emissionMode,
+                "Unsupported capability emission mode.");
+        }
 
         var emissionToken = emissionMode switch
         {
-            StructuredDialogueCapabilityEmissionMode.SentConfigured => "sent(configured)",
-            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly => "omitted(default-only)",
-            StructuredDialogueCapabilityEmissionMode.OmittedUnsupported => "omitted(unsupported)",
-            StructuredDialogueCapabilityEmissionMode.ExplicitDisable when parameterName == LlmCapabilityParameterName.ReasoningEffort
+            StructuredDialogueCapabilityEmissionMode.SentConfigured when decision.SupportState == LlmCapabilitySupportState.Supported
+                => "sent(configured)",
+            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly when
+                decision.SupportState == LlmCapabilitySupportState.Supported && decision.OmitWhenDefaultOnly
+                => "omitted(default-only)",
+            StructuredDialogueCapabilityEmissionMode.OmittedUnsupported when decision.SupportState == LlmCapabilitySupportState.Unsupported
+                => "omitted(unsupported)",
+            StructuredDialogueCapabilityEmissionMode.OmittedUnknown when decision.SupportState == LlmCapabilitySupportState.Unknown
+                => "omitted(unknown)",
+            StructuredDialogueCapabilityEmissionMode.ExplicitDisable when
+                parameterName == LlmCapabilityParameterName.ReasoningEffort &&
+                decision.SupportState == LlmCapabilitySupportState.Unsupported
                 => "explicit-none(unsupported)",
-            _ => $"omitted({supportToken})",
+            _ => throw new InvalidOperationException(
+                $"Emission mode '{emissionMode}' is incompatible with " +
+                $"parameter '{parameterName}' and support state '{decision.SupportState}'."),
         };
 
         return $"{parameterToken}={emissionToken}";

--- a/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
+++ b/Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs
@@ -76,8 +76,7 @@ internal static class StructuredDialogueCapabilityDecisionLogFormatter
         {
             StructuredDialogueCapabilityEmissionMode.SentConfigured when decision.SupportState == LlmCapabilitySupportState.Supported
                 => "sent(configured)",
-            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly when
-                decision.SupportState == LlmCapabilitySupportState.Supported && decision.OmitWhenDefaultOnly
+            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly when decision.OmitWhenDefaultOnly
                 => "omitted(default-only)",
             StructuredDialogueCapabilityEmissionMode.OmittedUnsupported when decision.SupportState == LlmCapabilitySupportState.Unsupported
                 => "omitted(unsupported)",

--- a/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
+++ b/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
@@ -1,0 +1,258 @@
+// <copyright file="StructuredDialogueDiagnosticsHelper.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.Text.RegularExpressions;
+
+using Echoglossian.Translators.Capabilities;
+
+namespace Echoglossian.Translators.Helpers;
+
+/// <summary>
+///     Formats standardized structured-dialogue downgrade diagnostics without
+///     leaking secrets into runtime logs.
+/// </summary>
+public static partial class StructuredDialogueDiagnosticsHelper
+{
+    private const int MaxExcerptLength = 72;
+
+    /// <summary>
+    ///     Builds one standardized structured-dialogue fallback diagnostic.
+    /// </summary>
+    /// <param name="providerName">The provider family name.</param>
+    /// <param name="modelName">The selected model name when known.</param>
+    /// <param name="capability">The structured capability attempted.</param>
+    /// <param name="stage">The downgrade stage such as validation or exception.</param>
+    /// <param name="failureReason">The failure reason or message.</param>
+    /// <param name="statusCode">The HTTP status code when available.</param>
+    /// <param name="responseExcerpt">The short provider error excerpt when available.</param>
+    /// <param name="endpointScope">The effective provider endpoint identity.</param>
+    /// <param name="route">The provider request route when known.</param>
+    /// <param name="capabilityDecisionTokens">The effective capability decision tokens.</param>
+    /// <param name="glossaryApplied">Whether glossary entries were included.</param>
+    /// <returns>The formatted diagnostic message.</returns>
+    public static string FormatStructuredFallbackMessage(
+        string providerName,
+        string? modelName,
+        StructuredDialogueProviderCapability capability,
+        string stage,
+        string failureReason,
+        int? statusCode = null,
+        string? responseExcerpt = null,
+        string? endpointScope = null,
+        string? route = null,
+        IReadOnlyList<string>? capabilityDecisionTokens = null,
+        bool? glossaryApplied = null)
+    {
+        var parts = new List<string>
+        {
+            "structured dialogue fallback",
+            $"provider={providerName}",
+            $"capability={FormatCapability(capability)}",
+            $"stage={NormalizeToken(stage)}",
+            $"reason={NormalizeToken(failureReason)}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(modelName))
+        {
+            parts.Add($"model={modelName}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(endpointScope))
+        {
+            parts.Add($"endpointScope={endpointScope}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(route))
+        {
+            parts.Add($"route={NormalizeToken(route)}");
+        }
+
+        if (capabilityDecisionTokens is not null)
+        {
+            parts.Add($"capabilityDecisions={string.Join("|", capabilityDecisionTokens)}");
+        }
+
+        if (glossaryApplied.HasValue)
+        {
+            parts.Add($"glossaryApplied={glossaryApplied.Value.ToString().ToLowerInvariant()}");
+        }
+
+        if (statusCode.HasValue)
+        {
+            parts.Add($"status={statusCode.Value}");
+        }
+
+        var sanitizedExcerpt = SanitizeExcerpt(responseExcerpt);
+        if (!string.IsNullOrWhiteSpace(sanitizedExcerpt))
+        {
+            parts.Add($"excerpt={sanitizedExcerpt}");
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    private static string FormatCapability(StructuredDialogueProviderCapability capability)
+    {
+        return capability switch
+        {
+            StructuredDialogueProviderCapability.JsonSchema => "json-schema",
+            StructuredDialogueProviderCapability.JsonObject => "json-object",
+            StructuredDialogueProviderCapability.PlainTextGlossary => "plain-text-glossary",
+            _ => "disabled",
+        };
+    }
+
+    private static string NormalizeToken(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "unknown";
+        }
+
+        var normalized = NonTokenCharacterPattern().Replace(
+            value.Trim().ToLowerInvariant(),
+            "-");
+        normalized = normalized.Trim('-');
+        return string.IsNullOrWhiteSpace(normalized) ? "unknown" : normalized;
+    }
+
+    private static string? SanitizeExcerpt(string? responseExcerpt)
+    {
+        if (string.IsNullOrWhiteSpace(responseExcerpt))
+        {
+            return null;
+        }
+
+        var sanitized = responseExcerpt
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Replace('\t', ' ');
+        sanitized = SecretAssignmentPattern().Replace(
+            sanitized,
+            "$1=[redacted]");
+        sanitized = BearerTokenPattern().Replace(
+            sanitized,
+            "[redacted]");
+        sanitized = MultiWhitespacePattern().Replace(
+            sanitized,
+            " ").Trim();
+
+        if (sanitized.Length > MaxExcerptLength)
+        {
+            sanitized = $"{sanitized[..(MaxExcerptLength - 3)]}...";
+        }
+
+        return sanitized;
+    }
+
+    [GeneratedRegex(@"\b(api[_-]?key|token|authorization)\s*[=:]\s*[^,\s;]+", RegexOptions.IgnoreCase)]
+    private static partial Regex SecretAssignmentPattern();
+
+    [GeneratedRegex(@"\b(?:sk|rk)-[A-Za-z0-9_-]+\b", RegexOptions.IgnoreCase)]
+    private static partial Regex BearerTokenPattern();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex MultiWhitespacePattern();
+
+    [GeneratedRegex(@"[^a-z0-9]+")]
+    private static partial Regex NonTokenCharacterPattern();
+    /// <summary>
+    ///     Builds a structured-dialogue request-start diagnostic.
+    /// </summary>
+    /// <param name="scope">The effective capability lookup scope.</param>
+    /// <param name="route">The provider request route.</param>
+    /// <param name="capability">The structured capability used for the request.</param>
+    /// <param name="sessionNamespace">The dialogue session namespace.</param>
+    /// <param name="priorTurns">The number of preceding dialogue turns.</param>
+    /// <param name="glossaryCount">The number of glossary entries included.</param>
+    /// <param name="speakerMetadataPresent">Whether speaker metadata was present.</param>
+    /// <param name="addresseeMetadataPresent">Whether addressee metadata was present.</param>
+    /// <param name="requestPromptLength">The generated prompt length.</param>
+    /// <param name="requestJsonLength">The serialized request length when applicable.</param>
+    /// <param name="promptPreview">The generated prompt preview.</param>
+    /// <param name="sourcePreview">The source text preview.</param>
+    /// <param name="capabilityDecisionTokens">The effective capability decision tokens.</param>
+    /// <returns>The formatted diagnostic message.</returns>
+    public static string FormatStructuredStartMessage(
+        LlmCapabilityScope scope,
+        string route,
+        StructuredDialogueProviderCapability capability,
+        string sessionNamespace,
+        int priorTurns,
+        int glossaryCount,
+        bool speakerMetadataPresent,
+        bool addresseeMetadataPresent,
+        int requestPromptLength,
+        int? requestJsonLength,
+        string promptPreview,
+        string sourcePreview,
+        IReadOnlyList<string> capabilityDecisionTokens)
+    {
+        var parts = new List<string>
+        {
+            "structured-start",
+            $"provider={scope.ProviderScope}",
+            $"endpointScope={scope.EndpointScope}",
+            $"route={NormalizeToken(route)}",
+            $"model={scope.ModelId}",
+            $"capability={FormatCapability(capability)}",
+            $"sessionNamespace={NormalizeToken(sessionNamespace)}",
+            $"priorTurns={priorTurns}",
+            $"glossaryCount={glossaryCount}",
+            $"glossaryApplied={(glossaryCount > 0).ToString().ToLowerInvariant()}",
+            $"speakerMetadataPresent={speakerMetadataPresent.ToString().ToLowerInvariant()}",
+            $"addresseeMetadataPresent={addresseeMetadataPresent.ToString().ToLowerInvariant()}",
+            $"requestPromptLength={requestPromptLength}",
+            $"promptPreview={SanitizeExcerpt(promptPreview)}",
+            $"sourcePreview={SanitizeExcerpt(sourcePreview)}",
+            $"capabilityDecisions={string.Join("|", capabilityDecisionTokens)}",
+        };
+
+        if (requestJsonLength.HasValue)
+        {
+            parts.Add($"requestJsonLength={requestJsonLength.Value}");
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>
+    ///     Builds a structured-dialogue request-success diagnostic.
+    /// </summary>
+    /// <param name="scope">The effective capability lookup scope.</param>
+    /// <param name="route">The provider request route.</param>
+    /// <param name="capability">The structured capability used for the request.</param>
+    /// <param name="glossaryApplied">Whether glossary entries were included.</param>
+    /// <param name="rawPayloadLength">The raw provider payload length.</param>
+    /// <param name="translatedLength">The extracted translation length.</param>
+    /// <param name="rawPayloadPreview">The raw provider payload preview.</param>
+    /// <param name="translatedPreview">The translated text preview.</param>
+    /// <returns>The formatted diagnostic message.</returns>
+    public static string FormatStructuredSuccessMessage(
+        LlmCapabilityScope scope,
+        string route,
+        StructuredDialogueProviderCapability capability,
+        bool glossaryApplied,
+        int rawPayloadLength,
+        int translatedLength,
+        string rawPayloadPreview,
+        string translatedPreview)
+    {
+        return string.Join(", ", new[]
+        {
+            "structured-success",
+            $"provider={scope.ProviderScope}",
+            $"endpointScope={scope.EndpointScope}",
+            $"route={NormalizeToken(route)}",
+            $"model={scope.ModelId}",
+            $"capability={FormatCapability(capability)}",
+            $"glossaryApplied={glossaryApplied.ToString().ToLowerInvariant()}",
+            $"rawPayloadLength={rawPayloadLength}",
+            $"translatedLength={translatedLength}",
+            $"rawPayloadPreview={SanitizeExcerpt(rawPayloadPreview)}",
+            $"translatedPreview={SanitizeExcerpt(translatedPreview)}",
+        });
+    }
+}

--- a/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
+++ b/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
@@ -114,7 +114,7 @@ public static partial class StructuredDialogueDiagnosticsHelper
             return "provider-exception";
         }
 
-        return NormalizeToken(failureReason);
+        return NormalizeToken(SanitizeExcerpt(failureReason));
     }
 
     private static string NormalizeToken(string? value)
@@ -187,7 +187,7 @@ public static partial class StructuredDialogueDiagnosticsHelper
         return sanitizedUri.Uri.GetLeftPart(UriPartial.Path);
     }
 
-    [GeneratedRegex(@"\b(?<key>api[_-]?key|token|authorization|password|secret|key)\s*[=:]\s*(?:""[^""]*""|'[^']*'|[^,\s;}\]]+)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?<key>api[_-]?key|token|authorization|password|secret|key)\b""?\s*[=:]\s*(?:""[^""]*""|'[^']*'|[^,\s;}\]]+)", RegexOptions.IgnoreCase)]
     private static partial Regex SecretAssignmentPattern();
 
     [GeneratedRegex(@"\bBearer\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase)]

--- a/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
+++ b/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
@@ -61,7 +61,7 @@ public static partial class StructuredDialogueDiagnosticsHelper
 
         if (!string.IsNullOrWhiteSpace(endpointScope))
         {
-            parts.Add($"endpointScope={endpointScope}");
+            parts.Add($"endpointScope={SanitizeEndpointScope(endpointScope)}");
         }
 
         if (!string.IsNullOrWhiteSpace(route))
@@ -129,6 +129,9 @@ public static partial class StructuredDialogueDiagnosticsHelper
             .Replace('\r', ' ')
             .Replace('\n', ' ')
             .Replace('\t', ' ');
+        sanitized = BearerCredentialPattern().Replace(
+            sanitized,
+            "[redacted]");
         sanitized = SecretAssignmentPattern().Replace(
             sanitized,
             "$1=[redacted]");
@@ -147,8 +150,35 @@ public static partial class StructuredDialogueDiagnosticsHelper
         return sanitized;
     }
 
+    private static string SanitizeEndpointScope(string? endpointScope)
+    {
+        if (string.IsNullOrWhiteSpace(endpointScope))
+        {
+            return "unknown";
+        }
+
+        var singleLineEndpoint = endpointScope.Split(['\r', '\n', '\t'])[0].Trim();
+        if (!Uri.TryCreate(singleLineEndpoint, UriKind.Absolute, out var endpointUri) ||
+            (endpointUri.Scheme != Uri.UriSchemeHttp && endpointUri.Scheme != Uri.UriSchemeHttps))
+        {
+            return "unknown";
+        }
+
+        var sanitizedUri = new UriBuilder(endpointUri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty,
+        };
+        return sanitizedUri.Uri.GetLeftPart(UriPartial.Path);
+    }
+
     [GeneratedRegex(@"\b(api[_-]?key|token|authorization)\s*[=:]\s*[^,\s;]+", RegexOptions.IgnoreCase)]
     private static partial Regex SecretAssignmentPattern();
+
+    [GeneratedRegex(@"\bBearer\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase)]
+    private static partial Regex BearerCredentialPattern();
 
     [GeneratedRegex(@"\b(?:sk|rk)-[A-Za-z0-9_-]+\b", RegexOptions.IgnoreCase)]
     private static partial Regex BearerTokenPattern();
@@ -194,7 +224,7 @@ public static partial class StructuredDialogueDiagnosticsHelper
         {
             "structured-start",
             $"provider={scope.ProviderScope}",
-            $"endpointScope={scope.EndpointScope}",
+            $"endpointScope={SanitizeEndpointScope(scope.EndpointScope)}",
             $"route={NormalizeToken(route)}",
             $"model={scope.ModelId}",
             $"capability={FormatCapability(capability)}",
@@ -244,7 +274,7 @@ public static partial class StructuredDialogueDiagnosticsHelper
         {
             "structured-success",
             $"provider={scope.ProviderScope}",
-            $"endpointScope={scope.EndpointScope}",
+            $"endpointScope={SanitizeEndpointScope(scope.EndpointScope)}",
             $"route={NormalizeToken(route)}",
             $"model={scope.ModelId}",
             $"capability={FormatCapability(capability)}",

--- a/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
+++ b/Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
@@ -47,11 +47,11 @@ public static partial class StructuredDialogueDiagnosticsHelper
     {
         var parts = new List<string>
         {
-            "structured dialogue fallback",
+            "structured-fallback",
             $"provider={providerName}",
             $"capability={FormatCapability(capability)}",
             $"stage={NormalizeToken(stage)}",
-            $"reason={NormalizeToken(failureReason)}",
+            $"reason={FormatFailureReason(stage, failureReason)}",
         };
 
         if (!string.IsNullOrWhiteSpace(modelName))
@@ -102,6 +102,19 @@ public static partial class StructuredDialogueDiagnosticsHelper
             StructuredDialogueProviderCapability.PlainTextGlossary => "plain-text-glossary",
             _ => "disabled",
         };
+    }
+
+    private static string FormatFailureReason(string stage, string? failureReason)
+    {
+        if (string.Equals(
+                NormalizeToken(stage),
+                "exception",
+                StringComparison.Ordinal))
+        {
+            return "provider-exception";
+        }
+
+        return NormalizeToken(failureReason);
     }
 
     private static string NormalizeToken(string? value)
@@ -174,7 +187,7 @@ public static partial class StructuredDialogueDiagnosticsHelper
         return sanitizedUri.Uri.GetLeftPart(UriPartial.Path);
     }
 
-    [GeneratedRegex(@"\b(api[_-]?key|token|authorization)\s*[=:]\s*[^,\s;]+", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?<key>api[_-]?key|token|authorization|password|secret|key)\s*[=:]\s*(?:""[^""]*""|'[^']*'|[^,\s;}\]]+)", RegexOptions.IgnoreCase)]
     private static partial Regex SecretAssignmentPattern();
 
     [GeneratedRegex(@"\bBearer\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase)]

--- a/Translators/Helpers/StructuredDialogueTranslationRequestBuilder.cs
+++ b/Translators/Helpers/StructuredDialogueTranslationRequestBuilder.cs
@@ -45,6 +45,7 @@ public static class StructuredDialogueTranslationRequestBuilder
         .ToList() ?? [];
     IReadOnlyList<StructuredDialogueGlossaryEntry> glossaryRows =
         glossary?.ToList() ?? [];
+    string? resolvedSpeakerRoleHint = dialogueContext?.SpeakerRoleHint ?? speakerRoleHint;
 
     return new StructuredDialogueTranslationRequest(
         sourceLanguage ?? string.Empty,
@@ -57,7 +58,13 @@ public static class StructuredDialogueTranslationRequestBuilder
         new StructuredDialogueTranslationMetadata(
             questNameOriginal,
             normalizedSpeakerOriginal,
-            speakerRoleHint,
+            resolvedSpeakerRoleHint,
+            dialogueContext?.SpeakerGenderHint,
+            dialogueContext?.AddresseeHint,
+            dialogueContext?.AddresseeRoleHint,
+            dialogueContext?.AddresseeGenderHint,
+            dialogueContext?.MetadataProvenance,
+            dialogueContext?.MetadataConfidenceTier,
             pronounHint,
             subjectHint));
   }

--- a/Translators/LmStudio/LmStudioModelManager.cs
+++ b/Translators/LmStudio/LmStudioModelManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.OpenAI;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators.LmStudio;
 
@@ -83,6 +84,12 @@ public static class LmStudioModelManager
             if (models.Any())
             {
                 CurrentModelList = models;
+                LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                    Echoglossian.TransEngines.LmStudio,
+                    "LmStudio",
+                    baseUrl,
+                    models.Select(static model => model.Id).ToArray(),
+                    DateTime.UtcNow);
             }
         }
         catch (Exception ex)

--- a/Translators/LmStudioTranslator.cs
+++ b/Translators/LmStudioTranslator.cs
@@ -246,6 +246,7 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             var normalizedText = FixText(text);
@@ -298,10 +299,48 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                 request,
                 this.capabilityScope,
                 this.temperature);
+            var temperatureDecision = LlmCapabilityPolicyService.GetSnapshot(
+                    this.capabilityScope)
+                .GetDecision(LlmCapabilityParameterName.Temperature);
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
+            var jsonContent = JsonConvert.SerializeObject(request);
+            using var httpContent = new StringContent(
+                jsonContent,
+                Encoding.UTF8,
+                "application/json");
 
-            var response = await this.httpClient.PostAsJsonAsync(
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    "chat/completions",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    jsonContent.Length,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
+
+            var response = await this.httpClient.PostAsync(
                 "chat/completions",
-                request).ConfigureAwait(false);
+                httpContent).ConfigureAwait(false);
             await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
@@ -324,7 +363,19 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(this.pluginLog, $"LmStudio structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "LmStudio",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: "chat/completions",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -339,6 +390,17 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                 this.translationCache.Remember(
                     cacheKey,
                     translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        "chat/completions",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload.Length,
+                        translatedText.Length,
+                        rawStructuredPayload,
+                        translatedText));
                 return translatedText;
             }
 
@@ -347,6 +409,18 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "LmStudio",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: "chat/completions",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)
@@ -356,7 +430,23 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(this.pluginLog, $"LmStudio structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "LmStudio",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    "chat/completions",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }

--- a/Translators/LmStudioTranslator.cs
+++ b/Translators/LmStudioTranslator.cs
@@ -44,7 +44,7 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
             "LmStudio",
             baseUrl,
             this.model);
-        this.httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        this.httpClient = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/") };
 
         if (config.UseLmStudioAuth &&
             !string.IsNullOrWhiteSpace(config.LmStudioApiKey))
@@ -375,7 +375,8 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                         endpointScope: this.capabilityScope.EndpointScope,
                         route: "chat/completions",
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -420,7 +421,8 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                     endpointScope: this.capabilityScope.EndpointScope,
                     route: "chat/completions",
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)

--- a/Translators/LmStudioTranslator.cs
+++ b/Translators/LmStudioTranslator.cs
@@ -173,7 +173,10 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                 new { role = "user", content = fullPrompt },
             },
         };
-        var temperatureWasSent = this.TryAddTemperature(request);
+        var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+            request,
+            this.capabilityScope,
+            this.temperature);
 
         try
         {
@@ -291,7 +294,10 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
-            var temperatureWasSent = this.TryAddTemperature(request);
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                request,
+                this.capabilityScope,
+                this.temperature);
 
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
@@ -377,21 +383,12 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
             FixText);
     }
 
-    private bool TryAddTemperature(Dictionary<string, object> request)
-    {
-        if (!LlmCapabilityPolicyService.TryResolveTemperature(
-                this.capabilityScope,
-                this.temperature,
-                out var sanitizedTemperature,
-                out _))
-        {
-            return false;
-        }
-
-        request.Add("temperature", sanitizedTemperature);
-        return true;
-    }
-
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from a
+    ///     failed LM Studio request that included temperature.
+    /// </summary>
+    /// <param name="response">The provider response associated with the request.</param>
+    /// <param name="temperatureWasSent">Whether the request included temperature.</param>
     private async Task LearnTemperatureFailureAsync(
         HttpResponseMessage response,
         bool temperatureWasSent)

--- a/Translators/LmStudioTranslator.cs
+++ b/Translators/LmStudioTranslator.cs
@@ -5,6 +5,7 @@
 
 using System.Net.Http.Json;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Helpers;
 
 namespace Echoglossian.Translators;
@@ -14,6 +15,7 @@ namespace Echoglossian.Translators;
 /// </summary>
 public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
 {
+    private readonly LlmCapabilityScope capabilityScope;
     private readonly HttpClient httpClient;
     private readonly string model;
     private readonly IPluginLog pluginLog;
@@ -37,6 +39,11 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
 
         var baseUrl = config.LmStudioBaseUrl?.TrimEnd('/') ??
                       "http://localhost:1234/v1";
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.LmStudio,
+            "LmStudio",
+            baseUrl,
+            this.model);
         this.httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
 
         if (config.UseLmStudioAuth &&
@@ -158,21 +165,22 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
             targetLanguage,
             dialogueContext);
 
-        var request = new
+        var request = new Dictionary<string, object>
         {
-            this.model,
-            this.temperature,
-            messages = new[]
+            ["model"] = this.model,
+            ["messages"] = new[]
             {
                 new { role = "user", content = fullPrompt },
             },
         };
+        var temperatureWasSent = this.TryAddTemperature(request);
 
         try
         {
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
                 request);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var json =
@@ -253,15 +261,14 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                         sourceLanguage,
                         targetLanguage),
                     structuredRequest);
-            var request = new
+            var request = new Dictionary<string, object>
             {
-                this.model,
-                this.temperature,
-                messages = new[]
+                ["model"] = this.model,
+                ["messages"] = new[]
                 {
                     new { role = "user", content = structuredPrompt },
                 },
-                tools = new[]
+                ["tools"] = new[]
                 {
                     new
                     {
@@ -275,7 +282,7 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                         },
                     },
                 },
-                tool_choice = new
+                ["tool_choice"] = new
                 {
                     type = "function",
                     function = new
@@ -284,10 +291,12 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
+            var temperatureWasSent = this.TryAddTemperature(request);
 
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
                 request).ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var responseJson =
@@ -309,9 +318,7 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(
-                    this.pluginLog,
-                    $"LmStudio structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(this.pluginLog, $"LmStudio structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
                 return null;
             }
 
@@ -343,9 +350,7 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(
-                this.pluginLog,
-                $"LmStudio structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(this.pluginLog, $"LmStudio structured dialogue path failed and will fall back to plain-text: {ex.Message}");
             return null;
         }
     }
@@ -370,6 +375,41 @@ public class LmStudioTranslator : ITranslator, IDialogueContextAwareTranslator
             prompt,
             dialogueContext.Value,
             FixText);
+    }
+
+    private bool TryAddTemperature(Dictionary<string, object> request)
+    {
+        if (!LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _))
+        {
+            return false;
+        }
+
+        request.Add("temperature", sanitizedTemperature);
+        return true;
+    }
+
+    private async Task LearnTemperatureFailureAsync(
+        HttpResponseMessage response,
+        bool temperatureWasSent)
+    {
+        if (response.IsSuccessStatusCode || !temperatureWasSent)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            (int)response.StatusCode,
+            responseText);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 
     private sealed class LmStudioResponse

--- a/Translators/Ollama/OllamaModelManager.cs
+++ b/Translators/Ollama/OllamaModelManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.OpenAI;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators.Ollama;
 
@@ -52,6 +53,16 @@ public static class OllamaModelManager
                     CurrentModels.Add(model);
                     tooltips[name!] = $"🦙 Ollama model: {tier}";
                 }
+            }
+
+            if (CurrentModels.Count > 0)
+            {
+                LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                    Echoglossian.TransEngines.Ollama,
+                    "Ollama",
+                    baseUrl,
+                    CurrentModels.Select(static model => model.Id).ToArray(),
+                    DateTime.UtcNow);
             }
         }
         catch (Exception ex)

--- a/Translators/OllamaTranslator.cs
+++ b/Translators/OllamaTranslator.cs
@@ -330,7 +330,8 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                         endpointScope: this.capabilityScope.EndpointScope,
                         route: "/api/generate",
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -373,7 +374,8 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                     endpointScope: this.capabilityScope.EndpointScope,
                     route: "/api/generate",
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)

--- a/Translators/OllamaTranslator.cs
+++ b/Translators/OllamaTranslator.cs
@@ -5,6 +5,7 @@
 
 using System.Net.Http.Json;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Helpers;
 
 namespace Echoglossian.Translators;
@@ -16,6 +17,7 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
     private readonly string model;
     private readonly IPluginLog pluginLog;
     private readonly string promptTemplate;
+    private readonly LlmCapabilityScope capabilityScope;
     private readonly float temperature;
     private readonly ConcurrentTranslationRequestCache translationCache = new();
 
@@ -25,6 +27,11 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
         this.endpoint =
             config.OllamaUrl?.TrimEnd('/') ?? "http://localhost:11434";
         this.model = config.OllamaModel ?? "llama3";
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.Ollama,
+            "Ollama",
+            this.endpoint,
+            this.model);
         this.promptTemplate = string.IsNullOrWhiteSpace(config.OllamaPrompt)
             ? PromptTemplateManager.GetDefaultPrompt(Echoglossian.PromptType.Ollama)
             : config.OllamaPrompt;
@@ -138,18 +145,22 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
             targetLanguage,
             dialogueContext);
 
-        var request = new
+        var request = new Dictionary<string, object>
         {
-            this.model,
-            prompt,
-            this.temperature,
-            stream = false,
+            ["model"] = this.model,
+            ["prompt"] = prompt,
+            ["stream"] = false,
         };
+        var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+            request,
+            this.capabilityScope,
+            this.temperature);
 
         try
         {
             var response =
                 await this.httpClient.PostAsJsonAsync("/api/generate", request);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync();
@@ -231,22 +242,25 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                 "Structured dialogue request JSON:\n" +
                 StructuredDialogueOpenAiToolHelper.SerializeRequestPayload(
                     structuredRequest);
-            var request = new
+            var options = new Dictionary<string, object>();
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                options,
+                this.capabilityScope,
+                this.temperature);
+            var request = new Dictionary<string, object>
             {
-                this.model,
-                prompt = structuredPrompt,
-                stream = false,
-                format = JObject.Parse(
+                ["model"] = this.model,
+                ["prompt"] = structuredPrompt,
+                ["stream"] = false,
+                ["format"] = JObject.Parse(
                     StructuredDialogueOpenAiToolHelper.BuildFunctionParametersSchemaJson()),
-                options = new
-                {
-                    temperature = this.temperature,
-                },
+                ["options"] = options,
             };
 
             var response =
                 await this.httpClient.PostAsJsonAsync("/api/generate", request)
                     .ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -325,5 +339,31 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
             prompt,
             dialogueContext.Value,
             FixText);
+    }
+
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from a
+    ///     failed Ollama request that included temperature.
+    /// </summary>
+    /// <param name="response">The provider response associated with the request.</param>
+    /// <param name="temperatureWasSent">Whether the request included temperature.</param>
+    private async Task LearnTemperatureFailureAsync(
+        HttpResponseMessage response,
+        bool temperatureWasSent)
+    {
+        if (response.IsSuccessStatusCode || !temperatureWasSent)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            (int)response.StatusCode,
+            responseText);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 }

--- a/Translators/OllamaTranslator.cs
+++ b/Translators/OllamaTranslator.cs
@@ -220,6 +220,7 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             var normalizedText = FixText(text);
@@ -247,6 +248,22 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                 options,
                 this.capabilityScope,
                 this.temperature);
+            var temperatureDecision = LlmCapabilityPolicyService.GetSnapshot(
+                    this.capabilityScope)
+                .GetDecision(LlmCapabilityParameterName.Temperature);
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
             var request = new Dictionary<string, object>
             {
                 ["model"] = this.model,
@@ -256,9 +273,31 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                     StructuredDialogueOpenAiToolHelper.BuildFunctionParametersSchemaJson()),
                 ["options"] = options,
             };
+            var jsonContent = JsonConvert.SerializeObject(request);
+            using var httpContent = new StringContent(
+                jsonContent,
+                Encoding.UTF8,
+                "application/json");
+
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    "/api/generate",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    jsonContent.Length,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
 
             var response =
-                await this.httpClient.PostAsJsonAsync("/api/generate", request)
+                await this.httpClient.PostAsync("/api/generate", httpContent)
                     .ConfigureAwait(false);
             await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
@@ -281,7 +320,17 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                     "unknown-structured-dialogue-failure");
                 PluginRuntimeLog.Debug(
                     this.pluginLog,
-                    $"Ollama structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "Ollama",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: "/api/generate",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -294,6 +343,17 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                     true,
                     usedGlossary);
                 this.translationCache.Remember(cacheKey, translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        "/api/generate",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload?.Length ?? 0,
+                        translatedText.Length,
+                        rawStructuredPayload ?? string.Empty,
+                        translatedText));
                 return translatedText;
             }
 
@@ -302,6 +362,18 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "Ollama",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: "/api/generate",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)
@@ -313,7 +385,21 @@ public class OllamaTranslator : ITranslator, IDialogueContextAwareTranslator
                 ex.Message);
             PluginRuntimeLog.Debug(
                 this.pluginLog,
-                $"Ollama structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "Ollama",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    "/api/generate",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }

--- a/Translators/OpenAI/OpenAIModelManager.cs
+++ b/Translators/OpenAI/OpenAIModelManager.cs
@@ -3,6 +3,8 @@
 // Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
 // </copyright>
 
+using Echoglossian.Translators.Capabilities;
+
 namespace Echoglossian.Translators.OpenAI;
 
 public static class OpenAIModelManager
@@ -338,6 +340,13 @@ public static class OpenAIModelManager
           : baseUrl.TrimEnd('/');
       state.LastRefreshFailureDetail = null;
     }
+
+    LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+        Echoglossian.TransEngines.ChatGPT,
+        providerName,
+        baseUrl,
+        models.Select(static model => model.Id).ToArray(),
+        observedAtUtc);
   }
 
   /// <summary>

--- a/Translators/OpenRouter/OpenRouterModelManager.cs
+++ b/Translators/OpenRouter/OpenRouterModelManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Echoglossian.Translators.OpenAI;
+using Echoglossian.Translators.Capabilities;
 
 namespace Echoglossian.Translators.OpenRouter;
 
@@ -93,6 +94,16 @@ public static class OpenRouterModelManager
                 {
                     CurrentModelList = models;
                 }
+            }
+
+            if (models.Count > 0)
+            {
+                LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+                    Echoglossian.TransEngines.OpenRouter,
+                    "OpenRouter",
+                    baseUrl,
+                    models.Select(static model => model.Id).ToArray(),
+                    DateTime.UtcNow);
             }
         }
         catch

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -191,7 +191,10 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                 new { role = "user", content = prompt },
             },
         };
-        var temperatureWasSent = this.TryAddTemperature(request);
+        var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+            request,
+            this.capabilityScope,
+            this.temperature);
 
         try
         {
@@ -309,7 +312,10 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
-            var temperatureWasSent = this.TryAddTemperature(request);
+            var temperatureWasSent = LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(
+                request,
+                this.capabilityScope,
+                this.temperature);
 
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
@@ -396,21 +402,12 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
             FixText);
     }
 
-    private bool TryAddTemperature(Dictionary<string, object> request)
-    {
-        if (!LlmCapabilityPolicyService.TryResolveTemperature(
-                this.capabilityScope,
-                this.temperature,
-                out var sanitizedTemperature,
-                out _))
-        {
-            return false;
-        }
-
-        request.Add("temperature", sanitizedTemperature);
-        return true;
-    }
-
+    /// <summary>
+    ///     Records a sanitized exact-model temperature observation from a
+    ///     failed OpenRouter request that included temperature.
+    /// </summary>
+    /// <param name="response">The provider response associated with the request.</param>
+    /// <param name="temperatureWasSent">Whether the request included temperature.</param>
     private async Task LearnTemperatureFailureAsync(
         HttpResponseMessage response,
         bool temperatureWasSent)

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -389,7 +389,8 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                         endpointScope: this.capabilityScope.EndpointScope,
                         route: "chat/completions",
                         capabilityDecisionTokens: capabilityDecisionTokens,
-                        glossaryApplied: usedGlossary));
+                        glossaryApplied: usedGlossary,
+                        responseExcerpt: rawStructuredPayload));
                 return null;
             }
 
@@ -434,7 +435,8 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                     endpointScope: this.capabilityScope.EndpointScope,
                     route: "chat/completions",
                     capabilityDecisionTokens: capabilityDecisionTokens,
-                    glossaryApplied: usedGlossary));
+                    glossaryApplied: usedGlossary,
+                    responseExcerpt: rawStructuredPayload));
             return null;
         }
         catch (Exception ex)

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -333,7 +333,7 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                                 ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
                                 : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
             ];
-            var requestJsonLength = JsonConvert.SerializeObject(request).Length;
+            var requestJson = JsonConvert.SerializeObject(request);
 
             PluginRuntimeLog.Debug(
                 this.pluginLog,
@@ -347,14 +347,14 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                     !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
                     !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
                     structuredPrompt.Length,
-                    requestJsonLength,
+                    requestJson.Length,
                     structuredPrompt,
                     normalizedText,
                     capabilityDecisionTokens));
 
-            var response = await this.httpClient.PostAsJsonAsync(
+            var response = await this.httpClient.PostAsync(
                 "chat/completions",
-                request).ConfigureAwait(false);
+                new StringContent(requestJson, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
@@ -423,6 +423,18 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 "non-persistable-structured-result");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "OpenRouter",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "validation",
+                    "non-persistable-structured-result",
+                    endpointScope: this.capabilityScope.EndpointScope,
+                    route: "chat/completions",
+                    capabilityDecisionTokens: capabilityDecisionTokens,
+                    glossaryApplied: usedGlossary));
             return null;
         }
         catch (Exception ex)

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -263,6 +263,7 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
             sourceLanguage,
             targetLanguage);
         var usedGlossary = glossaryEntries.Count > 0;
+        IReadOnlyList<string> capabilityDecisionTokens = [];
         try
         {
             var normalizedText = FixText(text);
@@ -316,6 +317,40 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                 request,
                 this.capabilityScope,
                 this.temperature);
+            var temperatureDecision = LlmCapabilityPolicyService.GetSnapshot(
+                    this.capabilityScope)
+                .GetDecision(LlmCapabilityParameterName.Temperature);
+            capabilityDecisionTokens =
+            [
+                StructuredDialogueCapabilityDecisionLogFormatter.Format(
+                    LlmCapabilityParameterName.Temperature,
+                    temperatureDecision,
+                    temperatureWasSent
+                        ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                        : temperatureDecision.OmitWhenDefaultOnly
+                            ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                            : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                                ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+            ];
+            var requestJsonLength = JsonConvert.SerializeObject(request).Length;
+
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+                    this.capabilityScope,
+                    "chat/completions",
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    dialogueContext.SessionNamespace,
+                    dialogueContext.PriorTurns.Count,
+                    glossaryEntries.Count,
+                    !string.IsNullOrWhiteSpace(dialogueContext.SpeakerName),
+                    !string.IsNullOrWhiteSpace(dialogueContext.AddresseeHint),
+                    structuredPrompt.Length,
+                    requestJsonLength,
+                    structuredPrompt,
+                    normalizedText,
+                    capabilityDecisionTokens));
 
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
@@ -342,7 +377,19 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(this.pluginLog, $"OpenRouter structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                        "OpenRouter",
+                        this.model,
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        "validation",
+                        structuredValidation.FailureReason ??
+                        "unknown-structured-dialogue-failure",
+                        endpointScope: this.capabilityScope.EndpointScope,
+                        route: "chat/completions",
+                        capabilityDecisionTokens: capabilityDecisionTokens,
+                        glossaryApplied: usedGlossary));
                 return null;
             }
 
@@ -357,6 +404,17 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                 this.translationCache.Remember(
                     cacheKey,
                     translatedText);
+                PluginRuntimeLog.Debug(
+                    this.pluginLog,
+                    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+                        this.capabilityScope,
+                        "chat/completions",
+                        StructuredDialogueProviderCapability.JsonSchema,
+                        usedGlossary,
+                        rawStructuredPayload.Length,
+                        translatedText.Length,
+                        rawStructuredPayload,
+                        translatedText));
                 return translatedText;
             }
 
@@ -374,7 +432,23 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(this.pluginLog, $"OpenRouter structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+                    "OpenRouter",
+                    this.model,
+                    StructuredDialogueProviderCapability.JsonSchema,
+                    "exception",
+                    ex.Message,
+                    ex is HttpRequestException httpRequestException &&
+                    httpRequestException.StatusCode.HasValue
+                        ? (int)httpRequestException.StatusCode.Value
+                        : null,
+                    ex.Message,
+                    this.capabilityScope.EndpointScope,
+                    "chat/completions",
+                    capabilityDecisionTokens,
+                    usedGlossary));
             return null;
         }
     }

--- a/Translators/OpenRouterTranslator.cs
+++ b/Translators/OpenRouterTranslator.cs
@@ -5,12 +5,14 @@
 
 using System.Net.Http.Json;
 using Echoglossian.PluginUI.Helpers;
+using Echoglossian.Translators.Capabilities;
 using Echoglossian.Translators.Helpers;
 
 namespace Echoglossian.Translators;
 
 public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
 {
+    private readonly LlmCapabilityScope capabilityScope;
     private const string DefaultModel = "mistral";
     private const string DefaultOpenRouterUrl = "https://openrouter.ai/api/v1/";
     private readonly string apiKey;
@@ -34,6 +36,11 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
         this.openRouterUrl = string.IsNullOrWhiteSpace(config.OpenRouterBaseUrl)
             ? DefaultOpenRouterUrl
             : config.OpenRouterBaseUrl!;
+        this.capabilityScope = LlmCapabilityPolicyService.CreateScope(
+            Echoglossian.TransEngines.OpenRouter,
+            "OpenRouter",
+            this.openRouterUrl,
+            this.model);
         this.promptTemplate = string.IsNullOrWhiteSpace(config.OpenRouterPrompt)
             ? PromptTemplateManager.GetDefaultPrompt(Echoglossian.PromptType.OpenRouter)
             : config.OpenRouterPrompt;
@@ -176,21 +183,22 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
             targetLanguage,
             dialogueContext);
 
-        var request = new
+        var request = new Dictionary<string, object>
         {
-            this.model,
-            messages = new[]
+            ["model"] = this.model,
+            ["messages"] = new[]
             {
                 new { role = "user", content = prompt },
             },
-            this.temperature,
         };
+        var temperatureWasSent = this.TryAddTemperature(request);
 
         try
         {
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
                 request).ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var jsonResponse =
@@ -271,15 +279,14 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                         sourceLanguage,
                         targetLanguage),
                     structuredRequest);
-            var request = new
+            var request = new Dictionary<string, object>
             {
-                this.model,
-                messages = new[]
+                ["model"] = this.model,
+                ["messages"] = new[]
                 {
                     new { role = "user", content = structuredPrompt },
                 },
-                this.temperature,
-                tools = new[]
+                ["tools"] = new[]
                 {
                     new
                     {
@@ -293,7 +300,7 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                         },
                     },
                 },
-                tool_choice = new
+                ["tool_choice"] = new
                 {
                     type = "function",
                     function = new
@@ -302,10 +309,12 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                     },
                 },
             };
+            var temperatureWasSent = this.TryAddTemperature(request);
 
             var response = await this.httpClient.PostAsJsonAsync(
                 "chat/completions",
                 request).ConfigureAwait(false);
+            await this.LearnTemperatureFailureAsync(response, temperatureWasSent).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var responseJson =
@@ -327,9 +336,7 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                     usedGlossary,
                     structuredValidation.FailureReason ??
                     "unknown-structured-dialogue-failure");
-                PluginRuntimeLog.Debug(
-                    this.pluginLog,
-                    $"OpenRouter structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
+                PluginRuntimeLog.Debug(this.pluginLog, $"OpenRouter structured dialogue path rejected provider output and will fall back to plain-text: {structuredValidation.FailureReason ?? "unknown-structured-dialogue-failure"}");
                 return null;
             }
 
@@ -361,9 +368,7 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
                 false,
                 usedGlossary,
                 ex.Message);
-            PluginRuntimeLog.Debug(
-                this.pluginLog,
-                $"OpenRouter structured dialogue path failed and will fall back to plain-text: {ex.Message}");
+            PluginRuntimeLog.Debug(this.pluginLog, $"OpenRouter structured dialogue path failed and will fall back to plain-text: {ex.Message}");
             return null;
         }
     }
@@ -389,6 +394,41 @@ public class OpenRouterTranslator : ITranslator, IDialogueContextAwareTranslator
             prompt,
             dialogueContext.Value,
             FixText);
+    }
+
+    private bool TryAddTemperature(Dictionary<string, object> request)
+    {
+        if (!LlmCapabilityPolicyService.TryResolveTemperature(
+                this.capabilityScope,
+                this.temperature,
+                out var sanitizedTemperature,
+                out _))
+        {
+            return false;
+        }
+
+        request.Add("temperature", sanitizedTemperature);
+        return true;
+    }
+
+    private async Task LearnTemperatureFailureAsync(
+        HttpResponseMessage response,
+        bool temperatureWasSent)
+    {
+        if (response.IsSuccessStatusCode || !temperatureWasSent)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+            this.capabilityScope,
+            LlmCapabilityParameterName.Temperature,
+            (int)response.StatusCode,
+            responseText);
+        PluginRuntimeLog.Debug(
+            this.pluginLog,
+            $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
     }
 
     private class OpenRouterResponse

--- a/Translators/StructuredDialogueTranslationMetadata.cs
+++ b/Translators/StructuredDialogueTranslationMetadata.cs
@@ -14,6 +14,12 @@ namespace Echoglossian.Translators;
 /// <param name="QuestNameOriginal">The original quest name when relevant.</param>
 /// <param name="SpeakerOriginal">The original visible speaker name.</param>
 /// <param name="SpeakerRoleHint">An optional role hint such as npc or player.</param>
+/// <param name="SpeakerGenderHint">An optional resolved speaker gender hint.</param>
+/// <param name="AddresseeOriginal">An optional resolved addressee name.</param>
+/// <param name="AddresseeRoleHint">An optional resolved addressee role hint.</param>
+/// <param name="AddresseeGenderHint">An optional resolved addressee gender hint.</param>
+/// <param name="MetadataProvenance">An optional metadata source label.</param>
+/// <param name="MetadataConfidenceTier">An optional metadata confidence tier.</param>
 /// <param name="PronounHint">An optional operator or runtime pronoun hint.</param>
 /// <param name="SubjectHint">An optional omitted-subject hint.</param>
 public readonly record struct StructuredDialogueTranslationMetadata(
@@ -23,6 +29,18 @@ public readonly record struct StructuredDialogueTranslationMetadata(
     string? SpeakerOriginal,
     [property: JsonPropertyName("speaker_role_hint")]
     string? SpeakerRoleHint,
+    [property: JsonPropertyName("speaker_gender_hint")]
+    string? SpeakerGenderHint,
+    [property: JsonPropertyName("addressee_original")]
+    string? AddresseeOriginal,
+    [property: JsonPropertyName("addressee_role_hint")]
+    string? AddresseeRoleHint,
+    [property: JsonPropertyName("addressee_gender_hint")]
+    string? AddresseeGenderHint,
+    [property: JsonPropertyName("metadata_provenance")]
+    string? MetadataProvenance,
+    [property: JsonPropertyName("metadata_confidence_tier")]
+    string? MetadataConfidenceTier,
     [property: JsonPropertyName("pronoun_hint")]
     string? PronounHint,
     [property: JsonPropertyName("subject_hint")]

--- a/Translators/StructuredDialogueTranslationMetadata.cs
+++ b/Translators/StructuredDialogueTranslationMetadata.cs
@@ -40,7 +40,7 @@ public readonly record struct StructuredDialogueTranslationMetadata(
     [property: JsonPropertyName("metadata_provenance")]
     string? MetadataProvenance,
     [property: JsonPropertyName("metadata_confidence_tier")]
-    string? MetadataConfidenceTier,
+    int? MetadataConfidenceTier,
     [property: JsonPropertyName("pronoun_hint")]
     string? PronounHint,
     [property: JsonPropertyName("subject_hint")]

--- a/Translators/TranslationService.cs
+++ b/Translators/TranslationService.cs
@@ -124,9 +124,10 @@ public class TranslationService
       Action<string, string, string, int, string, TimeSpan>? recordTransientFailedTranslation = null,
       Action<int, TranslationFailureClassification>? reportTranslationFailure = null,
       Func<TranslationSurfaceGroup, TranslatorResolution>? translatorResolver = null,
-      Func<string, SourceClientLanguage?>? sourceLanguageResolver = null)
+      Func<string, SourceClientLanguage?>? sourceLanguageResolver = null,
+      Action<string>? debugLog = null)
   {
-    this.debugLog = null;
+    this.debugLog = debugLog;
     this.sanitizeText = sanitizeText;
     this.translationEngineId = translationEngine;
     this.isKnownFailedTranslation = isKnownFailedTranslation;
@@ -1151,7 +1152,12 @@ public class TranslationService
     var useDialogueContext = this.WillUseDialogueContext(
         dialogueContext,
         resolvedTranslatorResolution);
-
+    this.LogDialogueContextSummary(
+        useDialogueContext,
+        dialogueContext,
+        resolvedTranslatorResolution.TranslationEngineId,
+        surfaceGroup,
+        resolvedOriginContext);
     var glossaryProtection = this.ProtectDialogueGlossaryTerms(
         parsedText,
         resolvedSourceLanguage.ProviderCode,

--- a/Translators/TranslationService.cs
+++ b/Translators/TranslationService.cs
@@ -5,6 +5,7 @@
 
 using Echoglossian.Cache;
 using Echoglossian.DBHelpers;
+using Echoglossian.Translators.Helpers;
 using Echoglossian.Translators.OpenAI;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -1150,27 +1151,38 @@ public class TranslationService
     var useDialogueContext = this.WillUseDialogueContext(
         dialogueContext,
         resolvedTranslatorResolution);
+
+    var glossaryProtection = this.ProtectDialogueGlossaryTerms(
+        parsedText,
+        resolvedSourceLanguage.ProviderCode,
+        targetLanguage,
+        useDialogueContext);
+    var providerInputText = glossaryProtection.Occurrences.Count > 0
+        ? glossaryProtection.ProtectedText
+        : parsedText;
     cancellationToken.ThrowIfCancellationRequested();
     var stopwatch = Stopwatch.StartNew();
     var finalDialogueText = useDialogueContext &&
                             resolvedTranslatorResolution.Translator is IDialogueContextAwareTranslator contextAwareTranslator
         ? await contextAwareTranslator.TranslateAsync(
-            parsedText,
+            providerInputText,
             resolvedSourceLanguage.ProviderCode,
             targetLanguage,
             dialogueContext!.Value).WaitAsync(cancellationToken).ConfigureAwait(false)
         : await resolvedTranslatorResolution.Translator.TranslateAsync(
-            parsedText,
+            providerInputText,
             resolvedSourceLanguage.ProviderCode,
             targetLanguage).WaitAsync(cancellationToken).ConfigureAwait(false);
-    var acceptanceResult = this.AcceptTranslatedResultOrFallback(
+    var acceptanceResult = this.AcceptDialogueGlossaryResultOrFallback(
         finalDialogueText,
+        glossaryProtection,
         parsedText,
         sanitizedText,
         normalizedSourceLanguage,
         normalizedTargetLanguage,
         resolvedOriginContext,
-        resolvedTranslatorResolution.TranslationEngineId);
+        resolvedTranslatorResolution.TranslationEngineId,
+        surfaceGroup);
     stopwatch.Stop();
     this.RecordTranslationMetric(
         acceptanceResult,
@@ -1411,6 +1423,108 @@ public class TranslationService
   }
 
   /// <summary>
+  ///     Accepts one dialogue translation result after restoring any protected
+  ///     glossary markers; otherwise records a transient glossary failure and
+  ///     falls back to the sanitized source text.
+  /// </summary>
+  /// <param name="translatedText">The translated text candidate.</param>
+  /// <param name="glossaryProtection">The protected glossary request state.</param>
+  /// <param name="parsedText">The parsed source text sent to the translator.</param>
+  /// <param name="sanitizedText">The sanitized source text shown on fallback.</param>
+  /// <param name="normalizedSourceLanguage">The normalized source language code.</param>
+  /// <param name="normalizedTargetLanguage">The normalized target language code.</param>
+  /// <param name="resolvedOriginContext">The resolved origin context for diagnostics.</param>
+  /// <param name="translationEngineId">The effective translation engine identifier.</param>
+  /// <param name="surfaceGroup">The translation surface group.</param>
+  /// <returns>The accepted translation result or the sanitized fallback.</returns>
+  private TranslationAcceptanceResult AcceptDialogueGlossaryResultOrFallback(
+      string? translatedText,
+      DialogueGlossaryTermProtector.ProtectionResult glossaryProtection,
+      string parsedText,
+      string sanitizedText,
+      string normalizedSourceLanguage,
+      string normalizedTargetLanguage,
+      string? resolvedOriginContext,
+      int translationEngineId,
+      TranslationSurfaceGroup surfaceGroup)
+  {
+    if (glossaryProtection.Occurrences.Count == 0 ||
+        string.IsNullOrWhiteSpace(translatedText))
+    {
+      return this.AcceptTranslatedResultOrFallback(
+          translatedText,
+          parsedText,
+          sanitizedText,
+          normalizedSourceLanguage,
+          normalizedTargetLanguage,
+          resolvedOriginContext,
+          translationEngineId);
+    }
+
+    var restoreResult = DialogueGlossaryTermProtector.TryRestore(
+        translatedText,
+        glossaryProtection);
+    if (restoreResult.Succeeded)
+    {
+      return this.AcceptTranslatedResultOrFallback(
+          restoreResult.RestoredText,
+          parsedText,
+          sanitizedText,
+          normalizedSourceLanguage,
+          normalizedTargetLanguage,
+          resolvedOriginContext,
+          translationEngineId);
+    }
+
+    this.debugLog?.Invoke(
+        $"[{GetSurfaceScope(surfaceGroup, resolvedOriginContext)}] TranslationService: dialogue glossary restore failed - reason={restoreResult.FailureReason}");
+    if (!string.IsNullOrWhiteSpace(restoreResult.FailureReason))
+    {
+      this.RecordTransientFailedTranslation(
+          parsedText,
+          normalizedSourceLanguage,
+          normalizedTargetLanguage,
+          restoreResult.FailureReason,
+          translationEngineId);
+    }
+
+    return new TranslationAcceptanceResult(
+        sanitizedText,
+        false,
+        restoreResult.FailureReason);
+  }
+
+  /// <summary>
+  ///     Writes a non-sensitive dialogue-context summary when the current
+  ///     request will actually use the captured dialogue contract.
+  /// </summary>
+  /// <param name="useDialogueContext">Whether the translator will consume the dialogue context.</param>
+  /// <param name="dialogueContext">The optional captured dialogue context.</param>
+  /// <param name="translationEngineId">The effective translation engine id.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="originContext">The resolved origin context.</param>
+  private void LogDialogueContextSummary(
+      bool useDialogueContext,
+      DialogueTranslationContext? dialogueContext,
+      int translationEngineId,
+      TranslationSurfaceGroup surfaceGroup,
+      string? originContext)
+  {
+    if (this.debugLog == null ||
+        !useDialogueContext ||
+        !dialogueContext.HasValue)
+    {
+      return;
+    }
+
+    var surfaceScope = GetSurfaceScope(surfaceGroup, originContext);
+    var summary = DialogueContextPromptHelper.SummarizeDialogueContextForDiagnostics(
+        dialogueContext.Value);
+    this.debugLog(
+        $"[{surfaceScope}] TranslationService: dialogue context summary - engineId={translationEngineId}, {summary}");
+  }
+
+  /// <summary>
   ///     Resolves the square-bracketed diagnostic scope for one translation
   ///     request.
   /// </summary>
@@ -1424,6 +1538,38 @@ public class TranslationService
     return string.IsNullOrWhiteSpace(originContext)
         ? surfaceGroup.ToString()
         : originContext;
+  }
+
+  /// <summary>
+  ///     Protects exact glossary terms for dialogue-family LLM requests while
+  ///     leaving non-dialogue and glossary-free requests untouched.
+  /// </summary>
+  /// <param name="parsedText">The parsed visible source text.</param>
+  /// <param name="sourceLanguage">The provider source language code.</param>
+  /// <param name="targetLanguage">The requested target language code.</param>
+  /// <param name="useDialogueContext">Whether the active request uses dialogue context.</param>
+  /// <returns>The protected glossary state for the request.</returns>
+  private DialogueGlossaryTermProtector.ProtectionResult ProtectDialogueGlossaryTerms(
+      string parsedText,
+      string sourceLanguage,
+      string targetLanguage,
+      bool useDialogueContext)
+  {
+    if (!useDialogueContext)
+    {
+      return new DialogueGlossaryTermProtector.ProtectionResult(
+          parsedText,
+          parsedText,
+          string.Empty,
+          []);
+    }
+
+    var glossaryEntries = StructuredDialogueGlossaryStore.GetEntries(
+        sourceLanguage,
+        targetLanguage);
+    return DialogueGlossaryTermProtector.Protect(
+        parsedText,
+        glossaryEntries);
   }
 
   /// <summary>

--- a/Translators/TranslationService.cs
+++ b/Translators/TranslationService.cs
@@ -910,7 +910,7 @@ public class TranslationService
   /// <param name="dialogueContext">The optional dialogue context.</param>
   /// <returns>
   ///     <see langword="true" /> when the active translator supports dialogue
-  ///     context and at least one prior turn is available; otherwise,
+  ///     context; otherwise,
   ///     <see langword="false" />.
   /// </returns>
   internal bool WillUseDialogueContext(
@@ -932,7 +932,7 @@ public class TranslationService
   /// </param>
   /// <returns>
   ///     <see langword="true" /> when the captured translator supports
-  ///     dialogue context and at least one prior turn is available; otherwise,
+  ///     dialogue context; otherwise,
   ///     <see langword="false" />.
   /// </returns>
   internal bool WillUseDialogueContext(
@@ -940,7 +940,6 @@ public class TranslationService
       TranslatorResolution translatorResolution)
   {
     return dialogueContext.HasValue &&
-           dialogueContext.Value.PriorTurns.Count > 0 &&
            translatorResolution.Translator is IDialogueContextAwareTranslator;
   }
 

--- a/Translators/TranslationService.cs
+++ b/Translators/TranslationService.cs
@@ -1080,6 +1080,7 @@ public class TranslationService
       CancellationToken cancellationToken,
       TranslatorResolution? translatorResolution = null)
   {
+    cancellationToken.ThrowIfCancellationRequested();
     var resolvedOriginContext = ResolveOriginContext(
         originContext,
         callerMemberName,
@@ -1149,6 +1150,7 @@ public class TranslationService
     var useDialogueContext = this.WillUseDialogueContext(
         dialogueContext,
         resolvedTranslatorResolution);
+    cancellationToken.ThrowIfCancellationRequested();
     var stopwatch = Stopwatch.StartNew();
     var finalDialogueText = useDialogueContext &&
                             resolvedTranslatorResolution.Translator is IDialogueContextAwareTranslator contextAwareTranslator

--- a/Translators/TranslationService.cs
+++ b/Translators/TranslationService.cs
@@ -374,6 +374,39 @@ public class TranslationService
         targetLanguage,
         null,
         TranslationSurfaceGroup.Default,
+        CancellationToken.None,
+        originContext,
+        callerMemberName,
+        callerFilePath).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">Source text language.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+  /// <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+  /// <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      string sourceLanguage,
+      string targetLanguage,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsync(
+        text,
+        sourceLanguage,
+        targetLanguage,
+        null,
+        TranslationSurfaceGroup.Default,
+        cancellationToken,
         originContext,
         callerMemberName,
         callerFilePath).ConfigureAwait(false);
@@ -407,7 +440,42 @@ public class TranslationService
         sourceLanguage,
         originContext,
         callerMemberName,
-        callerFilePath).ConfigureAwait(false);
+        callerFilePath,
+        CancellationToken.None).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously using a captured source contract while
+  ///     observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context.</param>
+  /// <param name="callerMemberName">The caller member name.</param>
+  /// <param name="callerFilePath">The caller file path.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      SourceClientLanguage sourceLanguage,
+      string targetLanguage,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage.ProviderCode,
+        targetLanguage,
+        null,
+        TranslationSurfaceGroup.Default,
+        sourceLanguage,
+        originContext,
+        callerMemberName,
+        callerFilePath,
+        cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>
@@ -440,6 +508,41 @@ public class TranslationService
         targetLanguage,
         null,
         surfaceGroup,
+        CancellationToken.None,
+        originContext,
+        callerMemberName,
+        callerFilePath).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously for a surface group while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">Source text language.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+  /// <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+  /// <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      string sourceLanguage,
+      string targetLanguage,
+      TranslationSurfaceGroup surfaceGroup,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsync(
+        text,
+        sourceLanguage,
+        targetLanguage,
+        null,
+        surfaceGroup,
+        cancellationToken,
         originContext,
         callerMemberName,
         callerFilePath).ConfigureAwait(false);
@@ -475,7 +578,44 @@ public class TranslationService
         sourceLanguage,
         originContext,
         callerMemberName,
-        callerFilePath).ConfigureAwait(false);
+        callerFilePath,
+        CancellationToken.None).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously for a surface group using a captured
+  ///     source contract while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context.</param>
+  /// <param name="callerMemberName">The caller member name.</param>
+  /// <param name="callerFilePath">The caller file path.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      SourceClientLanguage sourceLanguage,
+      string targetLanguage,
+      TranslationSurfaceGroup surfaceGroup,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage.ProviderCode,
+        targetLanguage,
+        null,
+        surfaceGroup,
+        sourceLanguage,
+        originContext,
+        callerMemberName,
+        callerFilePath,
+        cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>
@@ -509,6 +649,41 @@ public class TranslationService
         originContext,
         callerMemberName: string.Empty,
         callerFilePath: string.Empty,
+        CancellationToken.None,
+        translatorResolution).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text using a captured translator resolution while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="translatorResolution">The engine and translator instance captured for the operation.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  internal async Task<string> TranslateAsync(
+      string text,
+      SourceClientLanguage sourceLanguage,
+      string targetLanguage,
+      TranslationSurfaceGroup surfaceGroup,
+      TranslatorResolution translatorResolution,
+      CancellationToken cancellationToken,
+      string? originContext = null)
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage.ProviderCode,
+        targetLanguage,
+        null,
+        surfaceGroup,
+        sourceLanguage,
+        originContext,
+        callerMemberName: string.Empty,
+        callerFilePath: string.Empty,
+        cancellationToken,
         translatorResolution).ConfigureAwait(false);
   }
 
@@ -542,6 +717,41 @@ public class TranslationService
         targetLanguage,
         dialogueContext,
         TranslationSurfaceGroup.Default,
+        CancellationToken.None,
+        originContext,
+        callerMemberName,
+        callerFilePath).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously with dialogue context while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">Source text language.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="dialogueContext">Optional runtime-only short-lived dialogue context.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+  /// <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+  /// <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      string sourceLanguage,
+      string targetLanguage,
+      DialogueTranslationContext? dialogueContext,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsync(
+        text,
+        sourceLanguage,
+        targetLanguage,
+        dialogueContext,
+        TranslationSurfaceGroup.Default,
+        cancellationToken,
         originContext,
         callerMemberName,
         callerFilePath).ConfigureAwait(false);
@@ -577,7 +787,44 @@ public class TranslationService
         sourceLanguage,
         originContext,
         callerMemberName,
-        callerFilePath).ConfigureAwait(false);
+        callerFilePath,
+        CancellationToken.None).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously with dialogue context and a captured
+  ///     source contract while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context.</param>
+  /// <param name="callerMemberName">The caller member name.</param>
+  /// <param name="callerFilePath">The caller file path.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      SourceClientLanguage sourceLanguage,
+      string targetLanguage,
+      DialogueTranslationContext? dialogueContext,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage.ProviderCode,
+        targetLanguage,
+        dialogueContext,
+        TranslationSurfaceGroup.Default,
+        sourceLanguage,
+        originContext,
+        callerMemberName,
+        callerFilePath,
+        cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>
@@ -613,6 +860,44 @@ public class TranslationService
         originContext,
         callerMemberName: string.Empty,
         callerFilePath: string.Empty,
+        CancellationToken.None,
+        translatorResolution).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates dialogue text using a captured translator resolution while
+  ///     observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="translatorResolution">The engine and translator instance captured for the operation.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  internal async Task<string> TranslateAsync(
+      string text,
+      SourceClientLanguage sourceLanguage,
+      string targetLanguage,
+      DialogueTranslationContext? dialogueContext,
+      TranslationSurfaceGroup surfaceGroup,
+      TranslatorResolution translatorResolution,
+      CancellationToken cancellationToken,
+      string? originContext = null)
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage.ProviderCode,
+        targetLanguage,
+        dialogueContext,
+        surfaceGroup,
+        sourceLanguage,
+        originContext,
+        callerMemberName: string.Empty,
+        callerFilePath: string.Empty,
+        cancellationToken,
         translatorResolution).ConfigureAwait(false);
   }
 
@@ -652,7 +937,46 @@ public class TranslationService
         capturedSourceLanguage: null,
         originContext,
         callerMemberName,
-        callerFilePath).ConfigureAwait(false);
+        callerFilePath,
+        CancellationToken.None).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously with dialogue context and surface
+  ///     routing while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">Source text language.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="dialogueContext">Optional runtime-only short-lived dialogue context.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+  /// <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+  /// <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      string sourceLanguage,
+      string targetLanguage,
+      DialogueTranslationContext? dialogueContext,
+      TranslationSurfaceGroup surfaceGroup,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage,
+        targetLanguage,
+        dialogueContext,
+        surfaceGroup,
+        capturedSourceLanguage: null,
+        originContext,
+        callerMemberName,
+        callerFilePath,
+        cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>
@@ -687,7 +1011,46 @@ public class TranslationService
         sourceLanguage,
         originContext,
         callerMemberName,
-        callerFilePath).ConfigureAwait(false);
+        callerFilePath,
+        CancellationToken.None).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///     Translates text asynchronously with dialogue context, surface routing,
+  ///     and a captured source contract while observing cancellation.
+  /// </summary>
+  /// <param name="text">Text to translate.</param>
+  /// <param name="sourceLanguage">The captured source-language contract.</param>
+  /// <param name="targetLanguage">Target translation language.</param>
+  /// <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+  /// <param name="surfaceGroup">The coarse translation surface group.</param>
+  /// <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+  /// <param name="originContext">Optional explicit origin context.</param>
+  /// <param name="callerMemberName">The caller member name.</param>
+  /// <param name="callerFilePath">The caller file path.</param>
+  /// <returns>A task containing the translated or sanitized source text.</returns>
+  public async Task<string> TranslateAsync(
+      string text,
+      SourceClientLanguage sourceLanguage,
+      string targetLanguage,
+      DialogueTranslationContext? dialogueContext,
+      TranslationSurfaceGroup surfaceGroup,
+      CancellationToken cancellationToken,
+      string? originContext = null,
+      [CallerMemberName] string callerMemberName = "",
+      [CallerFilePath] string callerFilePath = "")
+  {
+    return await this.TranslateAsyncCore(
+        text,
+        sourceLanguage.ProviderCode,
+        targetLanguage,
+        dialogueContext,
+        surfaceGroup,
+        sourceLanguage,
+        originContext,
+        callerMemberName,
+        callerFilePath,
+        cancellationToken).ConfigureAwait(false);
   }
 
   /// <summary>
@@ -714,6 +1077,7 @@ public class TranslationService
       string? originContext,
       string callerMemberName,
       string callerFilePath,
+      CancellationToken cancellationToken,
       TranslatorResolution? translatorResolution = null)
   {
     var resolvedOriginContext = ResolveOriginContext(
@@ -792,11 +1156,11 @@ public class TranslationService
             parsedText,
             resolvedSourceLanguage.ProviderCode,
             targetLanguage,
-            dialogueContext!.Value).ConfigureAwait(false)
+            dialogueContext!.Value).WaitAsync(cancellationToken).ConfigureAwait(false)
         : await resolvedTranslatorResolution.Translator.TranslateAsync(
             parsedText,
             resolvedSourceLanguage.ProviderCode,
-            targetLanguage).ConfigureAwait(false);
+            targetLanguage).WaitAsync(cancellationToken).ConfigureAwait(false);
     var acceptanceResult = this.AcceptTranslatedResultOrFallback(
         finalDialogueText,
         parsedText,

--- a/docs/superpowers/plans/2026-08-10-issue-214-quest-dialogue-interlocutor-metadata-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-10-issue-214-quest-dialogue-interlocutor-metadata-implementation-plan.md
@@ -1,0 +1,315 @@
+# Issue 214 quest dialogue interlocutor metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the remaining `#214` scope on `issue-214-first-dialogue-speaker-context` / draft PR `#262` by deriving, persisting, and applying quest-scoped interlocutor metadata so first-line `Talk` and `BattleTalk` translations can carry addressee and gender hints without blocking Dalamud callbacks.
+
+**Architecture:** Keep `TranslationService` as the only translation orchestrator and treat interlocutor metadata as an auxiliary enrichment path. Accepted-quest work captures immutable managed quest state on the framework tick, then a background derivation pipeline reads quest DIALOG rows, upserts `QuestDialogueMetadata`, and later `Talk` / `BattleTalk` resolve tiered hints from accepted-quest metadata plus live actor snapshots before building `DialogueTranslationContext`.
+
+**Tech Stack:** C#/.NET 10, EF Core / SQLite migrations, Lumina raw quest sheets, existing `AcceptedQuestPrefetchRuntime`, `TranslationService`, `DialogueTranslationSessionStore`, `OwnedAsyncOperationSet`, xUnit, DalaMock where feasible, and PowerShell.
+
+## Global Constraints
+
+- Stay on the existing `issue-214-first-dialogue-speaker-context` branch and keep the work in draft PR `#262` to `v4-series`.
+- Do not split this remaining work into a new issue branch unless the current branch becomes unrecoverably conflicted.
+- No provider, database, file, model-list, prompt, glossary, configuration-persistence, or session operation may block a Dalamud framework/ImGui callback.
+- Capture native data into immutable managed values before awaits. Never carry Atk pointers, spans, or borrowed buffers across `await`/`Task.Run`.
+- Every task must be owned/observed/cancellable, stale results must be rejected, and native mutation must happen only after live pointer re-resolution on the framework thread.
+- Reuse `TranslationService`, the existing broker/caches, `SourcePublicationLifecycle`, and DB-first semantics; do not create a second translation pipeline or queue.
+- `IPlayerState.Sex` is the primary local-player sex source when the addressee is the player.
+- Prefer stronger live actor or NPC evidence when it exists.
+- The quest-metadata path stays auxiliary: no confident match means the current dialogue flow continues unchanged.
+- Persist the logical identity exactly as `QuestId + QuestSequence + SourceLanguageCode + GameVersion + SourceRowKey + SourceTextHash`, versioned by `DerivationVersion`.
+- Upsert matching logical keys instead of creating duplicates.
+
+---
+
+## File map
+
+### New files
+
+- `EFCoreSqlite/Models/Journal/QuestDialogueMetadata.cs` — dedicated persisted entity for derived quest dialogue hints.
+- `NativeUI/Helpers/DialogueInterlocutorMetadata.cs` — immutable lookup/hint/snapshot records shared by DB, resolver, and handlers.
+- `NativeUI/Helpers/QuestDialogueMetadataDerivation.cs` — quest-sheet DIALOG row acquisition and deterministic metadata derivation.
+- `NativeUI/Helpers/DialogueInterlocutorMetadataResolver.cs` — accepted-quest lookup plus live-actor/player hint fusion.
+- `Echoglossian.Tests/QuestDialogueMetadataPersistenceTests.cs` — DB upsert and exact-match lookup coverage.
+- `Echoglossian.Tests/QuestDialogueMetadataDerivationTests.cs` — deterministic quest-sheet derivation coverage.
+- `Echoglossian.Tests/DialogueInterlocutorMetadataResolverTests.cs` — tiered precedence and player/live fusion coverage.
+
+### Modified files
+
+- `Echoglossian.cs` — add `IPlayerState` plugin service access for the live player snapshot path.
+- `EFCoreSqlite/EchoglossianDBContext.cs` — table, `DbSet`, and indexes for `QuestDialogueMetadata`.
+- `EFCoreSqlite/Migrations/` — generated `AddQuestDialogueMetadata` migration files.
+- `DBHelpers/DbOperations.cs` — async exact-match lookup and batch upsert for quest dialogue metadata.
+- `NativeUI/Helpers/QuestContentHash.cs` — add a deterministic single-line hash helper reused by derivation and runtime lookup.
+- `NativeUI/Helpers/AcceptedQuestPrefetchRuntime.cs` — schedule owned background metadata generation from the existing accepted-quest capture flow.
+- `NativeUI/Helpers/AddonHandlerWiring.cs` — inject the new async dialogue-hint resolver into `TalkHandler` and `BattleTalkHandler`.
+- `NativeUI/AddonHandlers/Talk/TalkHandler.cs` — resolve and apply interlocutor hints before first-line translation.
+- `NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs` — same as `TalkHandler`.
+- `Translators/DialogueTranslationContext.cs` — extend runtime dialogue context with optional speaker/addressee metadata.
+- `Translators/DialogueTranslationSessionStore.cs` — accept resolved hint metadata when building one request context.
+- `Translators/StructuredDialogueTranslationMetadata.cs` — add explicit speaker/addressee gender and provenance fields.
+- `Translators/Helpers/StructuredDialogueTranslationRequestBuilder.cs` — project the new metadata into the structured contract.
+- `Translators/Helpers/DialogueContextPromptHelper.cs` — carry the same hints through plain-text providers and the dialogue cache key.
+- `Echoglossian.Tests/StructuredDialogueTranslationRequestBuilderTests.cs` — structured request projection coverage.
+- `Echoglossian.Tests/DialogueContextPromptHelperTests.cs` — prompt and cache-key regressions for the new hints.
+- `Echoglossian.Tests/AcceptedQuestPrefetchRuntimeContractTests.cs` — background scheduling contract checks.
+- `Echoglossian.Tests/NativeDialogueHandlerLifecycleTests.cs` — first-line handler integration and stale-result rejection tests.
+
+## Interfaces produced and consumed
+
+```csharp
+public sealed class QuestDialogueMetadata
+{
+    public long Id { get; set; }
+    public uint QuestId { get; set; }
+    public ushort QuestSequence { get; set; }
+    public string SourceLanguageCode { get; set; } = string.Empty;
+    public string GameVersion { get; set; } = string.Empty;
+    public string QuestSheetId { get; set; } = string.Empty;
+    public string QuestTextSheetName { get; set; } = string.Empty;
+    public string SourceRowKey { get; set; } = string.Empty;
+    public string SourceTextHash { get; set; } = string.Empty;
+    public string SourceTextPreview { get; set; } = string.Empty;
+    public string SpeakerHint { get; set; } = string.Empty;
+    public string AddresseeHint { get; set; } = string.Empty;
+    public string SpeakerRoleHint { get; set; } = string.Empty;
+    public string AddresseeRoleHint { get; set; } = string.Empty;
+    public string Provenance { get; set; } = string.Empty;
+    public int ConfidenceTier { get; set; }
+    public string DerivationVersion { get; set; } = string.Empty;
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime UpdatedAtUtc { get; set; }
+}
+
+internal readonly record struct QuestDialogueMetadataLookup(
+    uint QuestId,
+    ushort QuestSequence,
+    string SourceLanguageCode,
+    string GameVersion,
+    string SourceTextHash,
+    string DerivationVersion);
+
+internal readonly record struct QuestDialogueSheetEntry(
+    string RowKey,
+    string Text,
+    int SourceOrder);
+
+internal readonly record struct LiveDialogueActorSnapshot(
+    string Name,
+    uint? NpcId,
+    string RoleHint,
+    string GenderHint,
+    string RaceHint,
+    string BodyTypeHint);
+
+internal readonly record struct DialogueInterlocutorHints(
+    string SpeakerRoleHint,
+    string SpeakerGenderHint,
+    string AddresseeHint,
+    string AddresseeRoleHint,
+    string AddresseeGenderHint,
+    string MetadataProvenance,
+    int MetadataConfidenceTier);
+```
+
+```csharp
+public Task<QuestDialogueMetadata?> FindQuestDialogueMetadataAsync(
+    QuestDialogueMetadataLookup lookup,
+    CancellationToken cancellationToken);
+
+public Task UpsertQuestDialogueMetadataBatchAsync(
+    IReadOnlyList<QuestDialogueMetadata> rows,
+    CancellationToken cancellationToken);
+
+public static IReadOnlyList<QuestDialogueSheetEntry> ReadDialogueEntries(
+    QuestProgressSnapshot questProgressSnapshot);
+
+public static IReadOnlyList<QuestDialogueMetadata> BuildEntries(
+    QuestProgressSnapshot questProgressSnapshot,
+    IReadOnlyList<QuestDialogueSheetEntry> dialogueEntries,
+    string sourceLanguageCode,
+    string gameVersion,
+    string derivationVersion,
+    DateTime observedAtUtc);
+
+public static Task<DialogueInterlocutorHints> ResolveAsync(
+    string speakerName,
+    string sourceText,
+    SourceClientLanguage sourceLanguage,
+    Func<QuestDialogueMetadataLookup, CancellationToken, Task<QuestDialogueMetadata?>> findQuestDialogueMetadataAsync,
+    CancellationToken cancellationToken);
+```
+
+```csharp
+public static DialogueTranslationContext BuildContext(
+    string sessionNamespace,
+    string sessionKey,
+    string speakerName,
+    string sourceText,
+    int historyLimit,
+    TimeSpan ttl,
+    DialogueInterlocutorHints hints,
+    DateTime? observedAtUtc = null);
+```
+
+## Task 1: Persist exact-match quest dialogue metadata
+
+- [ ] Add `QuestDialogueMetadataPersistenceTests` that seeds rows differing by `QuestSequence`, `SourceLanguageCode`, `GameVersion`, `SourceRowKey`, `SourceTextHash`, and `DerivationVersion`, then asserts lookup only reuses the exact logical key and upsert replaces older duplicates.
+- [ ] Add `QuestDialogueMetadata` under `EFCoreSqlite/Models/Journal` and register `DbSet<QuestDialogueMetadata>` plus a unique lookup index in `EchoglossianDbContext`.
+- [ ] Implement `FindQuestDialogueMetadataAsync` and `UpsertQuestDialogueMetadataBatchAsync` in `DbOperations.cs` using `AsNoTracking`, `ToListAsync(cancellationToken)`, and merge-on-logical-key behavior.
+- [ ] Generate the `AddQuestDialogueMetadata` migration and stage the generated files from `EFCoreSqlite/Migrations/`.
+- [ ] Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~QuestDialogueMetadataPersistenceTests"
+```
+
+- [ ] Commit:
+
+```powershell
+git add -- EFCoreSqlite DBHelpers\DbOperations.cs Echoglossian.Tests\QuestDialogueMetadataPersistenceTests.cs
+git commit -m "feat(#214): persist quest dialogue metadata"
+```
+
+## Task 2: Derive deterministic metadata from quest DIALOG rows
+
+- [ ] Write `QuestDialogueMetadataDerivationTests` around synthetic row-key sequences such as `_SEQ_00`, `*_NAME_000_000`, `*_000_000`, `*_NAME_000_001`, `*_000_001`; assert speaker pairing uses the matching `*_NAME_*` row, sequence assignment follows the latest `_SEQ_` boundary, adjacent different-speaker turns become weak addressee fallbacks, and `SourceTextHash` is stable.
+- [ ] Extend `QuestContentHash` with a deterministic `ComputeLine(string sourceRowKey, string sourceText)` helper that returns the same 16-character lowercase hex fingerprint format already used for quest content hashes.
+- [ ] Implement `QuestDialogueMetadataDerivation.ReadDialogueEntries(...)` so quest-sheet acquisition skips `_SEQ_`, `_TODO_`, `_SYSTEM_`, and empty values, while preserving all populated DIALOG / NAME rows in source order.
+- [ ] Implement `BuildEntries(...)` with this exact heuristic:
+  - use the most recent `_SEQ_NN` row to establish `QuestSequence`;
+  - pair `*_NAME_xxx_yyy` rows with text rows sharing the same numeric suffix;
+  - use the paired speaker row as `SpeakerHint` and `SpeakerRoleHint = "npc"`;
+  - set `AddresseeHint` to the next different named speaker in the same sequence, else the previous different named speaker in the same sequence;
+  - set `ConfidenceTier = 2` when both speaker and addressee come from named same-sequence evidence, `1` when only the adjacent-speaker fallback is available, and `0` when no safe addressee hint exists.
+- [ ] Keep `SourceRowKey`, `SourceTextHash`, `QuestSheetId`, and `QuestTextSheetName` on every derived row so later runtime reuse never falls back to a quest-global text search.
+- [ ] Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~QuestDialogueMetadataDerivationTests"
+```
+
+- [ ] Commit:
+
+```powershell
+git add -- NativeUI\Helpers\QuestDialogueMetadataDerivation.cs NativeUI\Helpers\QuestContentHash.cs Echoglossian.Tests\QuestDialogueMetadataDerivationTests.cs
+git commit -m "feat(#214): derive quest dialogue interlocutor metadata"
+```
+
+## Task 3: Generate quest dialogue metadata asynchronously from accepted quests
+
+- [ ] Extend `AcceptedQuestPrefetchRuntimeContractTests` with source-level checks proving the framework tick still calls `ScheduleAcceptedQuestPrefetch(...)`, and dialogue metadata generation is started through an owned background operation rather than inline DB or sheet work.
+- [ ] Reuse the existing accepted-quest capture path in `AcceptedQuestPrefetchRuntime.cs`: after `TryCaptureAcceptedQuestPrefetchWorkItem(...)` succeeds, start a second owned background operation that calls `ReadDialogueEntries(...)`, `BuildEntries(...)`, and `UpsertQuestDialogueMetadataBatchAsync(...)`.
+- [ ] Capture only immutable managed values before the background handoff: `QuestProgressSnapshot`, `SourceClientLanguage`, `GetGameVersion()`, `DerivationVersion`, and the accepted-quest generation number.
+- [ ] Reject stale work items by comparing the captured generation to the current accepted-quest generation before upsert, and swallow ordinary cancellation without noisy logs.
+- [ ] Do not block or serialize the framework tick on dialogue metadata completion. The accepted-quest scan remains the trigger; the heavy work lives entirely after the capture boundary.
+- [ ] Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~AcceptedQuestPrefetchRuntimeContractTests"
+```
+
+- [ ] Commit:
+
+```powershell
+git add -- NativeUI\Helpers\AcceptedQuestPrefetchRuntime.cs Echoglossian.Tests\AcceptedQuestPrefetchRuntimeContractTests.cs
+git commit -m "feat(#214): precompute quest dialogue metadata on quest accept"
+```
+
+## Task 4: Resolve tiered live/player/quest hints
+
+- [ ] Add `DialogueInterlocutorMetadataResolverTests` covering three exact outcomes:
+  - persisted accepted-quest metadata alone yields `QuestSheetDerivedExact`;
+  - persisted addressee + matching loaded live actor upgrades to `QuestSheetPlusLiveFusion`;
+  - persisted player addressee + `IPlayerState.Sex` yields `AddresseeGenderHint = "male"` or `"female"` without touching quest metadata.
+- [ ] Add `[PluginService] public static IPlayerState PlayerStateInterface { get; set; } = null!;` in `Echoglossian.cs`.
+- [ ] Create `DialogueInterlocutorMetadata.cs` and `DialogueInterlocutorMetadataResolver.cs`.
+- [ ] Implement `ResolveAsync(...)` with this order:
+  - resolve accepted quest ids with `QuestProgressResolver.TryCollectAcceptedQuestIds`;
+  - for each accepted quest, resolve current `QuestProgressSnapshot` and query `FindQuestDialogueMetadataAsync` by exact `QuestId + QuestSequence + source language + game version + source text hash`;
+  - require a unique hit, or a unique hit whose `SpeakerHint` matches the current visible speaker name;
+  - if the resolved addressee matches the local player name or `AddresseeRoleHint == "player"`, use `PlayerStateInterface.Sex`;
+  - if the resolved speaker/addressee name matches a loaded actor in `ObjectTableInterface`, capture a managed `LiveDialogueActorSnapshot` and prefer its gender/race/body-type hints over persisted unknowns.
+- [ ] Keep the native capture boundary strict: copy name, `DataId`, sex, race, and body-type into managed strings/values before the first `await`; do not store `Character*`, `Human*`, `Span<byte>`, or borrowed customize data on the resolver result.
+- [ ] Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~DialogueInterlocutorMetadataResolverTests"
+```
+
+- [ ] Commit:
+
+```powershell
+git add -- Echoglossian.cs NativeUI\Helpers\DialogueInterlocutorMetadata.cs NativeUI\Helpers\DialogueInterlocutorMetadataResolver.cs Echoglossian.Tests\DialogueInterlocutorMetadataResolverTests.cs
+git commit -m "feat(#214): resolve live and quest dialogue hints"
+```
+
+## Task 5: Extend dialogue context for both structured and plain-text providers
+
+- [ ] Add `StructuredDialogueTranslationRequestBuilderTests` and `DialogueContextPromptHelperTests` assertions that one context with `SpeakerGenderHint = "female"` and `AddresseeHint = "Alphinaud"` produces both a distinct cache key and explicit metadata lines, while an empty-hint context still serializes cleanly.
+- [ ] Extend `DialogueTranslationContext` with optional `SpeakerRoleHint`, `SpeakerGenderHint`, `AddresseeHint`, `AddresseeRoleHint`, `AddresseeGenderHint`, `MetadataProvenance`, and `MetadataConfidenceTier` trailing parameters so current call sites remain source-compatible.
+- [ ] Update `DialogueTranslationSessionStore.BuildContext(...)` to accept `DialogueInterlocutorHints` and place those fields only on the returned current-request context; retained prior turns remain unchanged runtime history.
+- [ ] Extend `StructuredDialogueTranslationMetadata` and `StructuredDialogueTranslationRequestBuilder.Build(...)` so the structured contract exposes `speaker_gender_hint`, `addressee_original`, `addressee_role_hint`, `addressee_gender_hint`, `metadata_provenance`, and `metadata_confidence_tier`.
+- [ ] Update `DialogueContextPromptHelper` so non-structured providers append only non-empty lines in this order: current speaker, speaker role, speaker gender, addressee, addressee role, addressee gender, previous turns. Also include these fields in `BuildDialogueContextCacheKey(...)`.
+- [ ] Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~StructuredDialogueTranslationRequestBuilderTests|FullyQualifiedName~DialogueContextPromptHelperTests"
+```
+
+- [ ] Commit:
+
+```powershell
+git add -- Translators\DialogueTranslationContext.cs Translators\DialogueTranslationSessionStore.cs Translators\StructuredDialogueTranslationMetadata.cs Translators\Helpers\StructuredDialogueTranslationRequestBuilder.cs Translators\Helpers\DialogueContextPromptHelper.cs Echoglossian.Tests\StructuredDialogueTranslationRequestBuilderTests.cs Echoglossian.Tests\DialogueContextPromptHelperTests.cs
+git commit -m "feat(#214): carry interlocutor hints through dialogue contracts"
+```
+
+## Task 6: Apply the resolver in Talk and BattleTalk
+
+- [ ] Extend `NativeDialogueHandlerLifecycleTests` with handler-level first-line coverage: inject a fake resolver that returns `AddresseeHint = "Alphinaud"` / `AddresseeGenderHint = "male"` and assert the first `IDialogueContextAwareTranslator` request receives those fields before any prior turns exist.
+- [ ] Add stale-result coverage proving a retired source generation cancels the metadata resolver path the same way it already cancels DB lookup and provider work.
+- [ ] Add one regression proving DB reuse does not call the hint resolver when an existing translated `TalkMessage` / `BattleTalkMessage` row already satisfies the request.
+- [ ] Update `AddonHandlerWiring.cs` so `TalkHandler` and `BattleTalkHandler` receive one additional delegate:
+
+```csharp
+Func<string, string, SourceClientLanguage, CancellationToken, Task<DialogueInterlocutorHints>>
+```
+
+- [ ] In both handlers, call that delegate only on the fresh-translation path after DB miss and before `DialogueTranslationSessionStore.BuildContext(...)`, then pass the resolved hints into the returned `DialogueTranslationContext`.
+- [ ] Keep all resolver, DB, translation, and persistence awaits under the existing `OwnedAsyncOperationSet` / `SourcePublicationLifecycle` ownership checks. If hint resolution finishes after the source retires, reject publication without mutating overlay or native state.
+- [ ] Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~NativeDialogueHandlerLifecycleTests"
+```
+
+- [ ] Commit:
+
+```powershell
+git add -- NativeUI\Helpers\AddonHandlerWiring.cs NativeUI\AddonHandlers\Talk\TalkHandler.cs NativeUI\AddonHandlers\Talk\BattleTalkHandler.cs Echoglossian.Tests\NativeDialogueHandlerLifecycleTests.cs
+git commit -m "fix(#214): apply quest interlocutor hints to first dialogue lines"
+```
+
+## Task 7: Validate #214 end-to-end and update PR 262
+
+- [ ] Run the full validation set required by repo policy:
+
+```powershell
+dotnet build Echoglossian.sln -c Debug --no-restore
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build
+dotnet build Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-restore
+dotnet test Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1
+git diff --check
+```
+
+- [ ] If `Echoglossian.xml` changed as part of the validated code edits, stage and commit it with the owning task. Do not overwrite unrelated local XML edits.
+- [ ] In game, verify on a real accepted quest that:
+  - quest acceptance schedules metadata generation asynchronously;
+  - a first `Talk` or `BattleTalk` line can use addressee metadata with no prior-turn history;
+  - a loaded actor match upgrades persisted unknown gender when possible;
+  - unrelated non-quest dialogue receives no accidental quest hint;
+  - callback responsiveness remains unchanged while DB/provider work is delayed.
+- [ ] Capture sanitized evidence for `#214` and update draft PR `#262` so its summary mentions quest-derived interlocutor metadata, `IPlayerState.Sex`, live actor fusion, and the remaining in-game validation results.
+- [ ] After the task-by-task review loop passes, request the most-capable whole-branch review before marking the branch ready for merge.

--- a/docs/superpowers/plans/2026-08-12-llm-capability-matrix-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-12-llm-capability-matrix-implementation-plan.md
@@ -1,0 +1,937 @@
+# LLM Capability Matrix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one conservative shared LLM capability matrix that disables incompatible UI controls, sanitizes provider payloads before send, learns exact-model incompatibilities from classified `400` responses, and keeps SQLite overlays synchronized with the existing live-model refresh flow.
+
+**Architecture:** Introduce a small shared capability layer under `Translators/Capabilities` that resolves one effective policy snapshot from static defaults plus SQLite overlays. Keep runtime lookups DB-free by loading persisted rules into a cache manager, reuse existing model managers to promote discovered models after live refresh, and route UI plus translator payload decisions through the same policy service so they cannot drift apart.
+
+**Tech Stack:** C#/.NET 10, EF Core SQLite migrations, existing model managers and engine UIs, `HttpClient`/OpenAI SDK request builders, xUnit + FluentAssertions, resx/ImGui, and PowerShell.
+
+## Global Constraints
+
+- Add one shared capability-policy layer for LLM engines only:
+  - OpenAI / ChatGPT and custom OpenAI-compatible
+  - Claude
+  - Gemini
+  - DeepSeek
+  - OpenRouter
+  - Ollama
+  - LM Studio
+- Drive both UI gating and runtime payload sanitization from the same effective policy resolution path.
+- Keep the behavior conservative:
+  - if support is unknown, the runtime omits the parameter;
+  - the UI shows the control disabled with a tooltip rather than pretending it is supported.
+- Reuse the existing live-model refresh flow as the single operator entrypoint for refreshing both model identity and capability overlays.
+- Store live and learned capability overlays in SQLite, not in user config.
+- Support exact-model rules and family-prefix inheritance.
+- Allow bounded auto-learning from clearly classifiable provider `400` errors.
+- No change to non-LLM translation engines.
+- No second model-discovery pipeline or second refresh button.
+- No replacement of current engine-specific translator classes.
+- No automatic promotion from one observed model error to an entire family.
+- No optimistic assumption that a successful request proves a parameter is universally supported.
+- No provider-body dumps, raw prompts, or credential material in logs.
+- No broad refactor of all model catalog code in this first slice.
+- Every LLM translator request path must resolve the effective capability snapshot before building its outbound payload.
+- Live refresh is best-effort and must not assume every provider returns complete capability metadata.
+- Refresh work remains asynchronous and owned by the existing refresh coordinator, with no callback blocking.
+
+---
+
+## File map
+
+### New files
+
+- `Translators/Capabilities/LlmCapabilityParameterName.cs` — canonical supported parameter names for the first slice.
+- `Translators/Capabilities/LlmCapabilitySupportState.cs` — `Unknown`, `Supported`, `Unsupported`.
+- `Translators/Capabilities/LlmCapabilityRuleMatchType.cs` — `ExactModel` and `FamilyPrefix`.
+- `Translators/Capabilities/LlmCapabilityScope.cs` — stable lookup identity containing engine, provider scope, endpoint scope, and model id.
+- `Translators/Capabilities/LlmCapabilityRuleDefinition.cs` — static or cached rule shape consumed by the resolver.
+- `Translators/Capabilities/LlmCapabilityParameterDecision.cs` — one resolved parameter decision including range, source, and reason.
+- `Translators/Capabilities/LlmCapabilitySnapshot.cs` — immutable resolved policy snapshot with `GetDecision(LlmCapabilityParameterName parameterName)`.
+- `Translators/Capabilities/LlmCapabilityStaticCatalog.cs` — committed conservative defaults by engine family and prefix.
+- `Translators/Capabilities/LlmCapabilityResolver.cs` — merges static defaults and persisted overlays conservatively.
+- `Translators/Capabilities/LlmCapabilityPolicyService.cs` — shared runtime/UI entrypoint for scope creation, snapshot lookup, temperature sanitization, and failure learning.
+- `Translators/Capabilities/LlmCapabilityRefreshPromoter.cs` — promotes discovered model ids into exact-model overlay rows using family rules.
+- `Translators/Capabilities/LlmCapabilityErrorClassifier.cs` — maps sanitized provider `400` responses into promotable exact-model rules or observation-only outcomes.
+- `Cache/LlmCapabilityCacheManager.cs` — in-memory rule and observation cache hydrated from SQLite at startup.
+- `DBHelpers/LlmCapabilityPersistenceHelper.cs` — additive SQLite upsert helpers for rules and observations.
+- `EFCoreSqlite/Models/LlmModelCapabilityRule.cs` — persisted conservative rule entity.
+- `EFCoreSqlite/Models/LlmModelCapabilityObservation.cs` — persisted audit trail for classified provider feedback.
+- `PluginUI/EngineConfigUI/LlmCapabilityUiHelper.cs` — returns disabled/enabled state, tooltip text, and numeric ranges for temperature controls.
+- `Echoglossian.Tests/LlmCapabilityResolverTests.cs`.
+- `Echoglossian.Tests/LlmCapabilityPersistenceTests.cs`.
+- `Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs`.
+- `Echoglossian.Tests/LlmCapabilityErrorClassifierTests.cs`.
+- `Echoglossian.Tests/LlmCapabilityUiHelperTests.cs`.
+
+### Modified files
+
+- `Echoglossian.cs` — initialize the new capability cache on plugin startup and clear it on shutdown.
+- `GeneralHelpers/RuntimeConfigurationRefresh.cs` — clear capability cache/runtime state on translation-signature changes when required.
+- `EFCoreSqlite/EchoglossianDbContext.cs` — add the new tables and indexes.
+- `EFCoreSqlite/Migrations/EchoglossianDbContextModelSnapshot.cs` and one new dated migration pair — additive schema update only.
+- `Translators/OpenAI/OpenAIModelManager.cs` — promote exact-model capability overlays after successful refresh.
+- `Translators/Claude/ClaudeModelManager.cs`, `Translators/Gemini/GeminiModelManager.cs`, `Translators/DeepSeek/DeepSeekModelManager.cs`, `Translators/Ollama/OllamaModelManager.cs`, `Translators/LmStudio/LmStudioModelManager.cs` — same promotion hook for discovered models.
+- `Translators/ChatGPTTranslator.cs`, `Translators/ClaudeTranslator.cs`, `Translators/GeminiTranslator.cs`, `Translators/DeepSeekTranslator.cs`, `Translators/OpenRouterTranslator.cs`, `Translators/OllamaTranslator.cs`, `Translators/LmStudioTranslator.cs` — omit unsupported parameters on plain and structured paths and record classified observations.
+- `PluginUI/EngineConfigUI/ChatGptEngineUI.cs`, `ClaudeEngineUI.cs`, `GeminiEngineUI.cs`, `DeepSeekEngineUI.cs`, `OpenRouterEngineUI.cs`, `OllamaEngineUI.cs`, `LmStudioEngineUI.cs` — disable incompatible temperature sliders with tooltips and policy ranges.
+- `Echoglossian.Tests/OpenAIModelManagerTests.cs`, `DeepSeekModelManagerTests.cs`, `LiveModelRefreshCoordinatorTests.cs`, `TranslationServiceTests.cs`, `RuntimeConfigurationRefreshContractTests.cs`, `ConfigDefaultsTests.cs`, and `OpenAiProviderConfigurationTests.cs` — extend existing seams rather than duplicating coverage.
+- `Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs` — prove startup still hydrates the plugin runtime with the new capability cache.
+- `Properties/Resources.resx`, `Properties/Resources.en-US.resx`, `Properties/Resources.pt-BR.resx`, and `Properties/Resources.Designer.cs` — operator-facing tooltip and status copy.
+- `Echoglossian.xml` — include if XML docs change while touching documented public or internal members.
+
+## Interfaces produced and consumed
+
+```csharp
+public enum LlmCapabilityParameterName
+{
+    Temperature = 0,
+    TopP = 1,
+    TopK = 2,
+    PresencePenalty = 3,
+    FrequencyPenalty = 4,
+    ReasoningEffort = 5,
+    StructuredToolCalling = 6,
+}
+
+public enum LlmCapabilitySupportState
+{
+    Unknown = 0,
+    Supported = 1,
+    Unsupported = 2,
+}
+
+public enum LlmCapabilityRuleMatchType
+{
+    ExactModel = 0,
+    FamilyPrefix = 1,
+}
+
+public readonly record struct LlmCapabilityScope(
+    Echoglossian.TransEngines Engine,
+    string ProviderScope,
+    string EndpointScope,
+    string ModelId);
+
+public readonly record struct LlmCapabilityRuleDefinition(
+    string Engine,
+    string ProviderScope,
+    string EndpointScope,
+    LlmCapabilityRuleMatchType MatchType,
+    string MatchValue,
+    LlmCapabilityParameterName ParameterName,
+    LlmCapabilitySupportState SupportState,
+    float? MinValue,
+    float? MaxValue,
+    bool OmitWhenDefaultOnly,
+    string Source,
+    string Reason);
+
+public readonly record struct LlmCapabilityParameterDecision(
+    LlmCapabilitySupportState SupportState,
+    float? MinValue,
+    float? MaxValue,
+    bool OmitWhenDefaultOnly,
+    string Source,
+    string Reason);
+
+public sealed class LlmCapabilitySnapshot
+{
+    public LlmCapabilityParameterDecision GetDecision(
+        LlmCapabilityParameterName parameterName);
+}
+
+public readonly record struct LlmCapabilitySliderState(
+    bool IsEnabled,
+    float MinValue,
+    float MaxValue,
+    string TooltipText);
+
+public static class LlmCapabilityPolicyService
+{
+    public static LlmCapabilityScope CreateScope(
+        Echoglossian.TransEngines engine,
+        string providerScope,
+        string? endpointScope,
+        string? modelId);
+
+    public static LlmCapabilitySnapshot GetSnapshot(
+        LlmCapabilityScope scope);
+
+    public static bool TryResolveTemperature(
+        LlmCapabilityScope scope,
+        float configuredValue,
+        out float sanitizedValue,
+        out LlmCapabilityParameterDecision decision);
+
+    public static LlmCapabilityLearningResult LearnFromProviderFailure(
+        LlmCapabilityScope scope,
+        LlmCapabilityParameterName parameterName,
+        int? statusCode,
+        string? responseText);
+}
+
+public readonly record struct LlmCapabilityLearningResult(
+    bool ObservationRecorded,
+    bool RulePromoted,
+    string FailureKind);
+
+public static class LlmCapabilityRefreshPromoter
+{
+    public static void PromoteDiscoveredModels(
+        Echoglossian.TransEngines engine,
+        string providerScope,
+        string endpointScope,
+        IReadOnlyList<string> modelIds,
+        DateTime observedAtUtc);
+}
+
+public static class LlmCapabilityUiHelper
+{
+    public static LlmCapabilitySliderState GetTemperatureSliderState(
+        LlmCapabilityScope scope,
+        float fallbackMin,
+        float fallbackMax);
+}
+```
+
+## Task 1: Define the shared capability contracts and conservative resolver
+
+**Files:**
+- Create: `Translators/Capabilities/LlmCapabilityParameterName.cs`
+- Create: `Translators/Capabilities/LlmCapabilitySupportState.cs`
+- Create: `Translators/Capabilities/LlmCapabilityRuleMatchType.cs`
+- Create: `Translators/Capabilities/LlmCapabilityScope.cs`
+- Create: `Translators/Capabilities/LlmCapabilityRuleDefinition.cs`
+- Create: `Translators/Capabilities/LlmCapabilityParameterDecision.cs`
+- Create: `Translators/Capabilities/LlmCapabilitySnapshot.cs`
+- Create: `Translators/Capabilities/LlmCapabilityStaticCatalog.cs`
+- Create: `Translators/Capabilities/LlmCapabilityResolver.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `Echoglossian.TransEngines`, `OpenAiProviderVariantHelper.ResolveActiveSettings(Config config)`, existing `LlmTextModel` ids from model managers.
+- Produces:
+  - `public readonly record struct LlmCapabilityScope(Echoglossian.TransEngines Engine, string ProviderScope, string EndpointScope, string ModelId);`
+  - `public readonly record struct LlmCapabilityRuleDefinition(string Engine, string ProviderScope, string EndpointScope, LlmCapabilityRuleMatchType MatchType, string MatchValue, LlmCapabilityParameterName ParameterName, LlmCapabilitySupportState SupportState, float? MinValue, float? MaxValue, bool OmitWhenDefaultOnly, string Source, string Reason);`
+  - `public readonly record struct LlmCapabilityParameterDecision(LlmCapabilitySupportState SupportState, float? MinValue, float? MaxValue, bool OmitWhenDefaultOnly, string Source, string Reason);`
+  - `public sealed class LlmCapabilitySnapshot`
+  - `public static LlmCapabilitySnapshot Resolve(LlmCapabilityScope scope, IReadOnlyList<LlmCapabilityRuleDefinition> overlayRules);`
+
+- [ ] **Step 1: Write the failing resolver tests**
+
+```csharp
+[Fact]
+public void Resolve_WithExactAndFamilyRules_PrefersExactRule()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+
+    var snapshot = LlmCapabilityResolver.Resolve(
+        scope,
+        Array.Empty<LlmCapabilityRuleDefinition>());
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Unsupported);
+}
+
+[Fact]
+public void Resolve_WithUnknownSupport_RemainsConservative()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.Gemini,
+        "Gemini",
+        "https://generativelanguage.googleapis.com",
+        "gemini-3-pro");
+
+    var snapshot = LlmCapabilityResolver.Resolve(
+        scope,
+        Array.Empty<LlmCapabilityRuleDefinition>());
+
+    snapshot.GetDecision(LlmCapabilityParameterName.Temperature)
+        .SupportState
+        .Should()
+        .Be(LlmCapabilitySupportState.Unknown);
+}
+```
+
+- [ ] **Step 2: Run the focused resolver tests to verify failure**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityResolverTests"
+```
+
+Expected: FAIL because the capability contract types and resolver do not exist yet.
+
+- [ ] **Step 3: Implement the minimal contract and catalog code**
+
+```csharp
+public static class LlmCapabilityResolver
+{
+    public static LlmCapabilitySnapshot Resolve(
+        LlmCapabilityScope scope,
+        IReadOnlyList<LlmCapabilityRuleDefinition> overlayRules)
+    {
+        var definitions = LlmCapabilityStaticCatalog.GetDefinitions(scope.Engine);
+        return LlmCapabilitySnapshot.Create(scope, definitions, overlayRules);
+    }
+}
+```
+
+```csharp
+internal static IEnumerable<LlmCapabilityRuleDefinition> GetDefinitions(
+    Echoglossian.TransEngines engine)
+{
+    if (engine == Echoglossian.TransEngines.ChatGPT)
+    {
+        yield return LlmCapabilityRuleDefinition.FamilyPrefix(
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.6-",
+            LlmCapabilityParameterName.Temperature,
+            LlmCapabilitySupportState.Unsupported,
+            omitWhenDefaultOnly: true,
+            reason: "OpenAI chat-completions reasoning models accept only the implicit default temperature.");
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused resolver tests to verify pass**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityResolverTests"
+```
+
+Expected: PASS with exact-model, family-prefix, and conservative-unknown coverage green.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- Translators/Capabilities Echoglossian.Tests/LlmCapabilityResolverTests.cs
+git commit -m "feat: add LLM capability resolver primitives"
+```
+
+### Task 2: Persist capability overlays and hydrate an in-memory cache
+
+**Files:**
+- Create: `EFCoreSqlite/Models/LlmModelCapabilityRule.cs`
+- Create: `EFCoreSqlite/Models/LlmModelCapabilityObservation.cs`
+- Create: `Cache/LlmCapabilityCacheManager.cs`
+- Create: `DBHelpers/LlmCapabilityPersistenceHelper.cs`
+- Modify: `EFCoreSqlite/EchoglossianDbContext.cs`
+- Modify: `EFCoreSqlite/Migrations/EchoglossianDbContextModelSnapshot.cs`
+- Create: `EFCoreSqlite/Migrations/20260812130000_AddLlmCapabilityMatrix.cs`
+- Create: `EFCoreSqlite/Migrations/20260812130000_AddLlmCapabilityMatrix.Designer.cs`
+- Modify: `Echoglossian.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityPersistenceTests.cs`
+- Test: `Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs`
+
+**Interfaces:**
+- Consumes: `LlmCapabilityScope`, `LlmCapabilityParameterName`, `LlmCapabilitySupportState`, existing `EchoglossianDbContext(string configDir)` startup flow.
+- Produces:
+  - `public DbSet<LlmModelCapabilityRule> LlmModelCapabilityRules { get; set; }`
+  - `public DbSet<LlmModelCapabilityObservation> LlmModelCapabilityObservations { get; set; }`
+  - `public static void Initialize(string configDir);`
+  - `public static IReadOnlyList<LlmCapabilityRuleDefinition> GetRuleDefinitions();`
+  - `public static void UpsertRules(string configDir, IReadOnlyList<LlmModelCapabilityRule> rules);`
+  - `public static void RecordObservation(string configDir, LlmModelCapabilityObservation observation);`
+
+- [ ] **Step 1: Write failing persistence and startup tests**
+
+```csharp
+[Fact]
+public void UpsertRule_ThenReload_PreservesExactModelLookup()
+{
+    var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(configDir);
+    LlmCapabilityPersistenceHelper.UpsertRules(
+        configDir,
+        new[]
+        {
+            LlmModelCapabilityRule.CreateExactModel(
+                "ChatGPT",
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra",
+                LlmCapabilityParameterName.Temperature,
+                LlmCapabilitySupportState.Unsupported,
+                omitWhenDefaultOnly: true,
+                source: "Observed400",
+                reason: "provider rejected non-default temperature"),
+        });
+
+    LlmCapabilityCacheManager.Initialize(configDir);
+
+    LlmCapabilityCacheManager.GetRuleDefinitions()
+        .Should()
+        .ContainSingle(rule => rule.MatchValue == "gpt-5.6-terra");
+}
+```
+
+- [ ] **Step 2: Run the focused persistence tests to verify failure**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPersistenceTests|FullyQualifiedName~PluginStartupSmokeTests"
+```
+
+Expected: FAIL because the new EF entities, tables, and cache manager are missing.
+
+- [ ] **Step 3: Implement additive EF entities, indexes, and cache hydration**
+
+```csharp
+public static class LlmCapabilityCacheManager
+{
+    public static void Initialize(string configDir)
+    {
+        using var context = new EchoglossianDbContext(configDir);
+        cachedRules = context.LlmModelCapabilityRules.AsNoTracking().ToList();
+        cachedObservations = context.LlmModelCapabilityObservations
+            .AsNoTracking()
+            .OrderByDescending(row => row.ObservedAtUtc)
+            .Take(128)
+            .ToList();
+    }
+}
+```
+
+```csharp
+modelBuilder.Entity<LlmModelCapabilityRule>()
+    .HasIndex(row => new
+    {
+        row.Engine,
+        row.ProviderScope,
+        row.EndpointScope,
+        row.MatchType,
+        row.MatchValue,
+        row.ParameterName,
+    })
+    .IsUnique()
+    .HasDatabaseName("IX_llmmodelcapabilityrules_lookup");
+```
+
+- [ ] **Step 4: Run the persistence and startup tests to verify pass**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityPersistenceTests"
+dotnet test Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-restore -p:VSTestMaxCpuCount=1 --filter "FullyQualifiedName~PluginStartupSmokeTests"
+```
+
+Expected: PASS with additive migration and startup hydration covered.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- EFCoreSqlite Cache DBHelpers Echoglossian.cs Echoglossian.Tests/LlmCapabilityPersistenceTests.cs Echoglossian.Mock.Tests/PluginStartupSmokeTests.cs
+git commit -m "feat: persist LLM capability overlays"
+```
+
+### Task 3: Add the shared policy service and bounded failure learning
+
+**Files:**
+- Create: `Translators/Capabilities/LlmCapabilityPolicyService.cs`
+- Create: `Translators/Capabilities/LlmCapabilityRefreshPromoter.cs`
+- Create: `Translators/Capabilities/LlmCapabilityErrorClassifier.cs`
+- Modify: `GeneralHelpers/RuntimeConfigurationRefresh.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityErrorClassifierTests.cs`
+- Test: `Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs`
+
+**Interfaces:**
+- Consumes: `LlmCapabilityCacheManager`, `LlmCapabilityPersistenceHelper`, `OpenAiProviderVariantHelper.OpenAiProviderSettings`, existing runtime refresh contract.
+- Produces:
+  - `public static class LlmCapabilityPolicyService`
+  - `public static class LlmCapabilityRefreshPromoter`
+  - `public readonly record struct LlmCapabilityLearningResult(bool ObservationRecorded, bool RulePromoted, string FailureKind);`
+
+- [ ] **Step 1: Write failing tests for scope creation, sanitization, and exact-model learning**
+
+```csharp
+[Fact]
+public void TryResolveTemperature_WithUnsupportedDecision_OmitsPayloadValue()
+{
+    var scope = LlmCapabilityPolicyService.CreateScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+
+    var resolved = LlmCapabilityPolicyService.TryResolveTemperature(
+        scope,
+        0.7f,
+        out var sanitizedValue,
+        out var decision);
+
+    resolved.Should().BeFalse();
+    sanitizedValue.Should().Be(default);
+    decision.SupportState.Should().Be(LlmCapabilitySupportState.Unsupported);
+}
+
+[Fact]
+public void LearnFromProviderFailure_WithClassifiedTemperature400_PromotesExactModelOnly()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+
+    var result = LlmCapabilityPolicyService.LearnFromProviderFailure(
+        scope,
+        LlmCapabilityParameterName.Temperature,
+        400,
+        "{ \"error\": { \"message\": \"Unsupported value: 'temperature' does not support 0.7 with this model.\" } }");
+
+    result.RulePromoted.Should().BeTrue();
+    result.FailureKind.Should().Be("unsupported-parameter");
+}
+```
+
+- [ ] **Step 2: Run the focused policy tests to verify failure**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~LlmCapabilityErrorClassifierTests|FullyQualifiedName~RuntimeConfigurationRefreshContractTests"
+```
+
+Expected: FAIL because the policy service, classifier, and refresh clear path do not exist yet.
+
+- [ ] **Step 3: Implement the shared policy and learning helpers**
+
+```csharp
+public static bool TryResolveTemperature(
+    LlmCapabilityScope scope,
+    float configuredValue,
+    out float sanitizedValue,
+    out LlmCapabilityParameterDecision decision)
+{
+    decision = GetSnapshot(scope).GetDecision(LlmCapabilityParameterName.Temperature);
+    sanitizedValue = configuredValue;
+
+    if (decision.SupportState != LlmCapabilitySupportState.Supported ||
+        decision.OmitWhenDefaultOnly)
+    {
+        sanitizedValue = default;
+        return false;
+    }
+
+    if (decision.MinValue.HasValue && configuredValue < decision.MinValue.Value)
+    {
+        sanitizedValue = decision.MinValue.Value;
+    }
+
+    if (decision.MaxValue.HasValue && configuredValue > decision.MaxValue.Value)
+    {
+        sanitizedValue = decision.MaxValue.Value;
+    }
+
+    return true;
+}
+```
+
+```csharp
+public static LlmCapabilityLearningResult LearnFromProviderFailure(
+    LlmCapabilityScope scope,
+    LlmCapabilityParameterName parameterName,
+    int? statusCode,
+    string? responseText)
+{
+    var classification = LlmCapabilityErrorClassifier.TryClassify(
+        scope,
+        parameterName,
+        statusCode,
+        responseText);
+    return classification.Apply(scope);
+}
+```
+
+- [ ] **Step 4: Run the focused policy tests to verify pass**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~LlmCapabilityErrorClassifierTests|FullyQualifiedName~RuntimeConfigurationRefreshContractTests"
+```
+
+Expected: PASS with exact-model promotion only and runtime reset behavior covered.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- Translators/Capabilities GeneralHelpers/RuntimeConfigurationRefresh.cs Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs Echoglossian.Tests/LlmCapabilityErrorClassifierTests.cs Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs
+git commit -m "feat: add conservative LLM capability policy service"
+```
+
+### Task 4: Sanitize OpenAI-family and Anthropic request payloads
+
+**Files:**
+- Modify: `Translators/ChatGPTTranslator.cs`
+- Modify: `Translators/OpenRouterTranslator.cs`
+- Modify: `Translators/DeepSeekTranslator.cs`
+- Modify: `Translators/LmStudioTranslator.cs`
+- Modify: `Translators/ClaudeTranslator.cs`
+- Modify: `Echoglossian.Tests/TranslationServiceTests.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs`
+
+**Interfaces:**
+- Consumes:
+  - `public static LlmCapabilityScope CreateScope(Echoglossian.TransEngines engine, string providerScope, string? endpointScope, string? modelId);`
+  - `public static bool TryResolveTemperature(LlmCapabilityScope scope, float configuredValue, out float sanitizedValue, out LlmCapabilityParameterDecision decision);`
+  - `public static LlmCapabilityLearningResult LearnFromProviderFailure(LlmCapabilityScope scope, LlmCapabilityParameterName parameterName, int? statusCode, string? responseText);`
+- Produces:
+  - provider request builders that omit unsupported `temperature`
+  - provider failure handlers that record classified exact-model observations
+
+- [ ] **Step 1: Extend tests to prove temperature is omitted and exact-model learning is recorded**
+
+```csharp
+[Fact]
+public void CreateScope_ForOfficialOpenAi_UsesProviderVariantAndNormalizedEndpoint()
+{
+    var scope = LlmCapabilityPolicyService.CreateScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1/",
+        "gpt-5.6-terra");
+
+    scope.ProviderScope.Should().Be("OpenAI");
+    scope.EndpointScope.Should().Be("https://api.openai.com/v1");
+}
+```
+
+```csharp
+[Fact]
+public async Task TranslateAsync_WhenStructuredFailureIsClassified_PromotesExactModelRule()
+{
+    var result = LlmCapabilityPolicyService.LearnFromProviderFailure(
+        new LlmCapabilityScope(
+            Echoglossian.TransEngines.ChatGPT,
+            "OpenAI",
+            "https://api.openai.com/v1",
+            "gpt-5.6-terra"),
+        LlmCapabilityParameterName.ReasoningEffort,
+        400,
+        "function tools with reasoning_effort are not supported");
+
+    result.RulePromoted.Should().BeTrue();
+}
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~TranslationServiceTests"
+```
+
+Expected: FAIL because the translators still set `Temperature` unconditionally and do not report learning outcomes centrally.
+
+- [ ] **Step 3: Implement minimal OpenAI-family and Claude sanitization**
+
+```csharp
+var scope = LlmCapabilityPolicyService.CreateScope(
+    Echoglossian.TransEngines.ChatGPT,
+    providerSettings.ProviderName,
+    baseUrl,
+    this.model);
+
+var options = new ChatCompletionOptions();
+if (LlmCapabilityPolicyService.TryResolveTemperature(
+        scope,
+        this.temperature,
+        out var sanitizedTemperature,
+        out _))
+{
+    options.Temperature = sanitizedTemperature;
+}
+```
+
+```csharp
+var learning = LlmCapabilityPolicyService.LearnFromProviderFailure(
+    scope,
+    LlmCapabilityParameterName.Temperature,
+    statusCode,
+    responseExcerpt);
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    $"Capability learning: promoted={learning.RulePromoted}, kind={learning.FailureKind}");
+```
+
+- [ ] **Step 4: Run the focused tests to verify pass**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~TranslationServiceTests"
+```
+
+Expected: PASS with OpenAI-family and Claude request sanitization verified through shared policy behavior.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- Translators/ChatGPTTranslator.cs Translators/OpenRouterTranslator.cs Translators/DeepSeekTranslator.cs Translators/LmStudioTranslator.cs Translators/ClaudeTranslator.cs Echoglossian.Tests/TranslationServiceTests.cs Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+git commit -m "fix: sanitize OpenAI-family and Claude capability parameters"
+```
+
+### Task 5: Sanitize Gemini, Ollama, and remaining provider-specific payloads
+
+**Files:**
+- Modify: `Translators/GeminiTranslator.cs`
+- Modify: `Translators/OllamaTranslator.cs`
+- Modify: `Translators/OpenAI/OpenAIModelManager.cs`
+- Modify: `Translators/Claude/ClaudeModelManager.cs`
+- Modify: `Translators/Gemini/GeminiModelManager.cs`
+- Modify: `Translators/OpenRouter/OpenRouterModelManager.cs`
+- Modify: `Translators/Ollama/OllamaModelManager.cs`
+- Modify: `Translators/DeepSeek/DeepSeekModelManager.cs`
+- Modify: `Translators/LmStudio/LmStudioModelManager.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs`
+- Test: `Echoglossian.Tests/DeepSeekModelManagerTests.cs`
+
+**Interfaces:**
+- Consumes: `LlmCapabilityPolicyService`, `LlmCapabilityRefreshPromoter`.
+- Produces:
+  - provider-specific omission of unsupported sampling parameters on the remaining LLM engines
+  - refresh-time exact-model promotions for non-OpenAI managers
+
+- [ ] **Step 1: Add failing tests for family defaults and refresh promotion**
+
+```csharp
+[Fact]
+public void PromoteDiscoveredModels_WithGemini3Model_CreatesExactRuleFromFamilyDefault()
+{
+    LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+        Echoglossian.TransEngines.Gemini,
+        "Gemini",
+        "https://generativelanguage.googleapis.com",
+        new[] { "gemini-3-pro" },
+        new DateTime(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc));
+
+    LlmCapabilityCacheManager.GetRuleDefinitions()
+        .Should()
+        .Contain(rule => rule.MatchValue == "gemini-3-pro");
+}
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~DeepSeekModelManagerTests|FullyQualifiedName~OpenAIModelManagerTests"
+```
+
+Expected: FAIL because the remaining model managers do not promote discovered models and some provider payloads still serialize unsupported parameters.
+
+- [ ] **Step 3: Implement minimal provider-specific sanitization and promotion hooks**
+
+```csharp
+if (models.Count > 0)
+{
+    CurrentModelList = models;
+    LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(
+        Echoglossian.TransEngines.Gemini,
+        "Gemini",
+        "https://generativelanguage.googleapis.com",
+        models.Select(model => model.Id).ToArray(),
+        DateTime.UtcNow);
+}
+```
+
+```csharp
+if (LlmCapabilityPolicyService.TryResolveTemperature(
+        scope,
+        this.temperature,
+        out var sanitizedTemperature,
+        out _))
+{
+    payload["temperature"] = sanitizedTemperature;
+}
+```
+
+- [ ] **Step 4: Run the focused tests to verify pass**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~DeepSeekModelManagerTests|FullyQualifiedName~OpenAIModelManagerTests"
+```
+
+Expected: PASS with non-OpenAI refresh promotion and payload omission behavior covered.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- Translators/GeminiTranslator.cs Translators/OllamaTranslator.cs Translators/OpenAI/OpenAIModelManager.cs Translators/Claude/ClaudeModelManager.cs Translators/Gemini/GeminiModelManager.cs Translators/OpenRouter/OpenRouterModelManager.cs Translators/Ollama/OllamaModelManager.cs Translators/DeepSeek/DeepSeekModelManager.cs Translators/LmStudio/LmStudioModelManager.cs Echoglossian.Tests/DeepSeekModelManagerTests.cs Echoglossian.Tests/OpenAIModelManagerTests.cs Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs
+git commit -m "feat: promote discovered LLM capability overlays"
+```
+
+### Task 6: Gate the LLM engine UI from the shared policy snapshot
+
+**Files:**
+- Create: `PluginUI/EngineConfigUI/LlmCapabilityUiHelper.cs`
+- Modify: `PluginUI/EngineConfigUI/ChatGptEngineUI.cs`
+- Modify: `PluginUI/EngineConfigUI/ClaudeEngineUI.cs`
+- Modify: `PluginUI/EngineConfigUI/GeminiEngineUI.cs`
+- Modify: `PluginUI/EngineConfigUI/DeepSeekEngineUI.cs`
+- Modify: `PluginUI/EngineConfigUI/OpenRouterEngineUI.cs`
+- Modify: `PluginUI/EngineConfigUI/OllamaEngineUI.cs`
+- Modify: `PluginUI/EngineConfigUI/LmStudioEngineUI.cs`
+- Modify: `Properties/Resources.resx`
+- Modify: `Properties/Resources.en-US.resx`
+- Modify: `Properties/Resources.pt-BR.resx`
+- Modify: `Properties/Resources.Designer.cs`
+- Test: `Echoglossian.Tests/LlmCapabilityUiHelperTests.cs`
+- Test: `Echoglossian.Tests/ConfigDefaultsTests.cs`
+
+**Interfaces:**
+- Consumes:
+  - `public static LlmCapabilityScope CreateScope(Echoglossian.TransEngines engine, string providerScope, string? endpointScope, string? modelId);`
+  - existing engine-specific config/model selectors and selected model ids.
+- Produces:
+  - `public readonly record struct LlmCapabilitySliderState(bool IsEnabled, float MinValue, float MaxValue, string TooltipText);`
+  - `public static LlmCapabilitySliderState GetTemperatureSliderState(LlmCapabilityScope scope, float fallbackMin, float fallbackMax);`
+
+- [ ] **Step 1: Write failing UI helper tests**
+
+```csharp
+[Fact]
+public void GetTemperatureSliderState_WithDefaultOnlyDecision_DisablesControlAndExplainsWhy()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+
+    var state = LlmCapabilityUiHelper.GetTemperatureSliderState(
+        scope,
+        0.1f,
+        1.0f);
+
+    state.IsEnabled.Should().BeFalse();
+    state.TooltipText.Should().Contain("default-only");
+}
+```
+
+- [ ] **Step 2: Run the focused UI tests to verify failure**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityUiHelperTests|FullyQualifiedName~ConfigDefaultsTests"
+```
+
+Expected: FAIL because the UI helper and tooltip resources do not exist yet.
+
+- [ ] **Step 3: Implement the shared UI helper and wire each engine slider through it**
+
+```csharp
+var sliderState = LlmCapabilityUiHelper.GetTemperatureSliderState(
+    scope,
+    0.1f,
+    1.0f);
+
+ImGui.BeginDisabled(!sliderState.IsEnabled);
+if (ImGui.SliderFloat(Resources.Temperature, ref temp, sliderState.MinValue, sliderState.MaxValue, "%.1f"))
+{
+    config.ChatGptTemperature = temp;
+    changed = true;
+}
+ImGui.EndDisabled();
+
+if (!sliderState.IsEnabled && ImGui.IsItemHovered())
+{
+    ImGui.SetTooltip(sliderState.TooltipText);
+}
+```
+
+- [ ] **Step 4: Run the focused UI tests to verify pass**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityUiHelperTests|FullyQualifiedName~ConfigDefaultsTests"
+```
+
+Expected: PASS with disabled-slider tooltip text and dynamic ranges covered.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- PluginUI/EngineConfigUI Properties Echoglossian.Tests/LlmCapabilityUiHelperTests.cs Echoglossian.Tests/ConfigDefaultsTests.cs
+git commit -m "feat: gate LLM config controls by capability"
+```
+
+### Task 7: Validate the matrix end to end and prepare PR evidence
+
+**Files:**
+- Modify: `Echoglossian.xml` if XML docs changed
+- Verify: `docs/superpowers/specs/2026-08-12-llm-capability-matrix-design.md`
+- Verify: `docs/superpowers/plans/2026-08-12-llm-capability-matrix-implementation-plan.md`
+
+**Interfaces:**
+- Consumes: all prior tasks’ committed code and tests.
+- Produces: validated branch evidence ready for a PR to `v4-series`.
+
+- [ ] **Step 1: Run focused matrix tests**
+
+Run:
+
+```powershell
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~LlmCapabilityResolverTests|FullyQualifiedName~LlmCapabilityPersistenceTests|FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~LlmCapabilityErrorClassifierTests|FullyQualifiedName~LlmCapabilityUiHelperTests|FullyQualifiedName~OpenAIModelManagerTests|FullyQualifiedName~DeepSeekModelManagerTests|FullyQualifiedName~TranslationServiceTests|FullyQualifiedName~RuntimeConfigurationRefreshContractTests|FullyQualifiedName~ConfigDefaultsTests"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full build, full tests, Mock startup tests, and whitespace validation**
+
+Run:
+
+```powershell
+dotnet build Echoglossian.sln -c Debug --no-restore
+dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build
+dotnet test Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1
+git diff --check
+```
+
+Expected: PASS, and include `Echoglossian.xml` in the commit if the build updates it.
+
+- [ ] **Step 3: Run in-game verification focused on current failures**
+
+Check:
+
+```text
+1. Official OpenAI + gpt-5.6-terra: temperature slider disabled with tooltip; request no longer returns 400 for non-default temperature because the payload omits it.
+2. Official OpenAI structured dialogue on the same model: reasoning/tool incompatibility records one exact-model observation and the next request follows the learned conservative rule.
+3. Claude 4.7+/5 family model: temperature control disabled when policy marks default-only.
+4. Gemini 3 family: unknown or unsupported sampling remains omitted conservatively while the UI explains why.
+5. Live-model refresh on OpenAI, Gemini, DeepSeek, Ollama, and LM Studio updates model lists without blocking Draw and promotes exact-model capability rows derived from family rules.
+6. Changing endpoint, provider variant, or model produces a different capability scope and does not reuse the previous scope’s learned rule incorrectly.
+```
+
+- [ ] **Step 4: Prepare PR evidence and commit any remaining generated files**
+
+```powershell
+git add -- Echoglossian.xml
+git status --short
+git commit -m "chore: finalize LLM capability matrix validation"
+```
+
+Expected: Only real generated or validation-followup files are staged; skip the commit if no new files changed in this final validation pass.

--- a/docs/superpowers/plans/2026-08-13-structured-dialogue-debug-observability-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-13-structured-dialogue-debug-observability-implementation-plan.md
@@ -1,0 +1,696 @@
+# Structured Dialogue Debug Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one shared debug-only structured-dialogue observability contract that shows what was prepared, which capability decisions were applied, and what came back for every structured LLM dialogue attempt.
+
+**Architecture:** Keep policy decisions in the existing LLM capability matrix and emit compact shared `PluginRuntimeLog.Debug` lines through `StructuredDialogueDiagnosticsHelper`. Translators remain transport adapters only: each one reports the same `structured-start`, `structured-success`, and `structured-fallback` contract while continuing to use its existing request/response plumbing.
+
+**Tech Stack:** C# / .NET 10, Dalamud `IPluginLog`, `PluginRuntimeLog`, xUnit, FluentAssertions, existing LLM capability matrix helpers, existing structured-dialogue request/validation helpers.
+
+## Global Constraints
+
+- Keep diagnostics in normal debug logging only. No extra diagnostic file.
+- Emit one shared structured logging shape across all structured LLM translators.
+- Show the effective capability decision used at runtime, including whether a parameter was sent, omitted, or forced to an explicit transport-specific disable such as `reasoning_effort=none`.
+- Preserve the capability matrix as the only policy authority.
+- No raw prompt dumps, full provider bodies, API keys, bearer tokens, or complete glossary contents in logs.
+- Use `PluginRuntimeLog.Debug(...)` as the only output path for all new diagnostics.
+- Keep the patch narrow: extend shared helpers, wire existing translators, add targeted tests, avoid a broad executor refactor.
+
+---
+
+## File Structure
+
+- `Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs`
+  - Shared formatter and sanitizer for compact debug log lines.
+- `Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs`
+  - Shared token formatter for runtime capability decisions such as `temperature=omitted(default-only)` and `reasoning_effort=explicit-none(unsupported)`.
+- `Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs`
+  - Shared log-shape and sanitization tests.
+- `Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs`
+  - Shared capability-decision token tests.
+- `Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs`
+  - Reusable log-capture double for tests that need to inspect `PluginRuntimeLog.Debug` output.
+- `Translators/ChatGPTTranslator.cs`
+  - OpenAI SDK structured dialogue path; must report `reasoning_effort` decisions explicitly.
+- `Translators/OpenRouterTranslator.cs`
+  - OpenAI-compatible HTTP structured dialogue path.
+- `Translators/DeepSeekTranslator.cs`
+  - OpenAI-compatible HTTP structured dialogue path.
+- `Translators/GeminiTranslator.cs`
+  - Gemini structured dialogue HTTP path.
+- `Translators/ClaudeTranslator.cs`
+  - Claude structured dialogue HTTP path.
+- `Translators/OllamaTranslator.cs`
+  - Ollama structured dialogue HTTP path.
+- `Translators/LmStudioTranslator.cs`
+  - LM Studio structured dialogue HTTP path.
+
+### Task 1: Build The Shared Structured Debug Contract
+
+**Files:**
+- Create: `Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs`
+- Create: `Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs`
+- Create: `Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs`
+- Modify: `Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs`
+- Modify: `Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs`
+
+**Interfaces:**
+- Consumes:
+  - `LlmCapabilityScope`
+  - `LlmCapabilityParameterDecision`
+  - `LlmCapabilityParameterName`
+  - `StructuredDialogueProviderCapability`
+- Produces:
+  - `internal enum StructuredDialogueCapabilityEmissionMode`
+  - `internal static class StructuredDialogueCapabilityDecisionLogFormatter`
+  - `public static string StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        LlmCapabilityScope scope,
+        string route,
+        StructuredDialogueProviderCapability capability,
+        string sessionNamespace,
+        int priorTurns,
+        int glossaryCount,
+        bool speakerMetadataPresent,
+        bool addresseeMetadataPresent,
+        int requestPromptLength,
+        int? requestJsonLength,
+        string promptPreview,
+        string sourcePreview,
+        IReadOnlyList<string> capabilityDecisionTokens)`
+  - `public static string StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+        LlmCapabilityScope scope,
+        string route,
+        StructuredDialogueProviderCapability capability,
+        bool glossaryApplied,
+        int rawPayloadLength,
+        int translatedLength,
+        string rawPayloadPreview,
+        string translatedPreview)`
+  - `public static string StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(
+        string providerName,
+        string? modelName,
+        StructuredDialogueProviderCapability capability,
+        string stage,
+        string failureReason,
+        int? statusCode = null,
+        string? responseExcerpt = null,
+        string? endpointScope = null,
+        string? route = null,
+        IReadOnlyList<string>? capabilityDecisionTokens = null,
+        bool? glossaryApplied = null)`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public void FormatStructuredStartMessage_ShouldIncludeRouteGlossaryAndCapabilityDecisionTokens()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.ChatGPT,
+        "OpenAI",
+        "https://api.openai.com/v1",
+        "gpt-5.6-terra");
+
+    string message = StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        scope,
+        "chat/completions",
+        StructuredDialogueProviderCapability.JsonSchema,
+        "Talk",
+        1,
+        2,
+        true,
+        false,
+        420,
+        640,
+        "Return only a JSON object...",
+        "All these bright lights...",
+        [
+            "temperature=omitted(default-only)",
+            "reasoning_effort=explicit-none(unsupported)",
+        ]);
+
+    message.Should().Contain("structured-start");
+    message.Should().Contain("endpointScope=https://api.openai.com/v1");
+    message.Should().Contain("route=chat-completions");
+    message.Should().Contain("glossaryCount=2");
+    message.Should().Contain("capabilityDecisions=temperature=omitted(default-only)|reasoning_effort=explicit-none(unsupported)");
+}
+
+[Fact]
+public void FormatStructuredSuccessMessage_ShouldIncludeSanitizedResponsePreview()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.OpenRouter,
+        "OpenRouter",
+        "https://openrouter.ai/api/v1",
+        "openai/gpt-5-mini");
+
+    string message = StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+        scope,
+        "chat/completions",
+        StructuredDialogueProviderCapability.JsonSchema,
+        true,
+        218,
+        84,
+        "{\"textTranslated\":\"sk-secret should never leak\"}",
+        "Texto traduzido final");
+
+    message.Should().Contain("structured-success");
+    message.Should().Contain("glossaryApplied=true");
+    message.Should().Contain("rawPayloadLength=218");
+    message.Should().Contain("translatedLength=84");
+    message.Should().NotContain("sk-secret");
+}
+
+[Fact]
+public void Format_WhenUnsupportedReasoningEffortUsesExplicitNone_ShouldEmitExplicitDisableToken()
+{
+    string token = StructuredDialogueCapabilityDecisionLogFormatter.Format(
+        LlmCapabilityParameterName.ReasoningEffort,
+        new LlmCapabilityParameterDecision(
+            LlmCapabilitySupportState.Unsupported,
+            null,
+            null,
+            false,
+            "StaticDefault",
+            "Unsupported"),
+        StructuredDialogueCapabilityEmissionMode.ExplicitDisable);
+
+    token.Should().Be("reasoning_effort=explicit-none(unsupported)");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~StructuredDialogueDiagnosticsHelperTests|FullyQualifiedName~StructuredDialogueCapabilityDecisionLogFormatterTests" `
+
+Expected: FAIL because the new formatter type and start/success methods do not exist yet.
+
+- [ ] **Step 3: Write the minimal shared implementation**
+
+```csharp
+internal enum StructuredDialogueCapabilityEmissionMode
+{
+    SentConfigured,
+    OmittedUnsupported,
+    OmittedDefaultOnly,
+    OmittedUnknown,
+    ExplicitDisable,
+}
+
+internal static class StructuredDialogueCapabilityDecisionLogFormatter
+{
+    public static string Format(
+        LlmCapabilityParameterName parameterName,
+        LlmCapabilityParameterDecision decision,
+        StructuredDialogueCapabilityEmissionMode emissionMode)
+    {
+        var parameterToken = parameterName switch
+        {
+            LlmCapabilityParameterName.ReasoningEffort => "reasoning_effort",
+            LlmCapabilityParameterName.Temperature => "temperature",
+            _ => parameterName.ToString().ToLowerInvariant(),
+        };
+
+        var supportToken = decision.SupportState switch
+        {
+            LlmCapabilitySupportState.Unsupported => "unsupported",
+            LlmCapabilitySupportState.Supported => "configured",
+            _ => "unknown",
+        };
+
+        var emissionToken = emissionMode switch
+        {
+            StructuredDialogueCapabilityEmissionMode.SentConfigured => "sent(configured)",
+            StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly => "omitted(default-only)",
+            StructuredDialogueCapabilityEmissionMode.OmittedUnsupported => "omitted(unsupported)",
+            StructuredDialogueCapabilityEmissionMode.ExplicitDisable when parameterName == LlmCapabilityParameterName.ReasoningEffort
+                => "explicit-none(unsupported)",
+            _ => $"omitted({supportToken})",
+        };
+
+        return $"{parameterToken}={emissionToken}";
+    }
+}
+```
+
+```csharp
+public static string FormatStructuredStartMessage(
+    LlmCapabilityScope scope,
+    string route,
+    StructuredDialogueProviderCapability capability,
+    string sessionNamespace,
+    int priorTurns,
+    int glossaryCount,
+    bool speakerMetadataPresent,
+    bool addresseeMetadataPresent,
+    int requestPromptLength,
+    int? requestJsonLength,
+    string promptPreview,
+    string sourcePreview,
+    IReadOnlyList<string> capabilityDecisionTokens)
+{
+    var parts = new List<string>
+    {
+        "structured-start",
+        $"provider={scope.ProviderScope}",
+        $"endpointScope={NormalizeToken(scope.EndpointScope)}",
+        $"route={NormalizeToken(route)}",
+        $"model={scope.ModelId}",
+        $"capability={FormatCapability(capability)}",
+        $"sessionNamespace={NormalizeToken(sessionNamespace)}",
+        $"priorTurns={priorTurns}",
+        $"glossaryCount={glossaryCount}",
+        $"glossaryApplied={(glossaryCount > 0).ToString().ToLowerInvariant()}",
+        $"speakerMetadataPresent={speakerMetadataPresent.ToString().ToLowerInvariant()}",
+        $"addresseeMetadataPresent={addresseeMetadataPresent.ToString().ToLowerInvariant()}",
+        $"requestPromptLength={requestPromptLength}",
+        $"promptPreview={SanitizeExcerpt(promptPreview)}",
+        $"sourcePreview={SanitizeExcerpt(sourcePreview)}",
+        $"capabilityDecisions={string.Join("|", capabilityDecisionTokens)}",
+    };
+
+    if (requestJsonLength.HasValue)
+    {
+        parts.Add($"requestJsonLength={requestJsonLength.Value}");
+    }
+
+    return string.Join(", ", parts);
+}
+
+public static string FormatStructuredSuccessMessage(
+    LlmCapabilityScope scope,
+    string route,
+    StructuredDialogueProviderCapability capability,
+    bool glossaryApplied,
+    int rawPayloadLength,
+    int translatedLength,
+    string rawPayloadPreview,
+    string translatedPreview)
+{
+    return string.Join(", ", new[]
+    {
+        "structured-success",
+        $"provider={scope.ProviderScope}",
+        $"endpointScope={NormalizeToken(scope.EndpointScope)}",
+        $"route={NormalizeToken(route)}",
+        $"model={scope.ModelId}",
+        $"capability={FormatCapability(capability)}",
+        $"glossaryApplied={glossaryApplied.ToString().ToLowerInvariant()}",
+        $"rawPayloadLength={rawPayloadLength}",
+        $"translatedLength={translatedLength}",
+        $"rawPayloadPreview={SanitizeExcerpt(rawPayloadPreview)}",
+        $"translatedPreview={SanitizeExcerpt(translatedPreview)}",
+    });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~StructuredDialogueDiagnosticsHelperTests|FullyQualifiedName~StructuredDialogueCapabilityDecisionLogFormatterTests" `
+
+Expected: PASS with coverage for `structured-start`, `structured-success`, fallback extensions, and capability-decision tokens.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Echoglossian.Tests/TestDoubles/CapturingPluginLog.cs Echoglossian.Tests/StructuredDialogueCapabilityDecisionLogFormatterTests.cs Echoglossian.Tests/StructuredDialogueDiagnosticsHelperTests.cs Translators/Helpers/StructuredDialogueCapabilityDecisionLogFormatter.cs Translators/Helpers/StructuredDialogueDiagnosticsHelper.cs
+git commit -m "feat: add shared structured dialogue debug contract"
+```
+
+### Task 2: Wire OpenAI And OpenAI-Compatible Structured Translators
+
+**Files:**
+- Modify: `Translators/ChatGPTTranslator.cs`
+- Modify: `Translators/OpenRouterTranslator.cs`
+- Modify: `Translators/DeepSeekTranslator.cs`
+- Modify: `Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs`
+
+**Interfaces:**
+- Consumes:
+  - `StructuredDialogueCapabilityDecisionLogFormatter.Format(...)`
+  - `StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(...)`
+  - `StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(...)`
+  - `StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(...)`
+  - `PluginRuntimeLog.Debug(...)`
+- Produces:
+  - OpenAI SDK and OpenAI-compatible structured translators emit:
+    - one `structured-start` line immediately before the provider request;
+    - one `structured-success` line after successful validation;
+    - one `structured-fallback` line carrying route, endpoint, glossary flag, and capability decisions.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public void ChatGptTranslator_WhenReasoningEffortIsUnsupported_UsesExplicitNoneCapabilityToken()
+{
+    var token = StructuredDialogueCapabilityDecisionLogFormatter.Format(
+        LlmCapabilityParameterName.ReasoningEffort,
+        new LlmCapabilityParameterDecision(
+            LlmCapabilitySupportState.Unsupported,
+            null,
+            null,
+            false,
+            "StaticDefault",
+            "Unsupported"),
+        StructuredDialogueCapabilityEmissionMode.ExplicitDisable);
+
+    token.Should().Be("reasoning_effort=explicit-none(unsupported)");
+}
+
+[Fact]
+public void ChatGptTranslator_WhenTemperatureIsDefaultOnly_UsesOmittedDefaultOnlyCapabilityToken()
+{
+    var token = StructuredDialogueCapabilityDecisionLogFormatter.Format(
+        LlmCapabilityParameterName.Temperature,
+        new LlmCapabilityParameterDecision(
+            LlmCapabilitySupportState.Unsupported,
+            null,
+            null,
+            true,
+            "StaticDefault",
+            "DefaultOnly"),
+        StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly);
+
+    token.Should().Be("temperature=omitted(default-only)");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~StructuredDialogueCapabilityDecisionLogFormatterTests" `
+
+Expected: FAIL until the translators and helper agree on the explicit token behavior used by the OpenAI-family structured path.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```csharp
+// ChatGPTTranslator structured path
+var snapshot = LlmCapabilityPolicyService.GetSnapshot(this.capabilityScope);
+var temperatureDecision = snapshot.GetDecision(LlmCapabilityParameterName.Temperature);
+var reasoningDecision = snapshot.GetDecision(LlmCapabilityParameterName.ReasoningEffort);
+
+var capabilityTokens = new List<string>
+{
+    StructuredDialogueCapabilityDecisionLogFormatter.Format(
+        LlmCapabilityParameterName.Temperature,
+        temperatureDecision,
+        temperatureWasSent
+            ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+            : temperatureDecision.OmitWhenDefaultOnly
+                ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                    ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                    : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+    StructuredDialogueCapabilityDecisionLogFormatter.Format(
+        LlmCapabilityParameterName.ReasoningEffort,
+        reasoningDecision,
+        reasoningEffortWasSent && chatCompletionOptions.ReasoningEffortLevel == ChatReasoningEffortLevel.None
+            ? StructuredDialogueCapabilityEmissionMode.ExplicitDisable
+            : reasoningEffortWasSent
+                ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+                : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+};
+
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        this.capabilityScope,
+        "chat/completions",
+        StructuredDialogueProviderCapability.JsonSchema,
+        dialogueContext.SessionNamespace,
+        dialogueContext.PriorTurns.Count,
+        glossaryEntries.Count,
+        dialogueContext.Speaker.HasValue,
+        dialogueContext.Addressee.HasValue,
+        structuredPrompt.Length,
+        null,
+        structuredPrompt,
+        normalizedText,
+        capabilityTokens));
+```
+
+```csharp
+// OpenRouter and DeepSeek structured HTTP paths
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        this.capabilityScope,
+        "chat/completions",
+        StructuredDialogueProviderCapability.JsonSchema,
+        dialogueContext.SessionNamespace,
+        dialogueContext.PriorTurns.Count,
+        glossaryEntries.Count,
+        dialogueContext.Speaker.HasValue,
+        dialogueContext.Addressee.HasValue,
+        structuredPrompt.Length,
+        jsonContent.Length,
+        structuredPrompt,
+        normalizedText,
+        capabilityTokens));
+
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+        this.capabilityScope,
+        "chat/completions",
+        StructuredDialogueProviderCapability.JsonSchema,
+        usedGlossary,
+        rawStructuredPayload?.Length ?? 0,
+        translatedText.Length,
+        rawStructuredPayload ?? string.Empty,
+        translatedText));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~LlmCapabilityPolicyServiceTests|FullyQualifiedName~StructuredDialogueCapabilityDecisionLogFormatterTests|FullyQualifiedName~StructuredDialogueDiagnosticsHelperTests" `
+
+Expected: PASS with the OpenAI-family explicit-disable and default-only token behavior preserved.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Echoglossian.Tests/LlmCapabilityPolicyServiceTests.cs Translators/ChatGPTTranslator.cs Translators/OpenRouterTranslator.cs Translators/DeepSeekTranslator.cs
+git commit -m "feat: log structured openai dialogue decisions"
+```
+
+### Task 3: Wire Gemini, Claude, Ollama, And LM Studio Structured Translators
+
+**Files:**
+- Modify: `Translators/GeminiTranslator.cs`
+- Modify: `Translators/ClaudeTranslator.cs`
+- Modify: `Translators/OllamaTranslator.cs`
+- Modify: `Translators/LmStudioTranslator.cs`
+
+**Interfaces:**
+- Consumes:
+  - `StructuredDialogueCapabilityDecisionLogFormatter.Format(...)`
+  - `StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(...)`
+  - `StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(...)`
+  - `StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(...)`
+  - `PluginRuntimeLog.Debug(...)`
+- Produces:
+  - Gemini, Claude, Ollama, and LM Studio emit the same compact
+    `structured-start` / `structured-success` / `structured-fallback` log
+    contract with transport-appropriate `route` and `requestJsonLength`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public void FormatStructuredStartMessage_WhenGlossaryIsAbsent_ShouldStillReportCapabilityDecisions()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.Gemini,
+        "Gemini",
+        "https://generativelanguage.googleapis.com",
+        "gemini-3-pro");
+
+    string message = StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        scope,
+        "models/gemini-3-pro:generateContent",
+        StructuredDialogueProviderCapability.JsonSchema,
+        "Talk",
+        0,
+        0,
+        true,
+        false,
+        310,
+        512,
+        "Return only a JSON object...",
+        "What brings you to the Gold Saucer?",
+        ["temperature=omitted(unsupported)"]);
+
+    message.Should().Contain("structured-start");
+    message.Should().Contain("glossaryCount=0");
+    message.Should().Contain("capabilityDecisions=temperature=omitted(unsupported)");
+}
+
+[Fact]
+public void FormatStructuredSuccessMessage_ShouldIncludeTransportRouteForGeminiStyleCalls()
+{
+    var scope = new LlmCapabilityScope(
+        Echoglossian.TransEngines.Gemini,
+        "Gemini",
+        "https://generativelanguage.googleapis.com",
+        "gemini-3-pro");
+
+    string message = StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+        scope,
+        "models/gemini-3-pro:generateContent",
+        StructuredDialogueProviderCapability.JsonSchema,
+        false,
+        144,
+        66,
+        "{\"textTranslated\":\"teste\"}",
+        "texto final");
+
+    message.Should().Contain("route=models-gemini-3-pro-generatecontent");
+    message.Should().Contain("structured-success");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~StructuredDialogueDiagnosticsHelperTests|FullyQualifiedName~StructuredDialogueCapabilityDecisionLogFormatterTests" `
+
+Expected: FAIL until the remaining structured translators are updated to use the shared start/success/fallback contract and route normalization.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```csharp
+// Gemini structured path
+var capabilityTokens = new List<string>
+{
+    StructuredDialogueCapabilityDecisionLogFormatter.Format(
+        LlmCapabilityParameterName.Temperature,
+        temperatureDecision,
+        temperatureWasSent
+            ? StructuredDialogueCapabilityEmissionMode.SentConfigured
+            : temperatureDecision.OmitWhenDefaultOnly
+                ? StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly
+                : temperatureDecision.SupportState == LlmCapabilitySupportState.Unsupported
+                    ? StructuredDialogueCapabilityEmissionMode.OmittedUnsupported
+                    : StructuredDialogueCapabilityEmissionMode.OmittedUnknown),
+};
+
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        this.capabilityScope,
+        $"models/{this.model}:generateContent",
+        StructuredDialogueProviderCapability.JsonSchema,
+        dialogueContext.SessionNamespace,
+        dialogueContext.PriorTurns.Count,
+        glossaryEntries.Count,
+        dialogueContext.Speaker.HasValue,
+        dialogueContext.Addressee.HasValue,
+        structuredPrompt.Length,
+        jsonContent.Length,
+        structuredPrompt,
+        normalizedText,
+        capabilityTokens));
+
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(
+        this.capabilityScope,
+        $"models/{this.model}:generateContent",
+        StructuredDialogueProviderCapability.JsonSchema,
+        usedGlossary,
+        rawStructuredPayload?.Length ?? 0,
+        translatedText.Length,
+        rawStructuredPayload ?? string.Empty,
+        translatedText));
+```
+
+```csharp
+// Claude structured path
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        this.capabilityScope,
+        "messages",
+        StructuredDialogueProviderCapability.JsonSchema,
+        dialogueContext.SessionNamespace,
+        dialogueContext.PriorTurns.Count,
+        glossaryEntries.Count,
+        dialogueContext.Speaker.HasValue,
+        dialogueContext.Addressee.HasValue,
+        structuredPrompt.Length,
+        jsonContent.Length,
+        structuredPrompt,
+        normalizedText,
+        capabilityTokens));
+
+// Ollama structured path
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        this.capabilityScope,
+        "api/chat",
+        StructuredDialogueProviderCapability.JsonSchema,
+        dialogueContext.SessionNamespace,
+        dialogueContext.PriorTurns.Count,
+        glossaryEntries.Count,
+        dialogueContext.Speaker.HasValue,
+        dialogueContext.Addressee.HasValue,
+        structuredPrompt.Length,
+        jsonContent.Length,
+        structuredPrompt,
+        normalizedText,
+        capabilityTokens));
+
+// LM Studio structured path
+PluginRuntimeLog.Debug(
+    this.pluginLog,
+    StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(
+        this.capabilityScope,
+        "v1/chat/completions",
+        StructuredDialogueProviderCapability.JsonSchema,
+        dialogueContext.SessionNamespace,
+        dialogueContext.PriorTurns.Count,
+        glossaryEntries.Count,
+        dialogueContext.Speaker.HasValue,
+        dialogueContext.Addressee.HasValue,
+        structuredPrompt.Length,
+        jsonContent.Length,
+        structuredPrompt,
+        normalizedText,
+        capabilityTokens));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~StructuredDialogueDiagnosticsHelperTests|FullyQualifiedName~StructuredDialogueCapabilityDecisionLogFormatterTests" `
+
+Run: `dotnet build Echoglossian.sln -c Debug --no-restore`
+
+Expected: PASS for targeted tests and successful solution build with all structured translators compiling against the shared debug contract.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Translators/GeminiTranslator.cs Translators/ClaudeTranslator.cs Translators/OllamaTranslator.cs Translators/LmStudioTranslator.cs
+git commit -m "feat: log structured dialogue diagnostics across llm providers"
+```
+
+## Self-Review
+
+- **Spec coverage:** The plan covers shared start/success/fallback debug lines, capability-decision tokens, glossary/context visibility, provider route visibility, sanitization, and shared translator wiring across every structured LLM provider named in the approved spec.
+- **Placeholder scan:** No `TODO`, `TBD`, or “implement later” placeholders remain. Each code step includes concrete method signatures or representative call sites.
+- **Type consistency:** The plan consistently uses `StructuredDialogueCapabilityDecisionLogFormatter`, `StructuredDialogueCapabilityEmissionMode`, `FormatStructuredStartMessage`, and `FormatStructuredSuccessMessage` across all tasks.
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-08-13-structured-dialogue-debug-observability-implementation-plan.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-08-10-quest-dialogue-interlocutor-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-10-quest-dialogue-interlocutor-metadata-design.md
@@ -1,0 +1,394 @@
+# Issue 214 Quest Dialogue Interlocutor Metadata Design
+
+**Date:** 2026-08-10
+
+**Repository:** `lokinmodar/Echoglossian`
+
+## Objective
+
+Complete issue `#214` by adding a quest-scoped dialogue metadata subsystem that
+can derive, persist, and reuse speaker and addressee hints for quest-related
+`Talk` and `BattleTalk` lines without blocking Dalamud callbacks or creating a
+second translation pipeline.
+
+## Issue Context
+
+Issue `#214` is not only about attaching the visible speaker name to the first
+request. Its user-facing symptom is incorrect pronoun and form-of-address
+selection on the first line of dialogue, especially in languages where
+speaker identity and relationship strongly affect output.
+
+The current branch work already improved two narrower parts of that problem:
+
+- first-line dialogue requests can now carry current-speaker context; and
+- `Talk` and `BattleTalk` work was moved away from callback-blocking execution.
+
+That still does not fully resolve `#214` when the first-line failure is caused
+by missing interlocutor or addressee context rather than only a missing current
+speaker.
+
+This design therefore treats quest-derived interlocutor metadata as part of the
+remaining `#214` scope, not as a separate unrelated follow-up.
+
+## Problem
+
+The current LLM dialogue path can carry current-speaker identity and bounded
+prior turns, but it still lacks a reliable way to infer the addressee or
+interlocutor for many quest-driven dialogue lines.
+
+This shows up most clearly in gendered target-language output where:
+
+- the speaker is known;
+- the visible text is quest-related;
+- the actor being addressed is not the local player; and
+- the runtime does not have broad, easy-to-query game metadata that directly
+  exposes the interlocutor.
+
+The result is that the model may guess grammatical gender or addressee role
+incorrectly even when the quest text itself contains enough surrounding
+structure to derive a better fallback hint.
+
+## Goals
+
+- Persist quest-derived dialogue metadata in a dedicated entity keyed to the
+  quest.
+- Precompute that metadata asynchronously when a quest is accepted.
+- Reuse the metadata later, even outside the currently active quest session.
+- Query metadata cheaply from `Talk` and `BattleTalk` without blocking runtime
+  callbacks.
+- Prefer stronger live actor or NPC evidence when it exists.
+- Version derived metadata by source language, game version, and derivation
+  logic version.
+
+## Non-Goals
+
+- No second translation service or parallel LLM pipeline.
+- No replacement of canonical translation tables or DB-first translation
+  semantics.
+- No requirement that every `Talk` or `BattleTalk` line resolve an
+  interlocutor.
+- No forced dependency on quest metadata when stronger live actor metadata
+  exists.
+- No broad scan of all game dialogue at runtime.
+- No synchronous quest-sheet parsing, DB I/O, or model lookup from framework or
+  ImGui callbacks.
+
+## Existing Foundations
+
+The repository already has the main building blocks needed for this design:
+
+- `QuestLuminaResolver` resolves `Quest.RowId` and `Quest.Id`.
+- `QuestProgressResolver` resolves live `QuestSequence` and mounts the
+  quest text sheet through Lumina.
+- structured dialogue requests already accept optional metadata fields.
+- `Talk` and `BattleTalk` already use a runtime-only dialogue context path.
+
+This design extends those foundations with a new metadata subsystem rather than
+replacing the current translation architecture. It assumes the already-landed
+first-line speaker-context work remains useful but insufficient by itself for
+fully resolving `#214`.
+
+## Metadata Sources
+
+The first implementation should use explicit concrete metadata sources instead
+of vague "gender detection" or generic prompt heuristics.
+
+### Local Player
+
+When the dialogue target is the local player, the primary source should be
+`IPlayerState.Sex`.
+
+Reasons:
+
+- it is already exposed as managed Dalamud state;
+- it avoids relying on raw `Customize` buffers as the main path;
+- it is easier to test through DalaMock because `MockPlayerState.Sex` already
+  exists.
+
+`Customize[(int)CustomizeIndex.Gender]` may remain a reference or fallback for
+native understanding, but it should not be the preferred first-cut source when
+`IPlayerState.Sex` is available.
+
+### Live NPC Or Actor
+
+When the current dialogue line can be linked strongly to a loaded actor or NPC,
+the runtime may capture a `LiveDialogueActorSnapshot` using a path similar to
+the metadata extraction seen in `TextToTalk`.
+
+Recommended captured managed fields:
+
+- `NpcId` via `INpc.DataId` when available;
+- `Gender` via the actor's native `Character` sex field;
+- `Race` via `DrawData.CustomizeData.Race`;
+- `BodyType` via `DrawData.CustomizeData.BodyType`.
+
+These fields are useful because they allow the runtime to preserve stronger live
+speaker metadata when the world actor is actually present and resolvable.
+
+### Capture Safety Rule
+
+All live actor and player metadata must be copied into managed immutable values
+before the first asynchronous boundary.
+
+That means:
+
+- no `Span<byte>` or borrowed `Customize` buffer crosses an `await`;
+- no native `Character*`, `Human*`, or other pointer survives into background
+  work;
+- lookup and translation operate only on the copied managed snapshot.
+
+## Relationship To PR 262
+
+The current `issue-214-first-dialogue-speaker-context` branch and draft PR
+`#262` already cover:
+
+- first-line current-speaker context on the initial request; and
+- non-blocking async execution for `Talk` and `BattleTalk`.
+
+They do not yet guarantee that the first line has enough addressee or
+interlocutor metadata to materially fix the original pronoun-selection symptom
+reported in `#214`.
+
+This design is therefore intended as remaining branch work for `#214`, not as a
+separate branch or issue by default.
+
+## Recommended Architecture
+
+Use a hybrid metadata strategy with fixed precedence tiers:
+
+1. `Tier 1`: strong live actor or NPC match.
+2. `Tier 2`: persisted quest dialogue metadata with exact quest and text match.
+3. `Tier 3`: no reliable hint, so the runtime falls back to the current
+   dialogue flow.
+
+This avoids two common failure modes:
+
+- blindly trusting derived quest metadata when a live actor is already known;
+- relying only on live actor state when the actor is absent, unloaded, or not
+  easily linked to the visible line.
+
+The new subsystem remains auxiliary. `TranslationService` stays the only
+translation orchestrator. The metadata subsystem only enriches dialogue request
+inputs.
+
+## Data Model
+
+Add one dedicated persisted entity:
+
+```csharp
+public sealed class QuestDialogueMetadata
+{
+    public long Id { get; set; }
+
+    public uint QuestId { get; set; }
+    public ushort QuestSequence { get; set; }
+
+    public string SourceLanguageCode { get; set; } = string.Empty;
+    public string GameVersion { get; set; } = string.Empty;
+
+    public string QuestSheetId { get; set; } = string.Empty;
+    public string QuestTextSheetName { get; set; } = string.Empty;
+
+    public string SourceRowKey { get; set; } = string.Empty;
+    public string SourceTextHash { get; set; } = string.Empty;
+    public string SourceTextPreview { get; set; } = string.Empty;
+
+    public string SpeakerHint { get; set; } = string.Empty;
+    public string AddresseeHint { get; set; } = string.Empty;
+
+    public string SpeakerRoleHint { get; set; } = string.Empty;
+    public string AddresseeRoleHint { get; set; } = string.Empty;
+
+    public string Provenance { get; set; } = string.Empty;
+    public int ConfidenceTier { get; set; }
+
+    public string DerivationVersion { get; set; } = string.Empty;
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime UpdatedAtUtc { get; set; }
+}
+```
+
+The logical identity for reuse is:
+
+- `QuestId`
+- `QuestSequence`
+- `SourceLanguageCode`
+- `GameVersion`
+- `SourceRowKey`
+- `SourceTextHash`
+
+`SourceTextPreview` is diagnostic-only and must not be used as the primary
+lookup key.
+
+## Background Generation
+
+### Trigger
+
+When a quest is accepted, the runtime captures only managed immutable values and
+starts a background derivation job.
+
+The capture must be limited to:
+
+- `QuestId`
+- source language
+- game version
+- derivation version
+- timestamp or generation id as needed for task ownership
+
+No quest-sheet parsing or database work may run inline with the acceptance
+callback.
+
+### Derivation
+
+The background worker:
+
+1. resolves the `Quest` row from Lumina;
+2. reads `Quest.Id`;
+3. derives the quest text sheet path;
+4. mounts the raw quest text sheet;
+5. traverses quest text grouped by `QuestSequence`;
+6. builds candidate dialogue metadata entries;
+7. upserts the resulting `QuestDialogueMetadata` rows.
+
+The first cut should derive metadata for the full quest text, not only the
+currently visible sequence, so the persisted entity remains useful outside the
+active quest session later.
+
+### Failure Behavior
+
+Derivation failure must not block quest acceptance, quest UI behavior, or later
+translation. It only means the fallback metadata is unavailable until a later
+successful derivation.
+
+## Runtime Lookup
+
+### Capture Boundary
+
+`Talk` and `BattleTalk` continue to capture only managed immutable values on the
+framework thread. In addition to the current text and speaker, the runtime may
+capture an optional live actor snapshot when a strong actor or NPC match exists.
+
+That snapshot must be copied into managed values before any `await`.
+
+### Query Order
+
+When translating a dialogue line:
+
+1. try `Tier 1` live actor or NPC metadata;
+2. if `Tier 1` is absent or weak, try `Tier 2` persisted quest dialogue
+   metadata;
+3. if neither source is reliable, do not invent an interlocutor hint.
+
+The persisted lookup uses:
+
+- `QuestId`
+- `QuestSequence`
+- `SourceLanguageCode`
+- `GameVersion`
+- `SourceRowKey` and/or `SourceTextHash`
+
+The first cut should only consult the quest metadata path when the quest context
+for the current dialogue line can be resolved with confidence. It should not do
+global text-only fallback across all quests.
+
+## Structured Dialogue Contract Changes
+
+The current request contract already has optional metadata fields, but the
+interlocutor problem needs more explicit optional hints.
+
+Recommended additions:
+
+- `SpeakerGenderHint`
+- `AddresseeHint`
+- `AddresseeRoleHint`
+- `AddresseeGenderHint`
+
+These remain optional. Engines that do not care can ignore them. Structured
+engines receive them in the shared request contract. Plain-text providers may
+receive an equivalent compact metadata block.
+
+## Confidence and Provenance
+
+Confidence must be discrete and auditable, not a free-form score.
+
+Recommended tiers:
+
+- `0`: unknown or unusable
+- `1`: weak derived quest hint
+- `2`: exact derived quest match
+- `3`: strong live actor or NPC match
+
+`Provenance` should capture where the metadata came from, for example:
+
+- `LiveActor`
+- `QuestSheetDerived`
+- `QuestSheetDerivedExact`
+- `QuestSheetPlusLiveFusion`
+
+The first implementation can stay narrower and use only the values it actually
+produces.
+
+## Persistence and Invalidation
+
+This entity is auxiliary, so invalidation rules must be strict and cheap:
+
+- source language mismatch invalidates reuse;
+- game version mismatch invalidates reuse;
+- derivation version mismatch invalidates reuse;
+- missing exact source key or hash match invalidates reuse.
+
+The runtime must never rely on stale rows across those boundaries.
+
+Upsert behavior should replace older rows for the same logical key instead of
+creating duplicates.
+
+## Validation Strategy
+
+Automated validation should cover:
+
+- derivation from a mounted quest text sheet into deterministic entity rows;
+- versioning by source language, game version, and derivation version;
+- exact lookup by `QuestId + QuestSequence + source row-key/hash`;
+- tiered precedence where strong live actor metadata beats persisted quest
+  metadata;
+- clean fallback when metadata is absent or ambiguous;
+- no blocking DB or sheet parsing inside framework and ImGui callback paths.
+
+In-game validation should cover:
+
+- accepting a quest triggers asynchronous metadata generation;
+- a later `Talk` or `BattleTalk` line can consume persisted quest metadata;
+- a line with a strong live NPC match still prefers live metadata;
+- unrelated dialogue does not receive quest hints accidentally.
+
+## Risks
+
+- Quest text may not expose a unique addressee for every line.
+- The same quest sequence can contain multiple dialogue targets, so
+  `QuestId + QuestSequence` alone is not enough.
+- Over-aggressive fallback could worsen output by forcing a wrong interlocutor.
+- A background derivation job could become noisy or expensive if it recomputes
+  the same quest too often.
+
+## Mitigations
+
+- require `SourceRowKey` or `SourceTextHash` in addition to quest identity;
+- store confidence and provenance explicitly;
+- use the fixed tier precedence instead of unconditional overrides;
+- make derivation versioned and upsert-based;
+- keep the subsystem auxiliary so absence of metadata does not break
+  translation.
+
+## First-Cut Scope
+
+The first implementation should stay narrow:
+
+- generate quest dialogue metadata asynchronously when a quest is accepted;
+- persist it in a dedicated table;
+- query it only for `Talk` and `BattleTalk`;
+- prefer strong live actor metadata over persisted quest metadata;
+- enrich the structured request with optional addressee-oriented hints;
+- fall back cleanly when no confident match exists.
+
+This is enough to validate the architecture without expanding into a general
+dialogue knowledge system.

--- a/docs/superpowers/specs/2026-08-12-llm-capability-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-12-llm-capability-matrix-design.md
@@ -1,0 +1,435 @@
+# LLM Capability Matrix Design
+
+**Date:** 2026-08-12
+
+**Repository:** `lokinmodar/Echoglossian`
+
+## Objective
+
+Add one conservative, shared LLM capability matrix that drives both engine
+configuration UI and runtime payload sanitization so Echoglossian stops sending
+model-incompatible parameters and only exposes supported controls for the
+selected LLM model.
+
+## Problem
+
+Recent logs showed multiple classes of provider incompatibility that the current
+architecture does not model centrally:
+
+- some OpenAI reasoning-model chat-completions paths reject
+  `reasoning_effort` when combined with tool-based structured dialogue;
+- some OpenAI models reject non-default `temperature` values;
+- Claude 4.7+ and later models reject non-default sampling parameters;
+- Gemini is deprecating sampling parameters for newer model generations;
+- local or compatibility endpoints may differ by host and model family.
+
+Today those constraints are not represented in one shared policy layer.
+Instead:
+
+- the UI shows generic controls such as `Temperature` with one static range;
+- translators often send configured parameters unconditionally;
+- live model refresh only discovers model identities, not request-shape
+  compatibility;
+- fixes risk being scattered across individual translators and drifting apart.
+
+That creates three user-facing failures:
+
+1. invalid requests reach providers and fail at runtime;
+2. the configuration UI offers controls that are not actually valid for the
+   selected model;
+3. one provider-specific hotfix can leave other LLM translators inconsistent.
+
+## Goals
+
+- Add one shared capability-policy layer for LLM engines only:
+  - OpenAI / ChatGPT and custom OpenAI-compatible
+  - Claude
+  - Gemini
+  - DeepSeek
+  - OpenRouter
+  - Ollama
+  - LM Studio
+- Drive both UI gating and runtime payload sanitization from the same effective
+  policy resolution path.
+- Keep the behavior conservative:
+  - if support is unknown, the runtime omits the parameter;
+  - the UI shows the control disabled with a tooltip rather than pretending it
+    is supported.
+- Reuse the existing live-model refresh flow as the single operator entrypoint
+  for refreshing both model identity and capability overlays.
+- Store live and learned capability overlays in SQLite, not in user config.
+- Support exact-model rules and family-prefix inheritance.
+- Allow bounded auto-learning from clearly classifiable provider `400` errors.
+
+## Non-Goals
+
+- No change to non-LLM translation engines.
+- No second model-discovery pipeline or second refresh button.
+- No replacement of current engine-specific translator classes.
+- No automatic promotion from one observed model error to an entire family.
+- No optimistic assumption that a successful request proves a parameter is
+  universally supported.
+- No provider-body dumps, raw prompts, or credential material in logs.
+- No broad refactor of all model catalog code in this first slice.
+
+## Existing Foundations
+
+The repository already has the right architectural seams for this work:
+
+- static model defaults already exist per engine family;
+- live model refresh already exists through
+  `PluginUI/EngineConfigUI/LiveModelRefreshCoordinator.cs`;
+- live model identity is already tracked by engine-specific model managers such
+  as:
+  - `Translators/OpenAI/OpenAIModelManager.cs`
+  - `Translators/Claude/ClaudeModelManager.cs`
+  - `Translators/Gemini/GeminiModelManager.cs`
+- engine configuration already flows through dedicated UI surfaces and shared
+  dropdown helpers such as
+  `PluginUI/Components/ModelDropdownUI.cs`;
+- SQLite persistence already exists through
+  `EFCoreSqlite/EchoglossianDbContext.cs`.
+
+This design extends those foundations instead of creating a parallel discovery,
+configuration, or translation path.
+
+## Recommended Architecture
+
+Introduce one shared `LLM capability policy` layer between config/UI and the
+translator request builders.
+
+The layer has three pieces:
+
+1. `Static defaults in code`
+   - committed conservative capability defaults per LLM engine family;
+   - includes exact-model and family-prefix rules;
+   - available even before any live refresh runs.
+
+2. `DB overlay`
+   - additive SQLite-backed rules discovered or learned at runtime;
+   - stores live capability overrides and observed provider incompatibilities;
+   - separate from preferences so config remains user-owned settings only.
+
+3. `Effective policy resolver`
+   - computes one effective capability snapshot for a selected engine/provider
+     scope/model;
+   - used by both UI and runtime;
+   - always resolves conflicts conservatively.
+
+The same resolver output must be used in two places:
+
+- `UI`: determine whether a control is enabled, its valid range, and its
+  tooltip explanation;
+- `Runtime`: sanitize outgoing request payloads so unsupported parameters are
+  omitted before the provider request is sent.
+
+## Scope Identity
+
+Capability rules must be scoped more narrowly than engine name alone.
+
+The effective lookup identity should include:
+
+- `engine`
+- `providerScope`
+- `endpointScope`
+- `modelId`
+
+Where:
+
+- `engine` is the plugin engine family such as `ChatGPT`, `Claude`, or
+  `Gemini`;
+- `providerScope` distinguishes semantically different providers inside one
+  engine family, for example:
+  - `OpenAI`
+  - `OpenAI-Compatible`
+  - `OpenRouter`
+- `endpointScope` is a normalized base URL or endpoint identity when the same
+  provider family can behave differently by host, especially for:
+  - custom OpenAI-compatible endpoints
+  - Ollama hosts
+  - LM Studio hosts
+- `modelId` is the exact selected model id.
+
+This keeps official OpenAI behavior separate from custom compatibility servers,
+and local-host behavior separate across installations.
+
+## Data Model
+
+Use two persisted entities.
+
+### 1. `LlmModelCapabilityRule`
+
+This is the effective-rule store used by the resolver.
+
+Representative fields:
+
+```csharp
+public sealed class LlmModelCapabilityRule
+{
+    public long Id { get; set; }
+
+    public string Engine { get; set; } = string.Empty;
+    public string ProviderScope { get; set; } = string.Empty;
+    public string EndpointScope { get; set; } = string.Empty;
+
+    public string MatchType { get; set; } = string.Empty; // ExactModel or FamilyPrefix
+    public string MatchValue { get; set; } = string.Empty;
+
+    public string ParameterName { get; set; } = string.Empty;
+    public string SupportState { get; set; } = string.Empty; // Supported, Unsupported, Unknown
+
+    public float? MinValue { get; set; }
+    public float? MaxValue { get; set; }
+    public string AllowedEnumValuesJson { get; set; } = string.Empty;
+    public bool OmitWhenDefaultOnly { get; set; }
+
+    public string Source { get; set; } = string.Empty; // StaticDefault, LiveRefresh, Observed400, ManualPromotion
+    public string Reason { get; set; } = string.Empty;
+    public string Confidence { get; set; } = string.Empty;
+
+    public DateTime ObservedAtUtc { get; set; }
+    public DateTime? ExpiresAtUtc { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime UpdatedAtUtc { get; set; }
+}
+```
+
+The first implementation only needs to cover the parameters currently exposed
+or already causing real failures, such as:
+
+- `temperature`
+- `top_p`
+- `top_k`
+- `presence_penalty`
+- `frequency_penalty`
+- `reasoning_effort`
+- structured-output mode or tool-calling compatibility where needed for the
+  existing dialogue flows
+
+### 2. `LlmModelCapabilityObservation`
+
+This is a short audit trail for provider feedback that may promote exact-model
+rules later.
+
+Representative fields:
+
+```csharp
+public sealed class LlmModelCapabilityObservation
+{
+    public long Id { get; set; }
+
+    public string Engine { get; set; } = string.Empty;
+    public string ProviderScope { get; set; } = string.Empty;
+    public string EndpointScope { get; set; } = string.Empty;
+    public string ModelId { get; set; } = string.Empty;
+
+    public string ParameterName { get; set; } = string.Empty;
+    public int StatusCode { get; set; }
+    public string ProviderErrorCode { get; set; } = string.Empty;
+    public string MessageExcerpt { get; set; } = string.Empty;
+    public DateTime ObservedAtUtc { get; set; }
+}
+```
+
+Observations are not the runtime lookup source. They exist to support safe
+promotion and postmortem review.
+
+## Static Capability Catalog
+
+The committed-in-code catalog should remain the default authority when the DB is
+empty or stale.
+
+It should be structured enough to express:
+
+- exact model ids such as `gpt-5.6-terra`;
+- family prefixes such as `gpt-5.6-`, `claude-sonnet-`, or `gemini-3`;
+- parameter support states;
+- numeric ranges;
+- `default-only` semantics where a provider only accepts omission or one
+  implicit default.
+
+The first cut should keep this catalog in code rather than introducing a new
+generator or external JSON authority. The shape should still be explicit enough
+that a later migration to a generated catalog is straightforward.
+
+## Effective Resolution Rules
+
+The resolver computes one effective capability snapshot using this precedence:
+
+1. static engine default
+2. DB family-prefix overlay
+3. DB exact-model overlay
+
+Conflict rules:
+
+- more specific beats less specific;
+- DB overlay beats static default at the same specificity;
+- if competing rules remain ambiguous, the effective result must choose the more
+  conservative interpretation.
+
+Conservative interpretation means:
+
+- `Unsupported` beats `Unknown`;
+- `Unknown` beats unconditional `Supported`;
+- narrower numeric ranges beat broader ones;
+- `default-only` means omit from runtime payload unless the current provider
+  contract explicitly requires the value to be sent.
+
+If nothing proves support, runtime behavior is omission.
+
+## Live Refresh Behavior
+
+`Fetch Live Models` remains the only operator-facing refresh entrypoint.
+
+When live refresh runs, it may update two things:
+
+1. the current discovered model list;
+2. any provider metadata that can safely refine capability rules.
+
+Live refresh is best-effort and must not assume every provider returns complete
+capability metadata. Therefore:
+
+- if a provider only returns model ids, only model identity is refreshed and
+  static/family defaults continue to govern capability;
+- if provider metadata is available, the refresh may write more specific rule
+  overlays into SQLite;
+- refresh failure must never wipe known-good static defaults or previously
+  retained compatible overlays;
+- refresh work remains asynchronous and owned by the existing refresh
+  coordinator, with no callback blocking.
+
+## UI Behavior
+
+The configuration UI continues to show the relevant parameter controls, but they
+become policy-aware.
+
+For the selected engine/provider/model:
+
+- unsupported controls remain visible but disabled;
+- a tooltip explains why the control is disabled and where the rule came from,
+  for example:
+  - unsupported by the selected model
+  - default-only for this model family
+  - unknown capability, omitted conservatively
+- when a valid numeric range is known, the UI uses that actual range instead of
+  a one-size-fits-all slider;
+- existing saved config values are not silently discarded, but the runtime may
+  ignore them when incompatible.
+
+This preserves operator visibility while preventing invalid edits.
+
+## Runtime Sanitization
+
+Every LLM translator request path must resolve the effective capability snapshot
+before building its outbound payload.
+
+The sanitization path must be shared logic, not ad hoc per translator, so that:
+
+- plain-text and structured-dialogue requests both obey the same rule set;
+- OpenAI-family compatibility differences are still honored through the scoped
+  lookup identity;
+- one future parameter-policy update automatically applies everywhere the shared
+  helper is used.
+
+Sanitization behavior:
+
+- omit unsupported parameters;
+- omit unknown parameters conservatively;
+- clamp or validate numeric values when the capability range is explicit;
+- honor `default-only` by omission rather than forcing a serialized default;
+- keep the translator-specific request contract otherwise unchanged.
+
+This is the behavior that prevents the current class of `400 unsupported_value`
+and similar parameter-shape failures.
+
+## Auto-Learning From Provider Errors
+
+The first version should support bounded auto-learning from clearly classifiable
+provider rejections.
+
+When a translator receives a provider `400` whose error body clearly indicates a
+parameter incompatibility:
+
+1. record a sanitized `LlmModelCapabilityObservation`;
+2. promote a conservative `LlmModelCapabilityRule` for the exact model only;
+3. use that rule on subsequent requests.
+
+Promotion rules:
+
+- auto-promotion may create or update `ExactModel` rules;
+- auto-promotion must not automatically create `FamilyPrefix` rules;
+- ambiguous or weakly classified errors create observations only and no rule;
+- success does not auto-promote support because one accepted call does not prove
+  global compatibility.
+
+This keeps learning useful without allowing one noisy endpoint to contaminate a
+whole family.
+
+## Logging And Diagnostics
+
+Capability-related diagnostics should remain concise and sanitized.
+
+Allowed diagnostics:
+
+- effective provider/model scope
+- parameter name
+- support decision
+- rule source
+- status code
+- short sanitized provider error excerpt
+
+Disallowed diagnostics:
+
+- raw request payloads
+- prompts
+- glossary contents
+- API keys or auth headers
+- full provider response bodies when they may echo sensitive input
+
+## Testing Strategy
+
+The first implementation should add focused automated coverage for:
+
+1. `Resolver precedence`
+   - exact-model overrides beat family rules;
+   - family rules beat static defaults;
+   - ambiguous conflicts resolve conservatively.
+
+2. `Payload sanitization`
+   - unsupported and unknown parameters are omitted;
+   - default-only parameters are omitted;
+   - explicit supported ranges clamp or validate correctly.
+
+3. `Error classification and learning`
+   - classifiable `400` errors create observations and exact-model rules;
+   - ambiguous errors do not promote rules;
+   - no auto-promotion to family rules occurs.
+
+4. `UI gating helpers`
+   - controls remain visible;
+   - controls disable correctly;
+   - tooltip text reflects rule source and reason;
+   - range-aware controls honor policy ranges.
+
+5. `Persistence`
+   - additive EF migration succeeds;
+   - startup can load an empty or partially populated capability DB safely.
+
+`Echoglossian.Mock.Tests` may be used only to verify startup and migration
+integration if needed. Capability correctness itself should remain covered by
+unit tests rather than in-game-only validation.
+
+## Acceptance
+
+This design is complete when the implementation can demonstrate that:
+
+- selecting an incompatible LLM model disables unsupported configuration
+  controls with explanatory tooltips;
+- the runtime omits unsupported or unknown parameters before sending provider
+  requests;
+- clearly classifiable provider `400` rejections can teach an exact-model
+  conservative rule without operator intervention;
+- live-model refresh remains the only refresh entrypoint and does not block
+  Dalamud or ImGui callbacks;
+- the same effective policy governs both UI and runtime behavior across the LLM
+  engines in scope.

--- a/docs/superpowers/specs/2026-08-13-structured-dialogue-debug-observability-design.md
+++ b/docs/superpowers/specs/2026-08-13-structured-dialogue-debug-observability-design.md
@@ -1,0 +1,324 @@
+# Structured Dialogue Debug Observability Design
+
+**Date:** 2026-08-13
+
+**Repository:** `lokinmodar/Echoglossian`
+
+## Objective
+
+Add one shared debug-only structured-dialogue observability layer that proves,
+for every LLM structured-dialogue attempt:
+
+- what prompt shape was prepared;
+- which effective capability decisions were applied;
+- which provider route and model were used;
+- whether glossary/context were included;
+- whether the request succeeded, validated, or downgraded.
+
+The design must reinforce the existing LLM capability matrix rather than
+introducing new provider-specific policy drift.
+
+## Problem
+
+Current logs show only part of the structured-dialogue pipeline:
+
+- `TranslationService: TranslateAsync called...`
+- dialogue-context summary
+- some structured fallback diagnostics on failure
+
+That leaves important gaps:
+
+1. we cannot prove from logs that the structured prompt payload was actually
+   emitted;
+2. we cannot tell whether glossary entries were included in the structured
+   request;
+3. we cannot tell which effective capability decision was applied for each
+   parameter such as `temperature` or `reasoning_effort`;
+4. we cannot tell what raw structured payload came back before validation;
+5. success paths are less observable than failure paths.
+
+This has created uncertainty around whether fixes are architectural or merely
+local bandaids.
+
+## Goals
+
+- Keep diagnostics in normal debug logging only. No extra diagnostic file.
+- Emit one shared structured logging shape across all structured LLM
+  translators:
+  - ChatGPT / OpenAI
+  - OpenRouter
+  - DeepSeek
+  - Gemini
+  - Claude
+  - Ollama
+  - LM Studio
+- Show the effective capability decision used at runtime, including whether a
+  parameter was:
+  - sent as configured;
+  - omitted due to unsupported or default-only policy;
+  - forced to an explicit transport-specific disable such as
+    `reasoning_effort=none`.
+- Show whether glossary/context were present in the structured request.
+- Show bounded sanitized previews for request and response content.
+- Preserve the capability matrix as the only policy authority.
+
+## Non-Goals
+
+- No new persisted diagnostics table or file.
+- No broad refactor into one universal provider executor in this slice.
+- No raw prompt dumps, full provider bodies, API keys, bearer tokens, or
+  complete glossary contents in logs.
+- No new UI.
+- No replacement of existing translator classes.
+
+## Existing Foundations
+
+The repository already has the right building blocks:
+
+- shared structured request builder:
+  - `StructuredDialogueTranslationRequestBuilder`
+- shared OpenAI-style schema and prompt helpers:
+  - `StructuredDialogueOpenAiToolHelper`
+  - `StructuredDialogueOpenAiCompatiblePayloadHelper`
+- shared validation path:
+  - `StructuredDialogueTranslationResponseValidator`
+- shared structured fallback formatting:
+  - `StructuredDialogueDiagnosticsHelper`
+- shared capability matrix:
+  - static catalog
+  - SQLite overlay rules and observations
+  - resolver / policy service
+
+The new work should extend those shared seams rather than adding free-form
+per-provider logs.
+
+## Recommended Approach
+
+Extend the existing structured diagnostics helper into one shared debug
+observability surface with three standardized log phases:
+
+1. `structured-start`
+2. `structured-success`
+3. `structured-fallback`
+
+Each structured translator continues to own transport-specific request
+construction, but every translator must emit the same debug contract before and
+after its provider call.
+
+This keeps policy central and transport local:
+
+- **policy** stays in the capability matrix and shared request logic;
+- **transport adaptation** stays in each translator where SDK or HTTP request
+  shapes differ.
+
+That means a future model incompatibility should be fixed by:
+
+- updating the shared static catalog or learned DB overlay;
+- or adjusting one transport adapter to honor the same shared policy;
+
+not by inventing new policy branches inside each translator.
+
+## Shared Debug Contract
+
+### 1. `structured-start`
+
+Emit immediately before the provider request is sent.
+
+Required fields:
+
+- `provider`
+- `endpointScope`
+- `route`
+- `model`
+- `capability`
+- `sessionNamespace`
+- `priorTurns`
+- `glossaryCount`
+- `glossaryApplied`
+- `speakerMetadataPresent`
+- `addresseeMetadataPresent`
+- `requestPromptLength`
+- `requestJsonLength` when a serialized request body exists
+- `promptPreview`
+- `sourcePreview`
+- `capabilityDecisions`
+
+`capabilityDecisions` must use normalized tokens derived from the effective
+matrix decision. Representative examples:
+
+- `temperature=sent(configured)`
+- `temperature=omitted(default-only)`
+- `temperature=omitted(unsupported)`
+- `reasoning_effort=explicit-none(unsupported)`
+- `reasoning_effort=sent(configured)`
+- `reasoning_effort=omitted(unknown)`
+
+The key rule is that these tokens describe the **effective runtime decision**,
+not merely the static catalog entry.
+
+### 2. `structured-success`
+
+Emit after the provider response is parsed and validated successfully, before
+the translated text is returned.
+
+Required fields:
+
+- `provider`
+- `endpointScope`
+- `route`
+- `model`
+- `capability`
+- `glossaryApplied`
+- `rawPayloadLength`
+- `translatedLength`
+- `translatedPreview`
+- `rawPayloadPreview`
+
+This is what proves "what came back" without dumping the entire response body.
+
+### 3. `structured-fallback`
+
+Keep the existing fallback diagnostics, but extend them to include enough
+shared request context to correlate with `structured-start`:
+
+- `provider`
+- `endpointScope`
+- `route`
+- `model`
+- `capability`
+- `stage`
+- `reason`
+- `status`
+- `excerpt`
+- `capabilityDecisions`
+- `glossaryApplied`
+
+This keeps failure logs structurally consistent with success logs.
+
+## Sanitization Rules
+
+All previews must be bounded and sanitized.
+
+Requirements:
+
+- redact API keys, bearer tokens, `authorization`, `apiKey`, `token`,
+  `password`, and similar assignments;
+- normalize whitespace into one line;
+- cap previews to a short fixed length;
+- log glossary count and presence, not full glossary contents;
+- log prompt and response previews only after sanitization;
+- never log raw provider JSON bodies in full.
+
+The current helper already sanitizes excerpts. The same style must be reused
+for request and success previews.
+
+## Provider Integration Pattern
+
+Every structured translator should follow the same sequencing:
+
+1. build normalized structured request object;
+2. compute effective capability decisions from the shared capability matrix;
+3. build transport-specific request payload;
+4. emit `structured-start`;
+5. send request;
+6. extract raw structured payload;
+7. validate payload;
+8. emit `structured-success` or `structured-fallback`;
+9. return translated text or downgrade to the plain-text path.
+
+### ChatGPT / OpenAI
+
+ChatGPT remains the only current translator with `reasoning_effort` in the
+structured path. That is acceptable as a transport-specific detail, as long as:
+
+- the decision source remains the shared capability matrix;
+- the debug logs explicitly show whether the runtime sent:
+  - configured reasoning effort,
+  - explicit `none`,
+  - or omission.
+
+This is not considered a bandaid because the policy does not live in a
+ChatGPT-only ad hoc branch. The transport mapping is local, but the decision
+authority remains shared.
+
+### Other Structured Translators
+
+Gemini, OpenRouter, DeepSeek, Claude, Ollama, and LM Studio should emit the
+same structured debug lifecycle even if they currently only consume a subset of
+capability decisions such as temperature.
+
+That keeps observability and future compatibility expansion uniform.
+
+## Why This Is Not A Per-Model Bandaid
+
+The architectural rule is:
+
+- translators may differ in **how** they encode a supported or unsupported
+  parameter for their transport;
+- translators must not differ in **whether** a parameter is considered
+  supported.
+
+Support state belongs to:
+
+- static catalog defaults;
+- DB overlay rules;
+- learned observations promoted into rules;
+- one shared resolver.
+
+The new debug layer should reveal that chain clearly at runtime. If a future
+model fails, the intended correction path is to update the capability rule or
+promotion logic, not to scatter more hidden conditional logic.
+
+## Testing Strategy
+
+Add or extend unit tests for:
+
+- `StructuredDialogueDiagnosticsHelper`
+  - start message format
+  - success message format
+  - fallback message extensions
+  - sanitization and truncation
+- capability decision token formatting
+  - sent
+  - omitted unsupported
+  - omitted default-only
+  - explicit disable such as `none`
+- ChatGPT structured reasoning diagnostics
+  - unsupported rule produces `explicit-none`
+- representative non-ChatGPT structured diagnostics
+  - temperature omission/sending tokens
+
+The tests should focus on formatted debug behavior and not require live
+provider calls.
+
+## Validation
+
+Implementation validation should include:
+
+- `dotnet build Echoglossian.sln -c Debug --no-restore`
+- targeted test execution for diagnostics and capability-policy tests
+- one in-game debug-log check confirming:
+  - `structured-start` appears for a Talk interaction;
+  - the log shows `glossaryCount` and `capabilityDecisions`;
+  - either `structured-success` or `structured-fallback` follows with the same
+    provider/model/route context.
+
+## Risks
+
+- adding too much noisy debug output can make logs harder to scan;
+- prompt previews that are too long can become quasi-dumps;
+- each translator has slightly different transport plumbing, so the shared
+  contract must stay simple enough to adopt consistently.
+
+The mitigation is to keep one compact structured line per phase with bounded
+preview sizes.
+
+## Recommended Implementation Scope
+
+Keep the patch narrow:
+
+- extend `StructuredDialogueDiagnosticsHelper`;
+- add any small shared formatter types needed for capability decision tokens;
+- wire the shared helper into all structured translators;
+- add targeted unit tests;
+- avoid larger executor refactors in this slice.

--- a/vendor/DalaMock/DalaMock/Mocks/DalamudServices/MockFramework.cs
+++ b/vendor/DalaMock/DalaMock/Mocks/DalamudServices/MockFramework.cs
@@ -430,7 +430,9 @@ public class MockFramework : IDisposable, IFramework, IMockService
         private readonly MockFramework framework;
         private readonly TimeSpan delay;
         private readonly System.Action action;
-        private readonly Timer timer;
+        private readonly object sync = new();
+        private Timer? timer;
+        private long generation;
         private bool disposed;
 
         internal MockDebouncer(MockFramework framework, TimeSpan delay, System.Action action)
@@ -438,44 +440,75 @@ public class MockFramework : IDisposable, IFramework, IMockService
             this.framework = framework;
             this.delay = delay;
             this.action = action;
-            this.timer = new Timer(this.OnTimerElapsed);
         }
 
-        public bool IsPending { get; private set; }
+        public bool IsPending
+        {
+            get
+            {
+                lock (this.sync)
+                {
+                    return this.timer is not null;
+                }
+            }
+        }
 
         public void Debounce()
         {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-            this.IsPending = true;
-            this.timer.Change(this.delay, Timeout.InfiniteTimeSpan);
+            lock (this.sync)
+            {
+                ObjectDisposedException.ThrowIf(this.disposed, this);
+                this.generation++;
+                this.timer?.Dispose();
+                this.timer = new Timer(
+                    state => this.OnTimerElapsed((long)state!),
+                    this.generation,
+                    this.delay,
+                    Timeout.InfiniteTimeSpan);
+            }
         }
 
         public void Cancel()
         {
-            this.IsPending = false;
-            this.timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            lock (this.sync)
+            {
+                this.generation++;
+                this.timer?.Dispose();
+                this.timer = null;
+            }
         }
 
         public void Dispose()
         {
-            if (this.disposed)
+            lock (this.sync)
             {
-                return;
-            }
+                if (this.disposed)
+                {
+                    return;
+                }
 
-            this.disposed = true;
-            this.timer.Dispose();
+                this.disposed = true;
+                this.generation++;
+                this.timer?.Dispose();
+                this.timer = null;
+            }
         }
 
-        private void OnTimerElapsed(object? state)
+        private void OnTimerElapsed(long callbackGeneration)
         {
-            if (this.disposed || !this.IsPending)
+            lock (this.sync)
             {
-                return;
-            }
+                if (this.disposed ||
+                    this.timer is null ||
+                    callbackGeneration != this.generation)
+                {
+                    return;
+                }
 
-            this.IsPending = false;
-            _ = this.framework.RunOnTick(this.action);
+                this.timer.Dispose();
+                this.timer = null;
+                _ = this.framework.RunOnTick(this.action);
+            }
         }
     }
 

--- a/vendor/DalaMock/DalaMock/Mocks/DalamudServices/MockFramework.cs
+++ b/vendor/DalaMock/DalaMock/Mocks/DalamudServices/MockFramework.cs
@@ -507,8 +507,21 @@ public class MockFramework : IDisposable, IFramework, IMockService
 
                 this.timer.Dispose();
                 this.timer = null;
-                _ = this.framework.RunOnTick(this.action);
+                _ = this.framework.RunOnTick(() => this.RunActionIfCurrent(callbackGeneration));
             }
+        }
+
+        private void RunActionIfCurrent(long callbackGeneration)
+        {
+            lock (this.sync)
+            {
+                if (this.disposed || callbackGeneration != this.generation)
+                {
+                    return;
+                }
+            }
+
+            this.action();
         }
     }
 

--- a/vendor/DalaMock/DalaMock/Mocks/DalamudServices/MockFramework.cs
+++ b/vendor/DalaMock/DalaMock/Mocks/DalamudServices/MockFramework.cs
@@ -80,6 +80,11 @@ public class MockFramework : IDisposable, IFramework, IMockService
         throw new NotImplementedException();
     }
 
+    public IDebouncer CreateDebouncer(TimeSpan delay, System.Action action)
+    {
+        return new MockDebouncer(this, delay, action);
+    }
+
     public Task DelayTicks(long numTicks, CancellationToken cancellationToken = default(CancellationToken))
     {
         return Task.CompletedTask;
@@ -419,6 +424,60 @@ public class MockFramework : IDisposable, IFramework, IMockService
     private delegate bool OnUpdateDetour(IntPtr framework);
 
     private delegate IntPtr OnDestroyDetour(); // OnDestroyDelegate
+
+    private sealed class MockDebouncer : IDebouncer
+    {
+        private readonly MockFramework framework;
+        private readonly TimeSpan delay;
+        private readonly System.Action action;
+        private readonly Timer timer;
+        private bool disposed;
+
+        internal MockDebouncer(MockFramework framework, TimeSpan delay, System.Action action)
+        {
+            this.framework = framework;
+            this.delay = delay;
+            this.action = action;
+            this.timer = new Timer(this.OnTimerElapsed);
+        }
+
+        public bool IsPending { get; private set; }
+
+        public void Debounce()
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+            this.IsPending = true;
+            this.timer.Change(this.delay, Timeout.InfiniteTimeSpan);
+        }
+
+        public void Cancel()
+        {
+            this.IsPending = false;
+            this.timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.timer.Dispose();
+        }
+
+        private void OnTimerElapsed(object? state)
+        {
+            if (this.disposed || !this.IsPending)
+            {
+                return;
+            }
+
+            this.IsPending = false;
+            _ = this.framework.RunOnTick(this.action);
+        }
+    }
 
     private abstract class RunOnNextTickTaskBase
     {

--- a/vendor/DalaMock/DalaMock/Mocks/Objects/MockCharacter.cs
+++ b/vendor/DalaMock/DalaMock/Mocks/Objects/MockCharacter.cs
@@ -145,6 +145,14 @@ public class MockCharacter : ICharacter
     }
 
     /// <inheritdoc/>
+    [ImGuiGroup("Position")]
+    public byte CurrentDistance { get; set; }
+
+    /// <inheritdoc/>
+    [ImGuiGroup("Position")]
+    public byte NextDistance { get; set; }
+
+    /// <inheritdoc/>
     [ImGuiGroup("Basic")]
     public bool IsDead
     {


### PR DESCRIPTION
## Summary
Implements issue #214 by making first-dialogue speaker context derive from stable game/runtime data instead of prompt-only guesses.

This branch now:
- captures local-player sex from `IPlayerState.Sex`
- resolves NPC sex/race metadata from live actor and model state when available
- precomputes and persists quest-scoped dialogue interlocutor metadata keyed to accepted-quest progress
- fuses live actor hints with precomputed quest-dialogue fallback so first-contact dialogue can identify the addressed speaker before prior conversation history exists
- keeps the work on the existing `TranslationService` / broker / DB-first flow without introducing a second translation pipeline

## Runtime notes
- accepted-quest callbacks now capture immutable managed values only and defer Lumina/sheet traversal to background work
- worker-side quest-progress resolution no longer calls framework-bound quest APIs off-thread
- quest-dialogue derivation and prefetch traversal now observe cancellation during long sheet walks
- pre-cancelled translation requests are rejected before invoking providers
- Mock debouncer invalidation and quest-dialogue metadata persistence semantics were tightened during final review

## Validation
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1` -> Passed `1175/1175`
- `dotnet build Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-restore`
- `dotnet test Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1` -> Passed `24/24`
- `git diff --check`

## Remaining blocker
Automated validation is green, but merge is still blocked on real in-game verification evidence for the first-dialogue speaker-context scenarios covered by #214. This PR should stay unmerged until that runtime evidence is captured.