### PR TITLE
fix: restore native BattleTalk and MiniTalk baselines

### DIFF
--- a/Echoglossian.Tests/BattleTalkNativeLayoutContractTests.cs
+++ b/Echoglossian.Tests/BattleTalkNativeLayoutContractTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using System.IO;
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+///     Guards the BattleTalk native-layout restore and sizing contract for
+///     regression fixes such as issue #264.
+/// </summary>
+public sealed class BattleTalkNativeLayoutContractTests
+{
+    /// <summary>
+    ///     Ensures BattleTalk falls back to layout-only cleanup when the game
+    ///     repaints live text before the plugin can restore its replacement.
+    /// </summary>
+    [Fact]
+    public void BattleTalkHandler_UsesLayoutFallbackCleanupForGameRepaintedText()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "AddonHandlers",
+            "Talk",
+            "BattleTalkHandler.cs"));
+
+        Assert.Contains(
+            "NativeMutationOwnership.TryRestoreWithLayoutFallback(",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Ensures BattleTalk measures wrapped native text from the clean
+    ///     text-node width instead of deriving a replacement wrap width from
+    ///     the parent or background containers.
+    /// </summary>
+    [Fact]
+    public void BattleTalkHandler_UsesTextNodeBaselineWidthForNativeWrapMeasurement()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "AddonHandlers",
+            "Talk",
+            "BattleTalkHandler.cs"));
+
+        Assert.Contains(
+            "var preferredWrapWidth = NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "        textNode);",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "var preferredWrapWidth = NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(\r\n        textNode,\r\n        parentNode,\r\n        backgroundNode);",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Ensures BattleTalk opts into an explicit fixed-horizontal geometry
+    ///     policy so timer anchors and game-owned widths stay untouched while
+    ///     translated text grows only vertically.
+    /// </summary>
+    [Fact]
+    public void BattleTalkHandler_UsesFixedHorizontalGeometryPolicyForNativeResize()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "AddonHandlers",
+            "Talk",
+            "BattleTalkHandler.cs"));
+
+        Assert.Contains(
+            "preserveHorizontalGeometry: true",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Locates the repository root from the test assembly output path.
+    /// </summary>
+    /// <returns>The repository root directory.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null &&
+               !File.Exists(Path.Combine(directory.FullName, "Echoglossian.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory ?? throw new DirectoryNotFoundException(
+            "Could not locate Echoglossian.sln from the current test output path.");
+    }
+}

--- a/Echoglossian.Tests/BattleTalkNativeLayoutContractTests.cs
+++ b/Echoglossian.Tests/BattleTalkNativeLayoutContractTests.cs
@@ -85,6 +85,48 @@ public sealed class BattleTalkNativeLayoutContractTests
     }
 
     /// <summary>
+    ///     Ensures BattleTalk explicitly opts into compact wrapped-height
+    ///     measurement only for its known stale-layout reuse path instead of
+    ///     relying on a global helper override.
+    /// </summary>
+    [Fact]
+    public void BattleTalkHandler_UsesCompactWrappedHeightPolicyForNativeMeasurement()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "AddonHandlers",
+            "Talk",
+            "BattleTalkHandler.cs"));
+
+        Assert.Contains(
+            "preferCompactWrappedHeight: true",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Ensures MiniTalk explicitly opts into compact wrapped-height
+    ///     measurement for pooled-slot reuse without changing the shared helper
+    ///     policy for unrelated native surfaces.
+    /// </summary>
+    [Fact]
+    public void MiniTalkHandler_UsesCompactWrappedHeightPolicyForNativeMeasurement()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "NativeUI",
+            "AddonHandlers",
+            "SingleText",
+            "MiniTalkHandler.cs"));
+
+        Assert.Contains(
+            "preferCompactWrappedHeight: true",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     ///     Locates the repository root from the test assembly output path.
     /// </summary>
     /// <returns>The repository root directory.</returns>

--- a/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
+++ b/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
@@ -34,6 +34,25 @@ public class NativeTextNodeLayoutHelperTests
     }
 
     /// <summary>
+    ///     Ensures wrapped text measurement preserves the larger live height by
+    ///     default when it may represent intentional game-owned padding rather
+    ///     than a stale plugin-applied extent.
+    /// </summary>
+    [Fact]
+    public void ResolveMeasuredTextExtent_PreservesWrappedLiveHeightByDefault_WhenItExceedsDrawHeight()
+    {
+        var resolved = NativeTextNodeLayoutHelper.ResolveMeasuredTextExtent(
+            liveWidth: 392,
+            liveHeight: 118,
+            drawWidth: 368,
+            drawHeight: 42,
+            textFlags: TextFlags.WordWrap | TextFlags.MultiLine | TextFlags.AutoAdjustNodeSize);
+
+        Assert.Equal((ushort)392, resolved.Width);
+        Assert.Equal((ushort)118, resolved.Height);
+    }
+
+    /// <summary>
     ///     Ensures zero-sized nodes still fall back to the text draw size.
     /// </summary>
     [Fact]
@@ -63,7 +82,8 @@ public class NativeTextNodeLayoutHelperTests
             liveHeight: 118,
             drawWidth: 368,
             drawHeight: 42,
-            textFlags: TextFlags.WordWrap | TextFlags.MultiLine | TextFlags.AutoAdjustNodeSize);
+            textFlags: TextFlags.WordWrap | TextFlags.MultiLine | TextFlags.AutoAdjustNodeSize,
+            preferCompactWrappedHeight: true);
 
         Assert.Equal((ushort)392, resolved.Width);
         Assert.Equal((ushort)42, resolved.Height);

--- a/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
+++ b/Echoglossian.Tests/NativeTextNodeLayoutHelperTests.cs
@@ -51,6 +51,25 @@ public class NativeTextNodeLayoutHelperTests
     }
 
     /// <summary>
+    ///     Ensures wrapped native measurement does not keep a stale translated
+    ///     high-water height when the live node was already left oversized by a
+    ///     previous apply.
+    /// </summary>
+    [Fact]
+    public void ResolveMeasuredTextExtent_IgnoresStaleWrappedLiveHeight_WhenDrawHeightIsShorter()
+    {
+        var resolved = NativeTextNodeLayoutHelper.ResolveMeasuredTextExtent(
+            liveWidth: 392,
+            liveHeight: 118,
+            drawWidth: 368,
+            drawHeight: 42,
+            textFlags: TextFlags.WordWrap | TextFlags.MultiLine | TextFlags.AutoAdjustNodeSize);
+
+        Assert.Equal((ushort)392, resolved.Width);
+        Assert.Equal((ushort)42, resolved.Height);
+    }
+
+    /// <summary>
     ///     Ensures pre-apply native width measurement honors explicit tooltip
     ///     line breaks instead of treating the whole payload as one unwrapped
     ///     line.

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -24086,6 +24086,19 @@
                 <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.ResolveBubbleKey(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.IntPtr)">
+            <summary>
+                Resolves one stable MiniTalk bubble key from the owning component slot
+                when available so pooled-slot reuse restores the prior dirty baseline
+                before any new source or text-node address is captured.
+            </summary>
+            <param name="textNode">The visible MiniTalk text node.</param>
+            <param name="fallbackBubbleKey">
+                The fallback key to use when no owning component container can be
+                resolved.
+            </param>
+            <returns>The stable key used for native and overlay state.</returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.SingleText.MiniTalkHandler.TryReadCurrentSource(System.IntPtr,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String@)">
             <summary>
                 Reads the logical source text from the live MiniTalk addon, mapping the
@@ -29460,7 +29473,7 @@
             </param>
             <returns>The measured size after the text replacement.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResizeFromSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,Echoglossian.NativeUI.Helpers.NativeTextNodeResizeResult,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean,System.Boolean,System.Int32,System.Int32,System.Boolean)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResizeFromSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,Echoglossian.NativeUI.Helpers.NativeTextNodeResizeResult,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean,System.Boolean,System.Int32,System.Int32,System.Boolean,System.Boolean)">
             <summary>
                 Resizes the supplied container nodes using the text delta captured in a
                 pre-replacement layout snapshot.
@@ -29497,6 +29510,11 @@
                 Whether detached-container height synchronization should explicitly
                 prefer the more compact of the preserved container baselines instead
                 of preserving the largest detached extent.
+            </param>
+            <param name="preserveHorizontalGeometry">
+                Whether horizontal geometry such as sibling anchor X positions and
+                secondary-container widths must remain fixed to the captured baseline
+                instead of being recomputed from the resized text width.
             </param>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutSnapshot,System.String,System.Boolean,System.Boolean)">

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -29415,7 +29415,7 @@
                 UI to wrap multi-line text and keep nearby background nodes in sync.
             </summary>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.CaptureLayoutSnapshot(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.CaptureLayoutSnapshot(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*,System.Boolean)">
             <summary>
                 Captures the current text-node and container sizing so a later native
                 replacement can grow the layout using inferred padding instead of fixed
@@ -29430,6 +29430,11 @@
             </param>
             <param name="anchoredXNode">
                 An optional sibling node whose X position is anchored to the text width.
+            </param>
+            <param name="preferCompactWrappedHeight">
+                Whether wrapped-node height measurement should prefer the current draw
+                height over a larger live node height when callers know the live
+                extent may still reflect stale plugin-applied growth.
             </param>
             <returns>The captured layout snapshot.</returns>
         </member>
@@ -29448,7 +29453,7 @@
             </param>
             <returns>The preferred wrap width to preserve.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyWrappedTextAndMeasure(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.UInt16,System.Boolean,System.Boolean,System.Byte[])">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyWrappedTextAndMeasure(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.UInt16,System.Boolean,System.Boolean,System.Byte[],System.Boolean)">
             <summary>
                 Applies translated text to a node using the existing wrap width and the
                 minimum multiline flags required for the game to recompute size.
@@ -29470,6 +29475,11 @@
             <param name="replacementPayload">
                 The optional rich SeString payload to write after layout flags and
                 wrap width are prepared.
+            </param>
+            <param name="preferCompactWrappedHeight">
+                Whether wrapped-node height measurement should prefer the current draw
+                height over a larger live node height when callers know the live
+                extent may still reflect stale plugin-applied growth.
             </param>
             <returns>The measured size after the text replacement.</returns>
         </member>
@@ -29545,7 +29555,7 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.Boolean,System.Boolean,System.UInt16,System.Int32,System.Int32,System.Boolean,System.Boolean,System.Byte[])">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*,FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.String,System.Boolean,System.Boolean,System.UInt16,System.Int32,System.Int32,System.Boolean,System.Boolean,System.Byte[],System.Boolean)">
             <summary>
                 Applies translated text to a node and grows its wrapper chain plus the
                 nearest nine-grid background using inferred padding from the current
@@ -29585,6 +29595,11 @@
             <param name="replacementPayload">
                 The optional rich SeString payload to write while keeping the same
                 replacement-text measurement and layout flow.
+            </param>
+            <param name="preferCompactWrappedHeight">
+                Whether wrapped-node height measurement should prefer the current draw
+                height over a larger live node height when callers know the live
+                extent may still reflect stale plugin-applied growth.
             </param>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveReplacementWrapWidth(System.UInt16,System.UInt16,System.Boolean)">
@@ -29637,7 +29652,7 @@
             </param>
             <returns>The width that should remain on the text node.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveMeasuredTextExtent(System.UInt16,System.UInt16,System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.ResolveMeasuredTextExtent(System.UInt16,System.UInt16,System.UInt16,System.UInt16,FFXIVClientStructs.FFXIV.Component.GUI.TextFlags,System.Boolean)">
             <summary>
                 Resolves the effective measured text extent by combining the live node
                 size with the text draw size when wrapped text still reports a stale
@@ -29648,6 +29663,11 @@
             <param name="drawWidth">The measured text draw width.</param>
             <param name="drawHeight">The measured text draw height.</param>
             <param name="textFlags">The live text flags.</param>
+            <param name="preferCompactWrappedHeight">
+                Whether wrapped-node height measurement should prefer the current draw
+                height over a larger live node height when callers know the live
+                extent may still reflect stale plugin-applied growth.
+            </param>
             <returns>The effective measured width and height.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.SplitMeasurementLines(System.String)">
@@ -29737,7 +29757,7 @@
                 background.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.TryMeasureTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.UInt16@,System.UInt16@)">
+        <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.TryMeasureTextNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkTextNode*,System.UInt16@,System.UInt16@,System.Boolean)">
             <summary>
                 Measures the current node size using the live node dimensions first and
                 falling back to text draw size when the node has not been sized yet.
@@ -29745,6 +29765,11 @@
             <param name="textNode">The text node to measure.</param>
             <param name="width">Receives the measured width.</param>
             <param name="height">Receives the measured height.</param>
+            <param name="preferCompactWrappedHeight">
+                Whether wrapped-node height measurement should prefer the current draw
+                height over a larger live node height when callers know the live
+                extent may still reflect stale plugin-applied growth.
+            </param>
         </member>
         <member name="M:Echoglossian.NativeUI.Helpers.NativeTextNodeLayoutHelper.FindNearestAncestorComponentNode(FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode*)">
             <summary>

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -615,7 +615,8 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
           preferCompactDetachedBaselineForHeight: true,
           additionalWrapWidth: this.ResolveMiniTalkAdditionalWrapWidth(
               addon,
-              textNode));
+              textNode),
+          preferCompactWrappedHeight: true);
       if (layoutSnapshot != null)
       {
         lock (this.stateGate)

--- a/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
+++ b/NativeUI/AddonHandlers/SingleText/MiniTalkHandler.cs
@@ -449,28 +449,31 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
     foreach (var bubbleNodeAddress in bubbleTextNodes)
     {
       var textNode = (AtkTextNode*)bubbleNodeAddress;
+      var bubbleKey = this.ResolveBubbleKey(
+          textNode,
+          bubbleNodeAddress);
       if (!this.IsMiniTalkBubbleVisible(textNode))
       {
-        this.clearOverlay(bubbleNodeAddress, false);
+        this.clearOverlay(bubbleKey, false);
         continue;
       }
 
-      activeBubbleKeys.Add(bubbleNodeAddress);
+      activeBubbleKeys.Add(bubbleKey);
 
-      if (!this.TryReadCurrentSource(bubbleNodeAddress, textNode, out var originalText))
+      if (!this.TryReadCurrentSource(bubbleKey, textNode, out var originalText))
       {
         // PluginRuntimeLog.Debug(
         //     $"[MiniTalk] trigger={type} addon=0x{((nint)addon):X} readable text unavailable {this.DescribeMiniTalkTextNode(textNode)}");
         continue;
       }
 
-      this.updateOverlayBounds(bubbleNodeAddress, addon, textNode);
+      this.updateOverlayBounds(bubbleKey, addon, textNode);
 
       // PluginRuntimeLog.Debug(
       //     $"[MiniTalk] trigger={type} addon=0x{((nint)addon):X} bubble=0x{bubbleNodeAddress:X} visible-capture overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeText()} swap={this.ShouldSwapTexts()}");
 
       if (this.TryCaptureOrQueueMiniTalkSource(
-              bubbleNodeAddress,
+              bubbleKey,
               originalText,
               type.ToString(),
               sourceLanguage))
@@ -516,22 +519,25 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
     foreach (var bubbleNodeAddress in bubbleTextNodes)
     {
       var textNode = (AtkTextNode*)bubbleNodeAddress;
+      var bubbleKey = this.ResolveBubbleKey(
+          textNode,
+          bubbleNodeAddress);
       if (!this.IsMiniTalkBubbleVisible(textNode))
       {
-        this.clearOverlay(bubbleNodeAddress, false);
+        this.clearOverlay(bubbleKey, false);
         continue;
       }
 
-      activeBubbleKeys.Add(bubbleNodeAddress);
-      if (!this.TryReadCurrentSource(bubbleNodeAddress, textNode, out var visibleOriginalText))
+      activeBubbleKeys.Add(bubbleKey);
+      if (!this.TryReadCurrentSource(bubbleKey, textNode, out var visibleOriginalText))
       {
         continue;
       }
 
-      this.updateOverlayBounds(bubbleNodeAddress, addon, textNode);
+      this.updateOverlayBounds(bubbleKey, addon, textNode);
 
       if (this.TryHandleVisibleSourceChange(
-              bubbleNodeAddress,
+              bubbleKey,
               visibleOriginalText,
               $"{type}-visible-reconcile",
               sourceLanguage))
@@ -543,14 +549,14 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       //     $"[MiniTalk] trigger={type} addon=0x{((nint)addon):X} bubble=0x{bubbleNodeAddress:X} visible-update overlay={this.ShouldUseOverlay()} native={this.ShouldApplyNativeText()} swap={this.ShouldSwapTexts()}");
 
       if (!this.TryGetCurrentResolvedTranslation(
-              bubbleNodeAddress,
+              bubbleKey,
               sourceLanguage,
               out var resolvedOriginalText,
               out var translatedText,
               out var replacementText))
       {
         if (this.TryCaptureOrQueueMiniTalkSource(
-                bubbleNodeAddress,
+                bubbleKey,
                 visibleOriginalText,
                 $"{type}-visible-fallback",
                 sourceLanguage))
@@ -564,7 +570,7 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       if (this.ShouldUseOverlay())
       {
         this.PublishOverlay(
-            bubbleNodeAddress,
+            bubbleKey,
             resolvedOriginalText,
             translatedText,
             type.ToString());
@@ -576,12 +582,12 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
 
       if (!this.ShouldApplyNativeText())
       {
-        this.RestoreTrackedBubbleLayoutIfNeeded(bubbleNodeAddress);
+        this.RestoreTrackedBubbleLayoutIfNeeded(bubbleKey);
         continue;
       }
 
       this.RestoreTrackedBubbleLayoutIfNeeded(
-          bubbleNodeAddress,
+          bubbleKey,
           resolvedOriginalText);
 
       if (textNode == null)
@@ -598,7 +604,7 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       }
 
       this.PrepareTrackedBubbleLayoutForReapply(
-          bubbleNodeAddress,
+          bubbleKey,
           resolvedOriginalText);
 
       var layoutSnapshot = NativeTextNodeLayoutHelper.ApplyTextReplacementWithInferredReflow(
@@ -614,7 +620,7 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
       {
         lock (this.stateGate)
         {
-          if (this.bubbleStates.TryGetValue(bubbleNodeAddress, out var state))
+          if (this.bubbleStates.TryGetValue(bubbleKey, out var state))
           {
             state.NativeLayoutSnapshot = layoutSnapshot;
             state.NativeLayoutOriginalText = resolvedOriginalText;
@@ -623,7 +629,7 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
         }
       }
 
-      this.updateOverlayBounds(bubbleNodeAddress, addon, textNode);
+      this.updateOverlayBounds(bubbleKey, addon, textNode);
     }
 
     this.PruneHiddenMiniTalkBubbles(activeBubbleKeys);
@@ -1331,6 +1337,35 @@ internal sealed class MiniTalkHandler : IAddonTranslationHandler
            left <= viewport.Pos.X + viewport.Size.X &&
            bottom >= viewport.Pos.Y &&
            top <= viewport.Pos.Y + viewport.Size.Y;
+  }
+
+  /// <summary>
+  ///     Resolves one stable MiniTalk bubble key from the owning component slot
+  ///     when available so pooled-slot reuse restores the prior dirty baseline
+  ///     before any new source or text-node address is captured.
+  /// </summary>
+  /// <param name="textNode">The visible MiniTalk text node.</param>
+  /// <param name="fallbackBubbleKey">
+  ///     The fallback key to use when no owning component container can be
+  ///     resolved.
+  /// </param>
+  /// <returns>The stable key used for native and overlay state.</returns>
+  private unsafe nint ResolveBubbleKey(
+      AtkTextNode* textNode,
+      nint fallbackBubbleKey)
+  {
+    if (textNode != null &&
+        NativeTextNodeLayoutHelper.TryResolveContainerNodes(
+            addon: null,
+            textNode,
+            out var containerNode,
+            out _) &&
+        containerNode != null)
+    {
+      return (nint)containerNode;
+    }
+
+    return fallbackBubbleKey;
   }
 
   /// <summary>

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -829,14 +829,19 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
     var liveText = MemoryHelper.ReadSeStringAsString(
         out _,
         (nint)textNode->NodeText.StringPtr.Value);
-    NativeMutationOwnership.TryRestore(
+    NativeMutationOwnership.TryRestoreWithLayoutFallback(
         liveText,
         replacementText,
         originalText,
+        restoreText,
         restoredText => NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
             layoutSnapshot,
             restoredText,
-            restoreText));
+            restoreText),
+        () => NativeTextNodeLayoutHelper.RestoreLayoutSnapshot(
+            layoutSnapshot,
+            originalText,
+            restoreText: false));
   }
 
   /// <summary>
@@ -1949,9 +1954,7 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         backgroundNode,
         timerNode);
     var preferredWrapWidth = NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(
-        textNode,
-        parentNode,
-        backgroundNode);
+        textNode);
     var resizeResult = NativeTextNodeLayoutHelper.ApplyWrappedTextAndMeasure(
         textNode,
         replacementText,
@@ -1962,7 +1965,8 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         parentNode,
         backgroundNode,
         timerNode,
-        allowWidthGrowth: false);
+        allowWidthGrowth: false,
+        preserveHorizontalGeometry: true);
 
     lock (this.stateGate)
     {

--- a/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
+++ b/NativeUI/AddonHandlers/Talk/BattleTalkHandler.cs
@@ -1952,13 +1952,15 @@ public sealed class BattleTalkHandler : IAddonTranslationHandler, IVisibleDialog
         textNode,
         parentNode,
         backgroundNode,
-        timerNode);
+        timerNode,
+        preferCompactWrappedHeight: true);
     var preferredWrapWidth = NativeTextNodeLayoutHelper.ResolvePreferredWrapWidth(
         textNode);
     var resizeResult = NativeTextNodeLayoutHelper.ApplyWrappedTextAndMeasure(
         textNode,
         replacementText,
-        preferredWrapWidth);
+        preferredWrapWidth,
+        preferCompactWrappedHeight: true);
     NativeTextNodeLayoutHelper.ResizeFromSnapshot(
         layoutSnapshot,
         resizeResult,

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -257,6 +257,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     prefer the more compact of the preserved container baselines instead
   ///     of preserving the largest detached extent.
   /// </param>
+  /// <param name="preserveHorizontalGeometry">
+  ///     Whether horizontal geometry such as sibling anchor X positions and
+  ///     secondary-container widths must remain fixed to the captured baseline
+  ///     instead of being recomputed from the resized text width.
+  /// </param>
   public static void ResizeFromSnapshot(
       NativeTextNodeLayoutSnapshot snapshot,
       NativeTextNodeResizeResult resizeResult,
@@ -267,7 +272,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
       bool restoreHorizontalCentering = true,
       int minimumSecondaryHorizontalPadding = 0,
       int minimumSecondaryVerticalPadding = 0,
-      bool preferCompactDetachedBaselineForHeight = false)
+      bool preferCompactDetachedBaselineForHeight = false,
+      bool preserveHorizontalGeometry = false)
   {
     var childWidth = resizeResult.Width;
     var childHeight = resizeResult.Height;
@@ -378,7 +384,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
       }
     }
 
-    if (anchoredXNode != null)
+    if (!preserveHorizontalGeometry &&
+        anchoredXNode != null)
     {
       anchoredXNode->SetXShort(
           (short)Math.Max(short.MinValue, Math.Min(
@@ -386,7 +393,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
               childWidth + snapshot.AnchoredXOffset)));
     }
 
-    if (secondaryContainerNode != null &&
+    if (!preserveHorizontalGeometry &&
+        secondaryContainerNode != null &&
         anchoredXNode != null &&
         snapshot.AnchoredXWidth > 0)
     {
@@ -821,7 +829,10 @@ internal static unsafe class NativeTextNodeLayoutHelper
     if (prefersDrawSize)
     {
       width = Math.Max(width, drawWidth);
-      height = Math.Max(height, drawHeight);
+      if (drawHeight > 0)
+      {
+        height = drawHeight;
+      }
     }
 
     if (width == 0)

--- a/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
+++ b/NativeUI/Helpers/NativeTextNodeLayoutHelper.cs
@@ -28,14 +28,24 @@ internal static unsafe class NativeTextNodeLayoutHelper
   /// <param name="anchoredXNode">
   ///     An optional sibling node whose X position is anchored to the text width.
   /// </param>
+  /// <param name="preferCompactWrappedHeight">
+  ///     Whether wrapped-node height measurement should prefer the current draw
+  ///     height over a larger live node height when callers know the live
+  ///     extent may still reflect stale plugin-applied growth.
+  /// </param>
   /// <returns>The captured layout snapshot.</returns>
   public static NativeTextNodeLayoutSnapshot CaptureLayoutSnapshot(
       AtkTextNode* textNode,
       AtkResNode* primaryContainerNode = null,
       AtkResNode* secondaryContainerNode = null,
-      AtkResNode* anchoredXNode = null)
+      AtkResNode* anchoredXNode = null,
+      bool preferCompactWrappedHeight = false)
   {
-    TryMeasureTextNode(textNode, out var textWidth, out var textHeight);
+    TryMeasureTextNode(
+        textNode,
+        out var textWidth,
+        out var textHeight,
+        preferCompactWrappedHeight);
     var textNodeWidth = textNode != null ? textNode->GetWidth() : (ushort)0;
     var textNodeHeight = textNode != null ? textNode->GetHeight() : (ushort)0;
     var textNodeTextFlags = textNode != null ? textNode->TextFlags : default;
@@ -152,6 +162,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     The optional rich SeString payload to write after layout flags and
   ///     wrap width are prepared.
   /// </param>
+  /// <param name="preferCompactWrappedHeight">
+  ///     Whether wrapped-node height measurement should prefer the current draw
+  ///     height over a larger live node height when callers know the live
+  ///     extent may still reflect stale plugin-applied growth.
+  /// </param>
   /// <returns>The measured size after the text replacement.</returns>
   public static NativeTextNodeResizeResult ApplyWrappedTextAndMeasure(
       AtkTextNode* textNode,
@@ -159,7 +174,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
       ushort preferredWrapWidth,
       bool allowWidthGrowth = false,
       bool measureReplacementWidthBeforeApply = false,
-      byte[]? replacementPayload = null)
+      byte[]? replacementPayload = null,
+      bool preferCompactWrappedHeight = false)
   {
     if (textNode == null)
     {
@@ -208,7 +224,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
       }
     }
 
-    TryMeasureTextNode(textNode, out var width, out var height);
+    TryMeasureTextNode(
+        textNode,
+        out var width,
+        out var height,
+        preferCompactWrappedHeight);
     if (resolvedWrapWidth > 0)
     {
       width = ResolveReplacementContainerWidth(
@@ -639,6 +659,11 @@ internal static unsafe class NativeTextNodeLayoutHelper
   ///     The optional rich SeString payload to write while keeping the same
   ///     replacement-text measurement and layout flow.
   /// </param>
+  /// <param name="preferCompactWrappedHeight">
+  ///     Whether wrapped-node height measurement should prefer the current draw
+  ///     height over a larger live node height when callers know the live
+  ///     extent may still reflect stale plugin-applied growth.
+  /// </param>
   public static NativeTextNodeLayoutSnapshot? ApplyTextReplacementWithInferredReflow(
       AtkUnitBase* addon,
       AtkTextNode* textNode,
@@ -650,7 +675,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
       int minimumSecondaryVerticalPadding = 0,
       bool preferCompactDetachedBaselineForHeight = false,
       bool measureReplacementWidthBeforeApply = false,
-      byte[]? replacementPayload = null)
+      byte[]? replacementPayload = null,
+      bool preferCompactWrappedHeight = false)
   {
     if (textNode == null)
     {
@@ -669,7 +695,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
     var snapshot = CaptureLayoutSnapshot(
         textNode,
         containerNode,
-        backgroundResNode);
+        backgroundResNode,
+        preferCompactWrappedHeight: preferCompactWrappedHeight);
     var preferredWrapWidth = ResolvePreferredWrapWidth(
         textNode,
         containerNode,
@@ -687,7 +714,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
         preferredWrapWidth,
         allowWidthGrowth,
         measureReplacementWidthBeforeApply,
-        replacementPayload);
+        replacementPayload,
+        preferCompactWrappedHeight);
     ResizeFromSnapshot(
         snapshot,
         resizeResult,
@@ -811,13 +839,19 @@ internal static unsafe class NativeTextNodeLayoutHelper
   /// <param name="drawWidth">The measured text draw width.</param>
   /// <param name="drawHeight">The measured text draw height.</param>
   /// <param name="textFlags">The live text flags.</param>
+  /// <param name="preferCompactWrappedHeight">
+  ///     Whether wrapped-node height measurement should prefer the current draw
+  ///     height over a larger live node height when callers know the live
+  ///     extent may still reflect stale plugin-applied growth.
+  /// </param>
   /// <returns>The effective measured width and height.</returns>
   public static NativeTextNodeResizeResult ResolveMeasuredTextExtent(
       ushort liveWidth,
       ushort liveHeight,
       ushort drawWidth,
       ushort drawHeight,
-      TextFlags textFlags)
+      TextFlags textFlags,
+      bool preferCompactWrappedHeight = false)
   {
     var width = liveWidth;
     var height = liveHeight;
@@ -829,9 +863,16 @@ internal static unsafe class NativeTextNodeLayoutHelper
     if (prefersDrawSize)
     {
       width = Math.Max(width, drawWidth);
-      if (drawHeight > 0)
+      if (preferCompactWrappedHeight)
       {
-        height = drawHeight;
+        if (drawHeight > 0)
+        {
+          height = drawHeight;
+        }
+      }
+      else
+      {
+        height = Math.Max(height, drawHeight);
       }
     }
 
@@ -1095,10 +1136,16 @@ internal static unsafe class NativeTextNodeLayoutHelper
   /// <param name="textNode">The text node to measure.</param>
   /// <param name="width">Receives the measured width.</param>
   /// <param name="height">Receives the measured height.</param>
+  /// <param name="preferCompactWrappedHeight">
+  ///     Whether wrapped-node height measurement should prefer the current draw
+  ///     height over a larger live node height when callers know the live
+  ///     extent may still reflect stale plugin-applied growth.
+  /// </param>
   public static void TryMeasureTextNode(
       AtkTextNode* textNode,
       out ushort width,
-      out ushort height)
+      out ushort height,
+      bool preferCompactWrappedHeight = false)
   {
     width = 0;
     height = 0;
@@ -1128,7 +1175,8 @@ internal static unsafe class NativeTextNodeLayoutHelper
         liveHeight,
         measuredWidth,
         measuredHeight,
-        textNode->TextFlags);
+        textNode->TextFlags,
+        preferCompactWrappedHeight);
     width = resolvedExtent.Width;
     height = resolvedExtent.Height;
   }

--- a/Properties/Resources.ca-ES.resx
+++ b/Properties/Resources.ca-ES.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Mode de visualització de la traducció</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Mode de visualització de la traducció</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Mode de visualització de la traducció</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.da-DK.resx
+++ b/Properties/Resources.da-DK.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Visningstilstand for oversættelse</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Visningstilstand for oversættelse</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Visningstilstand for oversættelse</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.de-DE.resx
+++ b/Properties/Resources.de-DE.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Anzeigemodus der Übersetzung</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Anzeigemodus der Übersetzung</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Anzeigemodus der Übersetzung</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.el-GR.resx
+++ b/Properties/Resources.el-GR.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Λειτουργία εμφάνισης μετάφρασης</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Λειτουργία εμφάνισης μετάφρασης</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Λειτουργία εμφάνισης μετάφρασης</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.en-US.resx
+++ b/Properties/Resources.en-US.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Translation Display Mode</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Translation Display Mode</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Translation Display Mode</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.es-ES.resx
+++ b/Properties/Resources.es-ES.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Modo de visualización de la traducción</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Modo de visualización de la traducción</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Modo de visualización de la traducción</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.eu-ES.resx
+++ b/Properties/Resources.eu-ES.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Itzulpena bistaratzeko modua</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Itzulpena bistaratzeko modua</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Itzulpena bistaratzeko modua</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.fr-FR.resx
+++ b/Properties/Resources.fr-FR.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Mode d'affichage de la traduction</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Mode d'affichage de la traduction</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Mode d'affichage de la traduction</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.it-IT.resx
+++ b/Properties/Resources.it-IT.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Modalità di visualizzazione della traduzione</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Modalità di visualizzazione della traduzione</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Modalità di visualizzazione della traduzione</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.nl-NL.resx
+++ b/Properties/Resources.nl-NL.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Weergavemodus voor vertaling</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Weergavemodus voor vertaling</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Weergavemodus voor vertaling</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.pt-BR.resx
+++ b/Properties/Resources.pt-BR.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Modo de exibição da tradução</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Modo de exibição da tradução</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Modo de exibição da tradução</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.pt-PT.resx
+++ b/Properties/Resources.pt-PT.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Modo de exibição da tradução</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Modo de exibição da tradução</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Modo de exibição da tradução</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Translation Display Mode</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Translation Display Mode</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Translation Display Mode</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -143,10 +143,10 @@
     <value>Whats, Whens and Hows</value>
   </data>
   <data name="ConfigTab1Name" xml:space="preserve">
-    <value>Talk settings</value>
+    <value>Dialogues settings</value>
   </data>
   <data name="ConfigTab2Name" xml:space="preserve">
-    <value>Battle Talk settings</value>
+    <value>Battle Dialogues settings</value>
   </data>
   <data name="ConfigTab3Name" xml:space="preserve">
     <value>Toast settings</value>
@@ -155,7 +155,7 @@
     <value>Journal</value>
   </data>
   <data name="ConfigTab5Name" xml:space="preserve">
-    <value>TalkSubtitle settings</value>
+    <value>Cutscene Subtitles settings</value>
   </data>
   <data name="ConfigTab6Name" xml:space="preserve">
     <value>Other settings</value>
@@ -268,7 +268,7 @@
     <value>Plugin Overlay height multiplier</value>
   </data>
   <data name="OverlayName" xml:space="preserve">
-    <value>Battle talk (Enenies dialogue lines) translation</value>
+    <value>Battle Dialogues (Enenies dialogue lines) translation</value>
     <comment>Translation overlay window name</comment>
   </data>
   <data name="OverlayPositionAdjustmentLabel" xml:space="preserve">
@@ -347,7 +347,7 @@
     <value>Translate in-game Area name Toast Messages</value>
   </data>
   <data name="TransLateBattletalkToggle" xml:space="preserve">
-    <value>Translate battle talk</value>
+    <value>Translate battle Dialogues</value>
   </data>
   <data name="TranslateClassChangeToastToggleText" xml:space="preserve">
     <value>Translate in-game Class/Job change Toast Messages</value>
@@ -455,7 +455,7 @@
     <value>Automatically copy the last translation to the Plugin Clipboard</value>
   </data>
   <data name="ConfigTab9CheckboxClipboardTooltipText" xml:space="preserve">
-    <value>This setting copies the last translation and source text to the clipboard (Works with Talk and BattleTalk)</value>
+    <value>This setting copies the last translation and source text to the clipboard (Works with Dialogues and Battle Dialogues)</value>
   </data>
   <data name="TranslateJournalToggle" xml:space="preserve">
     <value>Translate quest name, description and objectives (WIP)</value>
@@ -479,7 +479,7 @@
     <value>Dialogue LLM override</value>
   </data>
   <data name="DialogueLlmOverrideDescription" xml:space="preserve">
-    <value>Route Talk, BattleTalk, TalkSubtitle, and MiniTalk through a dedicated LLM without changing the primary engine used elsewhere.</value>
+    <value>Route Dialogues, Battle Dialogues, Cutscene Subtitles, and NPCs Dialogues Bubbles through a dedicated LLM without changing the primary engine used elsewhere.</value>
   </data>
   <data name="UseDialogueLlmOverrideLabel" xml:space="preserve">
     <value>Use a dedicated LLM for dialogue-family surfaces</value>
@@ -596,16 +596,16 @@
     <value>Reset configuration to defaults</value>
   </data>
   <data name="TalkTabTitle" xml:space="preserve">
-    <value>Talk</value>
+    <value>Dialogues</value>
   </data>
   <data name="BattleTalkTabTitle" xml:space="preserve">
-    <value>BattleTalk</value>
+    <value>Battle Dialogues</value>
   </data>
   <data name="ToastTabTitle" xml:space="preserve">
     <value>Toast</value>
   </data>
   <data name="SubtitleTabTitle" xml:space="preserve">
-    <value>TalkSubtitle</value>
+    <value>Cutscenes Subtitles</value>
   </data>
   <data name="TranslateToastToggle" xml:space="preserve">
     <value>Translate Toast Messages</value>
@@ -989,7 +989,7 @@
     <value>Translate Text Gimmick Hint</value>
   </data>
   <data name="OverlayTabMiniTalkText" xml:space="preserve">
-    <value>MiniTalk</value>
+    <value>NPCs Dialogues Bubbles</value>
   </data>
   <data name="OverlayTabCutSceneSelectStringText" xml:space="preserve">
     <value>CutSceneSelectString</value>
@@ -1055,7 +1055,7 @@
     <value>Use a Plugin Overlay for this toast type</value>
   </data>
   <data name="TranslateMiniTalkLabel" xml:space="preserve">
-    <value>Translate MiniTalk</value>
+    <value>Translate NPCs Dialogues Bubbles</value>
   </data>
   <data name="TranslateNamePlatesLabel" xml:space="preserve">
     <value>Translate eligible world-object nameplates</value>
@@ -1181,16 +1181,16 @@
     <value>Translate Context Menu</value>
   </data>
   <data name="OverlayWindowTitleTalkTranslation" xml:space="preserve">
-    <value>Talk translation</value>
+    <value>Dialogues translation</value>
   </data>
   <data name="OverlayWindowTitleBattleTalkTranslation" xml:space="preserve">
-    <value>BattleTalk translation</value>
+    <value>Battle Dialogues translation</value>
   </data>
   <data name="OverlayWindowTitleTalkSubtitleTranslation" xml:space="preserve">
-    <value>Talk Subtitle translation</value>
+    <value>Cutscene Subtitles translation</value>
   </data>
   <data name="OverlayWindowTitleMiniTalkTranslation" xml:space="preserve">
-    <value>MiniTalk translation</value>
+    <value>NPCs Dialogues Bubbles translation</value>
   </data>
   <data name="OverlayWindowTitleCutSceneSelectStringTranslation" xml:space="preserve">
     <value>CutSceneSelectString translation</value>
@@ -1610,13 +1610,13 @@
     <value>Last retranslation</value>
   </data>
   <data name="TranslatorDebuggerVisibleStorySurfaceNameTalk" xml:space="preserve">
-    <value>Talk</value>
+    <value>Dialogues</value>
   </data>
   <data name="TranslatorDebuggerVisibleStorySurfaceNameBattleTalk" xml:space="preserve">
-    <value>BattleTalk</value>
+    <value>Battle Dialogues</value>
   </data>
   <data name="TranslatorDebuggerVisibleStorySurfaceNameTalkSubtitle" xml:space="preserve">
-    <value>TalkSubtitle</value>
+    <value>Cutscene Subtitles</value>
   </data>
   <data name="TranslatorDebuggerVisibleStorySurfaceNameCutSceneSelectString" xml:space="preserve">
     <value>CutSceneSelectString</value>

--- a/Properties/Resources.ru-RU.resx
+++ b/Properties/Resources.ru-RU.resx
@@ -941,7 +941,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="JournalQuestDisplayModeLabel" xml:space="preserve">
-    <value>Journal quest display mode</value>
+    <value>Режим отображения перевода</value>
   </data>
   <data name="JournalQuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls Journal, ToDoList, RecommendList, ScenarioTree, AreaMap, JournalAccept, and JournalResult. Journal Plugin Tooltips follow this mode directly; the global Plugin Tooltip toggle only affects other translated UI.</value>
@@ -959,7 +959,7 @@
     <value>Native UI translation + original Plugin Tooltips</value>
   </data>
   <data name="QuestDisplayModeLabel" xml:space="preserve">
-    <value>Quest display mode</value>
+    <value>Режим отображения перевода</value>
   </data>
   <data name="QuestDisplayModeDescription" xml:space="preserve">
     <value>This mode controls how this quest window is presented. Native UI writes the translation into the addon, Plugin Tooltip translation only keeps the addon intact, and Native UI translation + original Plugin Tooltips writes the translation natively while showing the original in Plugin Tooltips.</value>
@@ -1127,7 +1127,7 @@
     <value>Action and item details</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeLabel" xml:space="preserve">
-    <value>Detail display mode</value>
+    <value>Режим отображения перевода</value>
   </data>
   <data name="ActionAndItemTooltipsDisplayModeDescription" xml:space="preserve">
     <value>This mode controls the ActionDetail and ItemDetail surfaces. Native UI writes the translated detail text into the game addon, Plugin Overlay translation only keeps the native addon intact and uses Plugin Overlays, and Native UI translation + original Plugin Overlay writes the translation natively while showing the original in our Plugin Overlay.</value>


### PR DESCRIPTION
## Summary
- fix cumulative and stale native layout dimensions in `_BattleTalk`
- restore clean native baselines for BattleTalk and MiniTalk pooled reuse
- align plugin UI source strings with the current dialogue terminology and unify the "Translation Display Mode" label across tabs and locales

## Validation
- dotnet build Echoglossian.sln -c Debug --no-restore
- dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build
- in-game validation completed in the issue worktree

Closes #264