### PR TITLE
docs: mark v4.2601.0809.0046 as published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
-## Submitted Release `v4.2601.0809.0046`
+## Published Release `v4.2601.0809.0046`
 
-This package submits the runtime localization correction merged through
+This package was published to the official Dalamud feed with the runtime
+localization correction merged through
 [PR #260](https://github.com/lokinmodar/Echoglossian/pull/260). It keeps the
 locale-specific resource naming introduced for Crowdin while ensuring the
 plugin actually loads the locale selected in its configuration.
+
+Published in `DalamudPluginsD17` via
+[PR #9177](https://github.com/goatcorp/DalamudPluginsD17/pull/9177) on
+2026-08-09.
 
 Highlights:
 
@@ -287,6 +292,8 @@ repository workflow.
 | 2026-07-19 | [PR #9031](https://github.com/goatcorp/DalamudPluginsD17/pull/9031) `v4.2601.0718.2006` | OpenRouter live-model refresh and hosted preview infrastructure follow-up |
 | 2026-08-05 | [PR #9125](https://github.com/goatcorp/DalamudPluginsD17/pull/9125) `v4.2601.0802.2355` | broad native UI runtime expansion across selection dialogs, tooltips, quest surfaces, nameplates, toasts, persistence, and diagnostics |
 | 2026-08-06 | [PR #9151](https://github.com/goatcorp/DalamudPluginsD17/pull/9151) `v4.2601.0806.0051` | MiniTalk native bubble stabilization follow-up, ActionDetail and ItemDetail overlay control activation, and localized plugin-label sync |
+| 2026-08-08 | [PR #9163](https://github.com/goatcorp/DalamudPluginsD17/pull/9163) `v4.2601.0807.1730` | MiniTalk recycled-bubble height stabilization follow-up |
+| 2026-08-09 | [PR #9177](https://github.com/goatcorp/DalamudPluginsD17/pull/9177) `v4.2601.0809.0046` | plugin UI culture application, locale-specific resource loading, and localization guardrails |
 
 ## Pre-Official History
 

--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -1,6 +1,6 @@
 # GitHub Issue Backlog
 
-Snapshot date: 2026-08-08
+Snapshot date: 2026-08-09
 
 This document is the operational snapshot for open issues in
 [`lokinmodar/Echoglossian`](https://github.com/lokinmodar/Echoglossian/issues).
@@ -9,21 +9,22 @@ release history belongs in [`CHANGELOG.md`](../CHANGELOG.md), not in this file.
 
 ## Published Release Baseline
 
-- Release: [`v4.2601.0807.1730`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0807.1730)
-- Product commit: `9a39a2be87c3a376448f2967ccc5225c63b1e69c`
-- Official submission: [`goatcorp/DalamudPluginsD17#9163`](https://github.com/goatcorp/DalamudPluginsD17/pull/9163)
-- D17 status: approved and merged on 2026-08-08
-- D17 merge commit: `12ca53c2095b4be958d61e065565131723c0e75e`
+- Release: [`v4.2601.0809.0046`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0809.0046)
+- Product commit: `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
+- Official submission: [`goatcorp/DalamudPluginsD17#9177`](https://github.com/goatcorp/DalamudPluginsD17/pull/9177)
+- D17 status: approved and merged on 2026-08-09
+- D17 merge commit: `1a033922f52afd74640c620bcc1145be8e8a7cbe`
 - Open issues after post-publication triage: 20
 - Open issues at the current audit head: 20
 - Focused open issues besides the living tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12): 19
 
 ## Current `v4-series` Delta
 
-- Audit head: `origin/v4-series` at `9a39a2be87c3a376448f2967ccc5225c63b1e69c`
-- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0807.1730` at `9a39a2be87c3a376448f2967ccc5225c63b1e69c`
+- Audit head: `origin/v4-series` at `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
+- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0809.0046` at `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
 - The audit head currently matches the latest published runtime baseline; there are no newer `v4-series` commits beyond this published release.
 - Issue [#12](https://github.com/lokinmodar/Echoglossian/issues/12) remains the living known-issues tracker and should stay aligned with this document whenever focused issue state changes materially.
+- Publication of `v4.2601.0809.0046` completed the plugin UI culture-loading correction from [PR #260](https://github.com/lokinmodar/Echoglossian/pull/260), including explicit locale selection and locale-specific resource fallback safeguards.
 - Publication of `v4.2601.0807.1730` completed the recycled `_MiniTalk` follow-up for [#246](https://github.com/lokinmodar/Echoglossian/issues/246).
 - New focused prompt and glossary behavior work is currently tracked in [#252](https://github.com/lokinmodar/Echoglossian/issues/252).
 - New performance and persistence architecture work is now tracked in [#258](https://github.com/lokinmodar/Echoglossian/issues/258).


### PR DESCRIPTION
## Summary

- mark `v4.2601.0809.0046` as published after goatcorp/DalamudPluginsD17#9177 merged
- record the official D17 PR, publication date, and merge commit
- advance the backlog release baseline and audit head while preserving the verified 20-open-issue inventory

## Validation

- [x] confirmed D17 PR #9177 is merged and both official checks passed
- [x] confirmed the official manifest points to `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
- [x] confirmed the GitHub release targets the same commit
- [x] audited the live open-issue inventory: 20 issues, unchanged
- [x] `git diff --check`

Documentation-only bookkeeping; no product build was required.

## AI Usage Disclosure

- [x] `Assist` — human-led work with AI used for specific tasks

AI scope:
- tooling used: Codex
- files or areas most affected: release changelog and issue-backlog baseline
- how the result was reviewed/tested: publication state, hashes, official manifest, and live issue count were verified directly before commit

## AI-Generated Assets Disclosure

AI-generated assets:
- none