### PR TITLE
docs: mark v4.2601.0809.2000 as published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
-## Submitted Release `v4.2601.0809.2000`
+## Published Release `v4.2601.0809.2000`
 
-This package is prepared for official Dalamud submission from the current
-`v4-series` head after [PR #265](https://github.com/lokinmodar/Echoglossian/pull/265).
-It focuses on the `_BattleTalk` native-layout restore fix, the remaining
-`_MiniTalk` pooled-background baseline cleanup, and the follow-up localization
-string corrections that shipped with that stabilization pass.
+This package was published to the official Dalamud feed after
+[PR #265](https://github.com/lokinmodar/Echoglossian/pull/265). It focuses on
+the `_BattleTalk` native-layout restore fix, the remaining `_MiniTalk`
+pooled-background baseline cleanup, and the follow-up localization string
+corrections that shipped with that stabilization pass.
 
-Official `DalamudPluginsD17` submission is pending.
+Published in `DalamudPluginsD17` via
+[PR #9183](https://github.com/goatcorp/DalamudPluginsD17/pull/9183) on
+2026-08-10.
 
 Highlights:
 
@@ -317,6 +319,7 @@ repository workflow.
 | 2026-08-06 | [PR #9151](https://github.com/goatcorp/DalamudPluginsD17/pull/9151) `v4.2601.0806.0051` | MiniTalk native bubble stabilization follow-up, ActionDetail and ItemDetail overlay control activation, and localized plugin-label sync |
 | 2026-08-08 | [PR #9163](https://github.com/goatcorp/DalamudPluginsD17/pull/9163) `v4.2601.0807.1730` | MiniTalk recycled-bubble height stabilization follow-up |
 | 2026-08-09 | [PR #9177](https://github.com/goatcorp/DalamudPluginsD17/pull/9177) `v4.2601.0809.0046` | plugin UI culture application, locale-specific resource loading, and localization guardrails |
+| 2026-08-10 | [PR #9183](https://github.com/goatcorp/DalamudPluginsD17/pull/9183) `v4.2601.0809.2000` | BattleTalk and MiniTalk stale native-layout stabilization plus dialogue-family label corrections |
 
 ## Pre-Official History
 

--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -1,6 +1,6 @@
 # GitHub Issue Backlog
 
-Snapshot date: 2026-08-09
+Snapshot date: 2026-08-10
 
 This document is the operational snapshot for open issues in
 [`lokinmodar/Echoglossian`](https://github.com/lokinmodar/Echoglossian/issues).
@@ -9,21 +9,22 @@ release history belongs in [`CHANGELOG.md`](../CHANGELOG.md), not in this file.
 
 ## Published Release Baseline
 
-- Release: [`v4.2601.0809.0046`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0809.0046)
-- Product commit: `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
-- Official submission: [`goatcorp/DalamudPluginsD17#9177`](https://github.com/goatcorp/DalamudPluginsD17/pull/9177)
-- D17 status: approved and merged on 2026-08-09
-- D17 merge commit: `1a033922f52afd74640c620bcc1145be8e8a7cbe`
+- Release: [`v4.2601.0809.2000`](https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0809.2000)
+- Product commit: `d1ac912d0f065e7d0294ab0fa9d80bd40296d06b`
+- Official submission: [`goatcorp/DalamudPluginsD17#9183`](https://github.com/goatcorp/DalamudPluginsD17/pull/9183)
+- D17 status: approved and merged on 2026-08-10
+- D17 merge commit: `f0ab3fa980bf7480b0b15bb37beef350b71ed546`
 - Open issues after post-publication triage: 20
 - Open issues at the current audit head: 20
 - Focused open issues besides the living tracker [#12](https://github.com/lokinmodar/Echoglossian/issues/12): 19
 
 ## Current `v4-series` Delta
 
-- Audit head: `origin/v4-series` at `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
-- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0809.0046` at `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
+- Audit head: `origin/v4-series` at `d1ac912d0f065e7d0294ab0fa9d80bd40296d06b`
+- Latest tagged and officially published runtime build on `v4-series`: `v4.2601.0809.2000` at `d1ac912d0f065e7d0294ab0fa9d80bd40296d06b`
 - The audit head currently matches the latest published runtime baseline; there are no newer `v4-series` commits beyond this published release.
 - Issue [#12](https://github.com/lokinmodar/Echoglossian/issues/12) remains the living known-issues tracker and should stay aligned with this document whenever focused issue state changes materially.
+- Publication of `v4.2601.0809.2000` completed the `_BattleTalk` and `_MiniTalk` stale native-layout stabilization from [#264](https://github.com/lokinmodar/Echoglossian/issues/264), including BattleTalk horizontal-geometry preservation plus the dialogue-family and `Translation Display Mode` label corrections that shipped with that pass.
 - Publication of `v4.2601.0809.0046` completed the plugin UI culture-loading correction from [PR #260](https://github.com/lokinmodar/Echoglossian/pull/260), including explicit locale selection and locale-specific resource fallback safeguards.
 - Publication of `v4.2601.0807.1730` completed the recycled `_MiniTalk` follow-up for [#246](https://github.com/lokinmodar/Echoglossian/issues/246).
 - New focused prompt and glossary behavior work is currently tracked in [#252](https://github.com/lokinmodar/Echoglossian/issues/252).
@@ -38,6 +39,7 @@ most relevant resolved fronts to reference during follow-up triage.
 
 | Issue | Published resolution |
 | --- | --- |
+| [#264 `_BattleTalk` height accumulates, width drifts, and `_MiniTalk` background baseline leaks`](https://github.com/lokinmodar/Echoglossian/issues/264) | The published release now restores clean native `_BattleTalk` and `_MiniTalk` baselines after translated reuse, allows `_BattleTalk` vertical growth only when translated height exceeds the clean baseline, and preserves the game's horizontal geometry ownership in `_BattleTalk`. |
 | [#246 `_MiniTalk` native bubble dimensions regress in `Native` and `Swap` modes`](https://github.com/lokinmodar/Echoglossian/issues/246) | The published follow-up release now isolates the compact detached-container baseline preference to `_MiniTalk_`, preventing recycled oversized bubble slots from stretching later translated balloons while keeping the shared tooltip and toast behavior unchanged. |
 | [#15 ActionDetail / ItemDetail tooltip translation](https://github.com/lokinmodar/Echoglossian/issues/15) | The DB-first structured tooltip flow is active in production with cache-gap prefetch, source-id binding, atomic detail updates, and native/overlay ownership safeguards. |
 | [#68 Selection dialogs and other specific surfaces](https://github.com/lokinmodar/Echoglossian/issues/68) | `SelectYesNo`, `SelectOk`, `SelectString`, `SelectIconString`, and `CutSceneSelectString` are shipped; the historical `ChatBubble` entry is covered by the production `_MiniTalk` / `MiniTalk` runtime. |


### PR DESCRIPTION
## Summary
- mark `v4.2601.0809.2000` as published in `CHANGELOG.md`
- promote the backlog baseline to the merged official release and record `#264` as a published resolved front
- refresh the living tracker issue `#12` and add the published-release note to issue `#264`

## Validation
- `git diff --check`
- remote verification of `goatcorp/DalamudPluginsD17#9183` merged on 2026-08-10
- remote verification that issue `#12` now points to `v4.2601.0809.2000`
