### PR TITLE
chore: prepare v4.2601.0815.1339 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
+## Submitted Release `v4.2601.0815.1339`
+
+This package is prepared for official Dalamud submission from the current
+`v4-series` head after [PR #262](https://github.com/lokinmodar/Echoglossian/pull/262).
+It focuses on first-line dialogue speaker context recovery, precomputed quest
+dialogue interlocutor metadata, shared glossary enforcement for dialogue LLM
+requests, and capability-aware parameter handling plus diagnostics across the
+structured LLM providers.
+
+Official `DalamudPluginsD17` submission is pending.
+
+Highlights:
+
+- preserves speaker-aware dialogue context from the very first line by
+  carrying speaker identity through the shared translation path and reusing
+  precomputed quest dialogue metadata plus live actor fallbacks when a visible
+  NPC or target can disambiguate the interlocutor
+- precomputes and persists quest dialogue interlocutor metadata asynchronously
+  after quest acceptance, keeping quest-sheet traversal, EF lookups, and stale
+  result suppression off Dalamud callbacks while preserving DB-first lookup
+  semantics for later dialogue resolution
+- enforces glossary term protection in the shared dialogue LLM flow so
+  provider-specific structured requests reuse the same protected replacements
+  instead of silently dropping configured glossary terms
+- adds conservative model capability learning, capability-gated LLM settings
+  UI, and structured request diagnostics so unsupported parameters such as
+  reasoning or temperature controls can be disabled or sanitized without
+  provider-specific guesswork
+
 ## Published Release `v4.2601.0809.2000`
 
 This package was published to the official Dalamud feed after

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0809</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">2000</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0815</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">1339</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -662,6 +662,60 @@
                 <see langword="false" />.
             </returns>
         </member>
+        <member name="T:Echoglossian.Cache.LlmCapabilityCacheManager">
+            <summary>
+                Maintains DB-free runtime snapshots of persisted LLM capability data.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.Initialize(System.String)">
+            <summary>
+                Hydrates the runtime cache from persisted capability tables.
+            </summary>
+            <param name="configDir">The plugin configuration directory.</param>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.GetRuleDefinitions">
+            <summary>
+                Gets the current persisted capability rule definitions without
+                querying SQLite.
+            </summary>
+            <returns>The cached rule definitions.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.PublishRule(Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition)">
+            <summary>
+                Publishes one persisted rule to the DB-free runtime cache.
+            </summary>
+            <param name="rule">The persisted rule definition to publish.</param>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.PublishObservation(Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation)">
+            <summary>
+                Publishes one persisted provider-feedback observation to the bounded
+                runtime audit snapshot.
+            </summary>
+            <param name="observation">The observation to publish.</param>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.Clear">
+            <summary>
+                Clears the runtime capability snapshots.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.HasSameLookupIdentity(Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition,Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition)">
+            <summary>
+                Determines whether two rules address the same persisted lookup
+                identity.
+            </summary>
+            <param name="left">The first rule to compare.</param>
+            <param name="right">The second rule to compare.</param>
+            <returns><see langword="true" /> if both rules share one lookup identity; otherwise, <see langword="false" />.</returns>
+        </member>
+        <member name="M:Echoglossian.Cache.LlmCapabilityCacheManager.HasSameObservationIdentity(Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation,Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation)">
+            <summary>
+                Determines whether two observations represent the same bounded
+                provider-feedback event identity.
+            </summary>
+            <param name="left">The first observation to compare.</param>
+            <param name="right">The second observation to compare.</param>
+            <returns><see langword="true" /> if both observations share one identity; otherwise, <see langword="false" />.</returns>
+        </member>
         <member name="T:Echoglossian.Cache.NamePlateCacheManager">
             <summary>
                 Manages in-memory nameplate translation rows so the NamePlateGui runtime
@@ -3148,6 +3202,39 @@
             <param name="talkMessage">TalkMessage to be found on the Database.</param>
             <returns>The found <see cref="T:Echoglossian.EFCoreSqlite.Models.TalkMessage" />.</returns>
         </member>
+        <member name="M:Echoglossian.Echoglossian.FindQuestDialogueMetadataAsync(Echoglossian.QuestDialogueMetadataLookup,System.Threading.CancellationToken)">
+            <summary>
+                Finds metadata that exactly matches one quest dialogue source row and
+                derivation version.
+            </summary>
+            <param name="lookup">The exact source row lookup values.</param>
+            <param name="cancellationToken">The token that cancels the database lookup.</param>
+            <returns>A matching metadata row; otherwise, <see langword="null" />.</returns>
+            <exception cref="T:System.OperationCanceledException">
+                The database lookup is cancelled.
+            </exception>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.UpsertQuestDialogueMetadataBatchAsync(System.Collections.Generic.IReadOnlyList{Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata},System.Threading.CancellationToken)">
+            <summary>
+                Replaces persisted metadata rows with the supplied exact logical rows.
+            </summary>
+            <param name="rows">The metadata rows to persist.</param>
+            <param name="cancellationToken">The token that cancels the database operation.</param>
+            <exception cref="T:System.OperationCanceledException">
+                The database operation is cancelled.
+            </exception>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FindAndReturnTalkMessageAsync(Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.CancellationToken)">
+            <summary>
+                Asynchronously finds and returns a TalkMessage from the database.
+            </summary>
+            <param name="talkMessage">The TalkMessage to find in the database.</param>
+            <param name="cancellationToken">The token that cancels the database lookup.</param>
+            <returns>A matching <see cref="T:Echoglossian.EFCoreSqlite.Models.TalkMessage" />, or <see langword="null" />.</returns>
+            <exception cref="T:System.OperationCanceledException">
+                The database lookup is cancelled.
+            </exception>
+        </member>
         <member name="M:Echoglossian.Echoglossian.FindToastMessage(Echoglossian.EFCoreSqlite.Models.ToastMessage)">
             <summary>
             Finds and returns a ToastMessage from the database.
@@ -3184,6 +3271,20 @@
             </summary>
             <param name="battleTalkMessage">Formatted BattleTalkMessage to be found in the database</param>
             <returns></returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FindAndReturnBattleTalkMessageAsync(Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.CancellationToken)">
+            <summary>
+                Asynchronously finds and returns a BattleTalkMessage from the
+                database.
+            </summary>
+            <param name="battleTalkMessage">The BattleTalkMessage to find in the database.</param>
+            <param name="cancellationToken">The token that cancels the database lookup.</param>
+            <returns>
+                A matching <see cref="T:Echoglossian.EFCoreSqlite.Models.BattleTalkMessage" />, or <see langword="null" />.
+            </returns>
+            <exception cref="T:System.OperationCanceledException">
+                The database lookup is cancelled.
+            </exception>
         </member>
         <member name="M:Echoglossian.Echoglossian.FindQuestPlate(Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate)">
              <summary>
@@ -4350,17 +4451,33 @@
                 current queue has fully drained.
             </summary>
         </member>
-        <member name="M:Echoglossian.Echoglossian.ShouldPrefetchAcceptedQuests">
+        <member name="M:Echoglossian.Echoglossian.ShouldProcessAcceptedQuests">
             <summary>
                 Gets whether accepted quests should be prefetched in the current
                 runtime state.
             </summary>
             <returns>True when the background prefetch should run.</returns>
         </member>
+        <member name="M:Echoglossian.Echoglossian.IsAcceptedQuestCanonicalPrefetchEnabled(Echoglossian.Config)">
+            <summary>
+                Gets whether canonical accepted-quest prefetch is enabled by the
+                current translation configuration.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <returns><see langword="true" /> when canonical prefetch is enabled.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.IsAcceptedQuestDialogueMetadataGenerationEnabled(Echoglossian.Config)">
+            <summary>
+                Gets whether accepted-quest dialogue metadata generation is enabled
+                by a dialogue translation surface.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <returns><see langword="true" /> when metadata generation is enabled.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ScheduleAcceptedQuestPrefetch(System.UInt32,System.String)">
             <summary>
-                Captures one accepted-quest snapshot on the plugin tick and queues the
-                heavy canonical prefetch work onto a serialized background worker.
+                Captures lightweight accepted-quest state on the plugin tick and queues
+                sheet-backed work onto a serialized background worker.
             </summary>
             <param name="questId">The accepted quest identifier.</param>
             <param name="requestSources">
@@ -4368,10 +4485,33 @@
                 prefetch cycle.
             </param>
         </member>
+        <member name="M:Echoglossian.Echoglossian.CaptureAcceptedQuestDialogueMetadataObservedAtUtc">
+            <summary>
+                Captures a strictly increasing observation time before dialogue
+                metadata work crosses the background handoff.
+            </summary>
+            <returns>The immutable UTC observation time.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ScheduleAcceptedQuestDialogueMetadataGeneration(Echoglossian.Echoglossian.AcceptedQuestDialogueMetadataWorkItem)">
+            <summary>
+                Starts owned background generation of persistent dialogue metadata for
+                one accepted-quest snapshot.
+            </summary>
+            <param name="workItem">The immutable metadata generation work item.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ProcessAcceptedQuestDialogueMetadataWorkItemAsync(Echoglossian.Echoglossian.AcceptedQuestDialogueMetadataWorkItem,System.Threading.CancellationToken)">
+            <summary>
+                Derives and persists dialogue metadata without blocking the framework
+                tick that captured the accepted quest.
+            </summary>
+            <param name="workItem">The immutable metadata generation work item.</param>
+            <param name="cancellationToken">The token that cancels the owned operation.</param>
+            <returns>A task representing the metadata generation operation.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.TryCaptureAcceptedQuestPrefetchWorkItem(System.UInt32,System.String,Echoglossian.Echoglossian.AcceptedQuestPrefetchWorkItem@)">
             <summary>
                 Captures one immutable accepted-quest prefetch work item from the
-                current live quest state.
+                current live quest state without traversing Lumina sheets.
             </summary>
             <param name="questId">The accepted quest identifier.</param>
             <param name="requestSources">
@@ -4379,7 +4519,7 @@
                 prefetch cycle.
             </param>
             <param name="workItem">
-                The captured background work item when snapshot capture succeeds.
+                The captured background work item when native state capture succeeds.
             </param>
             <returns><see langword="true" /> when a complete work item was captured.</returns>
         </member>
@@ -5972,6 +6112,25 @@
             <summary>
             Handles the registration of addon handlers.
             </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.CreateDialogueInterlocutorHints(Echoglossian.DialogueInterlocutorMetadata)">
+            <summary>
+                Projects resolver output onto the smaller per-request dialogue hint
+                contract without retaining live actor snapshots in translation state.
+            </summary>
+            <param name="metadata">The resolved quest and live interlocutor metadata.</param>
+            <returns>The hints applicable to the current dialogue translation request.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ResolveDialogueInterlocutorHintsAsync(System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken)">
+            <summary>
+                Resolves current dialogue hints through the owned handler operation
+                instead of the native callback that queued it.
+            </summary>
+            <param name="originalName">The visible dialogue speaker name.</param>
+            <param name="originalText">The visible dialogue source text.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="cancellationToken">The handler-owned cancellation token.</param>
+            <returns>The resolved hints for the current dialogue request.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
@@ -7835,6 +7994,16 @@
             <param name="payload">The payload to normalize.</param>
             <returns>The normalized payload copy.</returns>
         </member>
+        <member name="T:Echoglossian.QuestDialogueMetadataLookup">
+            <summary>
+                Identifies one exact versioned quest dialogue metadata row.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataLookup.#ctor(System.UInt32,System.UInt16,System.String,System.String,System.String,System.String,System.String)">
+            <summary>
+                Identifies one exact versioned quest dialogue metadata row.
+            </summary>
+        </member>
         <member name="T:Echoglossian.GameWindowPersistenceHelper">
             <summary>
                 Persists <see cref="T:Echoglossian.EFCoreSqlite.Models.GameWindow" /> rows without requiring the full plugin runtime.
@@ -7952,6 +8121,48 @@
             </summary>
             <param name="payload">The payload to normalize.</param>
             <returns>The normalized payload copy.</returns>
+        </member>
+        <member name="T:Echoglossian.DBHelpers.LlmCapabilityPersistenceHelper">
+            <summary>
+                Persists LLM capability overlays and provider-feedback observations.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBHelpers.LlmCapabilityPersistenceHelper.UpsertRules(System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule})">
+            <summary>
+                Inserts or updates capability rules by their scoped lookup identity.
+            </summary>
+            <param name="configDir">The plugin configuration directory.</param>
+            <param name="rules">The rules to persist.</param>
+        </member>
+        <member name="M:Echoglossian.DBHelpers.LlmCapabilityPersistenceHelper.RecordObservation(System.String,Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation)">
+            <summary>
+                Records or refreshes one provider-feedback observation for later
+                audit.
+            </summary>
+            <param name="configDir">The plugin configuration directory.</param>
+            <param name="observation">The observation to persist.</param>
+        </member>
+        <member name="T:Echoglossian.DBHelpers.TranslationFailurePersistenceHelper">
+            <summary>
+                Persists exact translation failures so the same request can be skipped
+                in later sessions.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DBHelpers.TranslationFailurePersistenceHelper.RecordFailure(System.String,System.String,System.String,System.String,System.Int32,System.String,System.String,System.Action{Echoglossian.EFCoreSqlite.Models.TranslationFailure})">
+            <summary>
+                Inserts or updates one exact translation-failure row and refreshes
+                the in-memory cache.
+            </summary>
+            <param name="configDirectory">The plugin configuration directory.</param>
+            <param name="sourceText">The exact sanitized source text.</param>
+            <param name="sourcePersistenceLanguage">
+                The canonical persisted source identity, never a provider alias.
+            </param>
+            <param name="targetLanguage">The target language code.</param>
+            <param name="translationEngine">The translation engine identifier.</param>
+            <param name="failureReason">The failure reason to persist.</param>
+            <param name="originContext">The origin context that produced the request.</param>
+            <param name="cacheUpdate">The callback used to refresh the cache.</param>
         </member>
         <member name="T:Echoglossian.ReferenceTextPersistenceHelper">
             <summary>
@@ -8236,28 +8447,6 @@
             </summary>
             <param name="payload">The payload to normalize.</param>
             <returns>The normalized payload copy.</returns>
-        </member>
-        <member name="T:Echoglossian.DBHelpers.TranslationFailurePersistenceHelper">
-            <summary>
-                Persists exact translation failures so the same request can be skipped
-                in later sessions.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.DBHelpers.TranslationFailurePersistenceHelper.RecordFailure(System.String,System.String,System.String,System.String,System.Int32,System.String,System.String,System.Action{Echoglossian.EFCoreSqlite.Models.TranslationFailure})">
-            <summary>
-                Inserts or updates one exact translation-failure row and refreshes
-                the in-memory cache.
-            </summary>
-            <param name="configDirectory">The plugin configuration directory.</param>
-            <param name="sourceText">The exact sanitized source text.</param>
-            <param name="sourcePersistenceLanguage">
-                The canonical persisted source identity, never a provider alias.
-            </param>
-            <param name="targetLanguage">The target language code.</param>
-            <param name="translationEngine">The translation engine identifier.</param>
-            <param name="failureReason">The failure reason to persist.</param>
-            <param name="originContext">The origin context that produced the request.</param>
-            <param name="cacheUpdate">The callback used to refresh the cache.</param>
         </member>
         <member name="T:Echoglossian.DBManagerUI.Components.DbTableView">
             <summary>
@@ -8719,6 +8908,11 @@
                 reconcile into canonical quest tables.
             </summary>
         </member>
+        <member name="P:Echoglossian.EFCoreSqlite.EchoglossianDbContext.QuestDialogueMetadata">
+            <summary>
+                Gets or sets derived metadata for exact quest dialogue source rows.
+            </summary>
+        </member>
         <member name="P:Echoglossian.EFCoreSqlite.EchoglossianDbContext.StringArrayDatas">
             <summary>
                 Gets or sets the translated string array records.
@@ -8798,6 +8992,16 @@
             <summary>
                 Gets or sets exact translation failures that should not be retried for
                 the same source/target language pair and engine.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.EchoglossianDbContext.LlmModelCapabilityRules">
+            <summary>
+                Gets or sets persisted LLM capability overlay rules.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.EchoglossianDbContext.LlmModelCapabilityObservations">
+            <summary>
+                Gets or sets provider-feedback observations for LLM capabilities.
             </summary>
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.EchoglossianDbContext.OnConfiguring(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder)">
@@ -9195,6 +9399,30 @@
             <inheritdoc />
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddTooltipTexts.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Migrations.AddQuestDialogueMetadata">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddQuestDialogueMetadata.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddQuestDialogueMetadata.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddQuestDialogueMetadata.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Migrations.AddLlmCapabilityMatrix">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddLlmCapabilityMatrix.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddLlmCapabilityMatrix.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Migrations.AddLlmCapabilityMatrix.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <inheritdoc />
         </member>
         <member name="T:Echoglossian.EFCoreSqlite.Models.ActionTooltip">
@@ -9979,6 +10207,107 @@
         <member name="M:Echoglossian.EFCoreSqlite.Models.ItemTooltip.ToString">
             <inheritdoc />
         </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata">
+            <summary>
+                Stores derived speaker and addressee metadata for one exact quest
+                dialogue source row.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.Id">
+            <summary>
+                Gets or sets the primary key.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.QuestId">
+            <summary>
+                Gets or sets the canonical quest id.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.QuestSequence">
+            <summary>
+                Gets or sets the quest sequence containing the source row.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.SourceLanguageCode">
+            <summary>
+                Gets or sets the source language code.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.GameVersion">
+            <summary>
+                Gets or sets the game version that supplied the source row.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.QuestSheetId">
+            <summary>
+                Gets or sets the quest sheet id.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.QuestTextSheetName">
+            <summary>
+                Gets or sets the quest text sheet name.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.SourceRowKey">
+            <summary>
+                Gets or sets the exact quest text row key.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.SourceTextHash">
+            <summary>
+                Gets or sets the hash of the exact source text.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.SourceTextPreview">
+            <summary>
+                Gets or sets a diagnostic preview of the source text.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.SpeakerHint">
+            <summary>
+                Gets or sets the derived speaker hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.AddresseeHint">
+            <summary>
+                Gets or sets the derived addressee hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.SpeakerRoleHint">
+            <summary>
+                Gets or sets the derived speaker role hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.AddresseeRoleHint">
+            <summary>
+                Gets or sets the derived addressee role hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.Provenance">
+            <summary>
+                Gets or sets the metadata derivation provenance.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.ConfidenceTier">
+            <summary>
+                Gets or sets the confidence tier assigned by derivation.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.DerivationVersion">
+            <summary>
+                Gets or sets the version of the metadata derivation algorithm.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.CreatedAtUtc">
+            <summary>
+                Gets or sets the UTC timestamp at which the row was created.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata.UpdatedAtUtc">
+            <summary>
+                Gets or sets the UTC timestamp at which the row was last updated.
+            </summary>
+        </member>
         <member name="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate">
             <summary>
                 Provides canonical quest payload helpers for <see cref="T:Echoglossian.EFCoreSqlite.Models.Journal.QuestPlate" />.
@@ -10498,6 +10827,127 @@
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.Models.Journal.QuestPopupText.ToString">
             <inheritdoc />
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation">
+            <summary>
+                Represents one provider capability-feedback observation retained for
+                later audit or conservative rule promotion.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.Id">
+            <summary>Gets or sets the primary key.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.Engine">
+            <summary>Gets or sets the engine identifier.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.ProviderScope">
+            <summary>Gets or sets the provider scope.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.EndpointScope">
+            <summary>Gets or sets the endpoint scope.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.ModelId">
+            <summary>Gets or sets the observed model identifier.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.ParameterName">
+            <summary>Gets or sets the rejected parameter name.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.StatusCode">
+            <summary>Gets or sets the provider response status code.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.ProviderErrorCode">
+            <summary>Gets or sets the provider error code.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.MessageExcerpt">
+            <summary>Gets or sets the sanitized provider message excerpt.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityObservation.ObservedAtUtc">
+            <summary>Gets or sets when the observation occurred in UTC.</summary>
+        </member>
+        <member name="T:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule">
+            <summary>
+                Represents one persisted LLM capability overlay rule.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.Id">
+            <summary>Gets or sets the primary key.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.Engine">
+            <summary>Gets or sets the engine identifier.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.ProviderScope">
+            <summary>Gets or sets the provider scope.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.EndpointScope">
+            <summary>Gets or sets the endpoint scope.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.MatchType">
+            <summary>Gets or sets the model matching strategy.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.MatchValue">
+            <summary>Gets or sets the model identifier or family prefix.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.ParameterName">
+            <summary>Gets or sets the governed parameter name.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.SupportState">
+            <summary>Gets or sets the parameter support state.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.MinValue">
+            <summary>Gets or sets the inclusive minimum supported value.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.MaxValue">
+            <summary>Gets or sets the inclusive maximum supported value.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.AllowedEnumValuesJson">
+            <summary>Gets or sets serialized allowed enum values.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.OmitWhenDefaultOnly">
+            <summary>Gets or sets a value indicating whether default-only values are omitted.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.Source">
+            <summary>Gets or sets the rule source.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.Reason">
+            <summary>Gets or sets the rule rationale.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.Confidence">
+            <summary>Gets or sets the source confidence.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.ObservedAtUtc">
+            <summary>Gets or sets when the rule was observed in UTC.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.ExpiresAtUtc">
+            <summary>Gets or sets when the rule expires in UTC.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.CreatedAtUtc">
+            <summary>Gets or sets when the row was created in UTC.</summary>
+        </member>
+        <member name="P:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.UpdatedAtUtc">
+            <summary>Gets or sets when the row was last updated in UTC.</summary>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.CreateExactModel(System.String,System.String,System.String,System.String,Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,Echoglossian.Translators.Capabilities.LlmCapabilitySupportState,System.Nullable{System.Single},System.Nullable{System.Single},System.Boolean,System.String,System.String)">
+            <summary>
+                Creates a persisted exact-model capability rule.
+            </summary>
+            <param name="engine">The engine identifier.</param>
+            <param name="providerScope">The provider identity.</param>
+            <param name="endpointScope">The endpoint identity.</param>
+            <param name="modelId">The complete model identifier.</param>
+            <param name="parameterName">The governed parameter.</param>
+            <param name="supportState">The known support state.</param>
+            <param name="minValue">The inclusive lower bound, when known.</param>
+            <param name="maxValue">The inclusive upper bound, when known.</param>
+            <param name="omitWhenDefaultOnly"><see langword="true" /> to omit the parameter when only its default is allowed; otherwise, <see langword="false" />.</param>
+            <param name="source">The source that established the rule.</param>
+            <param name="reason">The explanation for the rule.</param>
+            <returns>A persisted exact-model capability rule.</returns>
+        </member>
+        <member name="M:Echoglossian.EFCoreSqlite.Models.LlmModelCapabilityRule.ToDefinition">
+            <summary>
+                Converts this persisted row to the shared resolver rule contract.
+            </summary>
+            <returns>The shared capability rule definition.</returns>
         </member>
         <member name="M:Echoglossian.EFCoreSqlite.Models.LocationName.#ctor(System.Int32,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.Nullable{System.DateTime},System.Nullable{System.DateTime})">
             <summary>
@@ -23980,13 +24430,13 @@
                 async translation, overlay updates, and optional native text replacement.
             </summary>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,Echoglossian.EFCoreSqlite.Models.BattleTalkMessage},System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage}},System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String},System.Func{System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.DialogueInterlocutorHints}})">
             <summary>
                 Initializes a new instance of the <see cref="T:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler" /> class.
             </summary>
             <param name="config">The active plugin configuration.</param>
             <param name="translationService">The translation service used by the plugin.</param>
-            <param name="findBattleTalkMessage">
+            <param name="findBattleTalkMessageAsync">
                 Delegate used to look up previously translated BattleTalk messages.
             </param>
             <param name="insertBattleTalkMessageAsync">
@@ -24002,19 +24452,25 @@
             <param name="normalizeReplacementText">
                 Delegate used to normalize translated text before native replacement.
             </param>
+            <param name="resolveInterlocutorHintsAsync">
+                Delegate used to resolve current-line interlocutor hints after a database miss.
+            </param>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,Echoglossian.EFCoreSqlite.Models.BattleTalkMessage},System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String})">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage}},System.Func{Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String},System.Func{System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.DialogueInterlocutorHints}})">
             <summary>
                 Initializes a BattleTalk handler with cancellation-aware dialogue
                 persistence owned by the captured operation scope.
             </summary>
             <param name="config">The active plugin configuration.</param>
             <param name="translationService">The shared translation service.</param>
-            <param name="findBattleTalkMessage">The canonical BattleTalk lookup.</param>
+            <param name="findBattleTalkMessageAsync">The canonical asynchronous BattleTalk lookup.</param>
             <param name="insertBattleTalkMessageAsync">The cancellation-aware persistence delegate.</param>
             <param name="updateOverlay">The overlay publication callback.</param>
             <param name="clearOverlay">The overlay clear callback.</param>
             <param name="normalizeReplacementText">The native replacement normalizer.</param>
+            <param name="resolveInterlocutorHintsAsync">
+                The asynchronous current-line interlocutor hint resolver.
+            </param>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.GetEventHandlers">
             <summary>
@@ -24023,6 +24479,12 @@
             <returns>
                 A dictionary mapping addon events to combined delegates.
             </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.OnPluginUnload">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.Dispose">
+            <inheritdoc />
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.RetranslateVisibleTextAndPersistAsync">
             <inheritdoc />
@@ -24182,7 +24644,7 @@
             <param name="sourceLanguage">The resolved source language.</param>
             <returns>The immutable dialogue operation scope.</returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.ResolveTranslationAsync(System.String,System.String,System.Int32,Echoglossian.SourceClientLanguage,Echoglossian.NativeUI.AddonHandlers.Common.SourcePublicationOperation)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.ResolveTranslationAsync(System.String,System.String,System.Int32,Echoglossian.SourceClientLanguage,Echoglossian.NativeUI.AddonHandlers.Common.SourcePublicationOperation,System.Threading.CancellationToken)">
             <summary>
                 Resolves a BattleTalk translation from cache or external translation and
                 stores the result as the current translation state.
@@ -24194,7 +24656,19 @@
             </param>
             <param name="sourceLanguage">The resolved source language.</param>
             <param name="sourceOperation">The source generation captured when queued.</param>
+            <param name="operationToken">The token owned by the queued operation.</param>
             <returns>A task that completes when the translation state has been updated.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.ResolveInterlocutorHintsOrDefaultAsync(System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken)">
+            <summary>
+                Resolves optional BattleTalk metadata without allowing auxiliary
+                failures to abort the dialogue translation.
+            </summary>
+            <param name="originalName">The original visible speaker name.</param>
+            <param name="originalText">The original visible dialogue text.</param>
+            <param name="sourceLanguage">The captured source language.</param>
+            <param name="cancellationToken">The token that cancels the current source operation.</param>
+            <returns>The resolved hints, or an empty hint set after an auxiliary failure.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.IsStoredTranslationUsable(Echoglossian.EFCoreSqlite.Models.BattleTalkMessage,System.String,System.String)">
             <summary>
@@ -24207,6 +24681,32 @@
             <returns>
                 <see langword="true" /> when the stored row contains a non-empty
                 translation for the same original source line; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.IsTranslationInFlight">
+            <summary>
+                Gets a value indicating whether the current BattleTalk line has
+                unresolved background translation work.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryGetCurrentResolvedTranslation(Echoglossian.SourceClientLanguage,System.String@,System.String@,System.String@,System.String@)">
+            <summary>
+                Returns the active resolved BattleTalk translation currently held by
+                the handler state.
+            </summary>
+            <param name="sourceLanguage">The source language expected by the caller.</param>
+            <param name="translatedName">Receives the translated sender name.</param>
+            <param name="translatedText">Receives the translated BattleTalk text.</param>
+            <param name="replacementName">
+                Receives the sender name already normalized for native replacement.
+            </param>
+            <param name="replacementText">
+                Receives the BattleTalk text already normalized for native replacement.
+            </param>
+            <returns>
+                <see langword="true" /> when the handler already has a translated
+                BattleTalk line ready for native replacement; otherwise,
                 <see langword="false" />.
             </returns>
         </member>
@@ -24248,6 +24748,19 @@
             <returns>
                 <see langword="true" /> when a matching cached translation exists;
                 otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryQueueTranslation(System.String,System.String,Echoglossian.SourceClientLanguage)">
+            <summary>
+                Captures one BattleTalk line and starts its handler-owned asynchronous
+                resolution without waiting for persistent lookup to complete.
+            </summary>
+            <param name="originalName">The source sender name.</param>
+            <param name="originalText">The source BattleTalk text.</param>
+            <param name="sourceLanguage">The resolved source language.</param>
+            <returns>
+                <see langword="true" /> when the operation was queued; otherwise,
+                <see langword="false" />.
             </returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.TryQueueTranslation(System.String,System.String,Echoglossian.SourceClientLanguage,System.Int32@,Echoglossian.NativeUI.AddonHandlers.Common.SourcePublicationOperation@)">
@@ -24430,6 +24943,18 @@
                 The translated BattleTalk text already normalized for native replacement.
             </param>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.BattleTalkHandler.IsCurrentRequest(System.Int32,Echoglossian.SourceClientLanguage)">
+            <summary>
+                Determines whether one request still owns the active BattleTalk
+                managed state for the supplied source language.
+            </summary>
+            <param name="requestId">The captured request identifier.</param>
+            <param name="sourceLanguage">The captured source language.</param>
+            <returns>
+                <see langword="true" /> when the request remains current; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Talk.IVisibleDialogueRetranslationHandler">
             <summary>
                 Defines the runtime contract for explicitly retranslating the currently
@@ -24513,13 +25038,13 @@
                 updates, and optional native text replacement.
             </summary>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,Echoglossian.EFCoreSqlite.Models.TalkMessage},System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String},System.Action)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.EFCoreSqlite.Models.TalkMessage}},System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String},System.Func{System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.DialogueInterlocutorHints}},System.Action)">
             <summary>
                 Initializes a new instance of the <see cref="T:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler" /> class.
             </summary>
             <param name="config">The active plugin configuration.</param>
             <param name="translationService">The translation service used by the plugin.</param>
-            <param name="findTalkMessage">
+            <param name="findTalkMessageAsync">
                 Delegate used to look up previously translated Talk messages.
             </param>
             <param name="insertTalkMessageAsync">
@@ -24534,22 +25059,28 @@
             <param name="normalizeReplacementText">
                 Delegate used to normalize translated text before native replacement.
             </param>
+            <param name="resolveInterlocutorHintsAsync">
+                Delegate used to resolve current-line interlocutor hints after a database miss.
+            </param>
             <param name="restoreNativeMutation">
                 Optional native-free override for restoring tracked Talk mutation.
             </param>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,Echoglossian.EFCoreSqlite.Models.TalkMessage},System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String},System.Action)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.#ctor(Echoglossian.Config,Echoglossian.Translators.TranslationService,System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.EFCoreSqlite.Models.TalkMessage}},System.Func{Echoglossian.EFCoreSqlite.Models.TalkMessage,System.Threading.CancellationToken,System.Threading.Tasks.Task{System.String}},System.Action{System.String,System.String,System.String},System.Action,System.Func{System.String,System.String},System.Func{System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.DialogueInterlocutorHints}},System.Action)">
             <summary>
                 Initializes a Talk handler with cancellation-aware dialogue
                 persistence owned by the captured operation scope.
             </summary>
             <param name="config">The active plugin configuration.</param>
             <param name="translationService">The shared translation service.</param>
-            <param name="findTalkMessage">The canonical Talk lookup.</param>
+            <param name="findTalkMessageAsync">The canonical asynchronous Talk lookup.</param>
             <param name="insertTalkMessageAsync">The cancellation-aware persistence delegate.</param>
             <param name="updateOverlay">The overlay publication callback.</param>
             <param name="clearOverlay">The overlay clear callback.</param>
             <param name="normalizeReplacementText">The native replacement normalizer.</param>
+            <param name="resolveInterlocutorHintsAsync">
+                The asynchronous current-line interlocutor hint resolver.
+            </param>
             <param name="restoreNativeMutation">The optional native restoration override.</param>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.GetEventHandlers">
@@ -24559,6 +25090,12 @@
             <returns>
                 A dictionary mapping addon events to combined delegates.
             </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.OnPluginUnload">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.Dispose">
+            <inheritdoc />
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.RetranslateVisibleTextAndPersistAsync">
             <inheritdoc />
@@ -24738,22 +25275,7 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.TryLoadStoredTranslation(System.String,System.String,Echoglossian.SourceClientLanguage,System.String@,System.String@)">
-            <summary>
-                Tries to load an existing Talk translation synchronously from the
-                database so saved lines can still swap immediately during refresh.
-            </summary>
-            <param name="originalName">The original sender name.</param>
-            <param name="originalText">The original Talk text.</param>
-            <param name="sourceLanguage">The resolved source language.</param>
-            <param name="translatedName">Receives the translated sender name.</param>
-            <param name="translatedText">Receives the translated Talk text.</param>
-            <returns>
-                <see langword="true" /> when a stored translation exists for the current
-                Talk line; otherwise, <see langword="false" />.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.ResolveTranslationAsync(System.String,System.String,System.Int32,Echoglossian.SourceClientLanguage,Echoglossian.NativeUI.AddonHandlers.Common.SourcePublicationOperation)">
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.ResolveTranslationAsync(System.String,System.String,System.Int32,Echoglossian.SourceClientLanguage,Echoglossian.NativeUI.AddonHandlers.Common.SourcePublicationOperation,System.Threading.CancellationToken)">
             <summary>
                 Resolves a Talk translation from cache or external translation and stores
                 the result as the current translation state.
@@ -24763,6 +25285,7 @@
             <param name="requestId">The request identifier used to reject stale results.</param>
             <param name="sourceLanguage">The resolved source language.</param>
             <param name="sourceOperation">The source generation captured when queued.</param>
+            <param name="operationToken">The token owned by the queued operation.</param>
             <returns>A task that completes when the translation state has been updated.</returns>
         </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.RecordDiagnosticsSnapshot(Echoglossian.NativeUI.Helpers.VisibleStorySurfaceProvenanceKind,System.String,System.String,System.String,System.String,System.Boolean,System.Int32)">
@@ -24814,6 +25337,23 @@
                 <see langword="false" />.
             </returns>
         </member>
+        <member name="P:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.IsTranslationInFlight">
+            <summary>
+                Gets a value indicating whether the current Talk line has unresolved
+                background translation work.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.ResolveInterlocutorHintsOrDefaultAsync(System.String,System.String,Echoglossian.SourceClientLanguage,System.Threading.CancellationToken)">
+            <summary>
+                Resolves optional Talk metadata without allowing auxiliary failures to
+                abort the dialogue translation.
+            </summary>
+            <param name="originalName">The original visible speaker name.</param>
+            <param name="originalText">The original visible dialogue text.</param>
+            <param name="sourceLanguage">The captured source language.</param>
+            <param name="cancellationToken">The token that cancels the current source operation.</param>
+            <returns>The resolved hints, or an empty hint set after an auxiliary failure.</returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.TryGetCurrentResolvedTranslation(Echoglossian.SourceClientLanguage,System.String@,System.String@,System.String@,System.String@)">
             <summary>
                 Returns the active resolved Talk translation currently held by the
@@ -24846,6 +25386,19 @@
                 otherwise, <see langword="false" />.
             </returns>
         </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.TryQueueTranslation(System.String,System.String,Echoglossian.SourceClientLanguage)">
+            <summary>
+                Captures one Talk line and starts its handler-owned asynchronous
+                resolution without waiting for persistent lookup to complete.
+            </summary>
+            <param name="originalName">The source sender name.</param>
+            <param name="originalText">The source Talk text.</param>
+            <param name="sourceLanguage">The resolved source language.</param>
+            <returns>
+                <see langword="true" /> when the operation was queued; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
         <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.TryQueueTranslation(System.String,System.String,Echoglossian.SourceClientLanguage,System.Int32@,Echoglossian.NativeUI.AddonHandlers.Common.SourcePublicationOperation@)">
             <summary>
                 Starts a new translation request when the Talk source changes or when the
@@ -24862,6 +25415,18 @@
             <returns>
                 <see langword="true" /> when a new translation task should be queued;
                 otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.AddonHandlers.Talk.TalkHandler.IsCurrentRequest(System.Int32,Echoglossian.SourceClientLanguage)">
+            <summary>
+                Determines whether one request still owns the active Talk managed
+                state for the supplied source language.
+            </summary>
+            <param name="requestId">The captured request identifier.</param>
+            <param name="sourceLanguage">The captured source language.</param>
+            <returns>
+                <see langword="true" /> when the request remains current; otherwise,
+                <see langword="false" />.
             </returns>
         </member>
         <member name="T:Echoglossian.NativeUI.AddonHandlers.Talk.TalkSubtitleHandler">
@@ -29905,6 +30470,51 @@
         <member name="P:Echoglossian.NativeUI.Helpers.OverlayPublicationDiagnostics.EmissionState.EmittedAtUtc">
             <summary>The last emission time in UTC.</summary>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet">
+            <summary>
+                Owns background operations that must stop when their native UI runtime
+                is disposed.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet.#ctor(System.Action{System.Exception})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet" />
+                class.
+            </summary>
+            <param name="errorObserver">Optional observer for unexpected operation failures.</param>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet.Run(System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task},System.Threading.CancellationToken)">
+            <summary>
+                Starts an operation owned by this set.
+            </summary>
+            <param name="operation">The operation to start with the shutdown-linked token.</param>
+            <param name="externalCancellationToken">
+                An optional token that cancels the operation independently of shutdown.
+            </param>
+            <returns>
+                <see langword="true" /> if the operation was accepted; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet.Dispose">
+            <inheritdoc />
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet.ObserveOperationAsync(System.Threading.Tasks.Task,System.Threading.CancellationTokenSource)">
+            <summary>
+                Observes one operation and releases its owned cancellation source
+                after it completes.
+            </summary>
+            <param name="operationTask">The operation being observed.</param>
+            <param name="operationTokenSource">The linked token source for the operation.</param>
+            <returns>A task representing observation of the operation.</returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.OwnedAsyncOperationSet.ReportUnexpectedException(System.Exception)">
+            <summary>
+                Reports one unexpected exception without allowing observer failures
+                to escape the owning runtime.
+            </summary>
+            <param name="exception">The exception to report.</param>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.PayloadStabilityTracker">
             <summary>
                 Tracks whether one payload signature has remained unchanged for long
@@ -31701,6 +32311,382 @@
                 Identical source-scoped work was already pending.
             </summary>
         </member>
+        <member name="T:Echoglossian.DialogueInterlocutorResolutionTier">
+            <summary>
+                Specifies the evidence tier used to resolve dialogue interlocutor metadata.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.DialogueInterlocutorResolutionTier.QuestSheetDerivedExact">
+            <summary>
+                Indicates that exact persisted quest-sheet metadata supplied the result.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.DialogueInterlocutorResolutionTier.QuestSheetPlusLiveFusion">
+            <summary>
+                Indicates that persisted quest-sheet metadata was enriched by a live actor.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.DialogueInterlocutorResolutionTier.LiveActorVisibleSpeakerFallback">
+            <summary>
+                Indicates that no exact persisted metadata existed, so a unique visible
+                speaker match against live actors supplied the available hints.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.DialogueInterlocutorMetadataRequest">
+            <summary>
+                Represents the managed dialogue input used to resolve interlocutor metadata.
+            </summary>
+            <param name="SourceText">The visible source dialogue text.</param>
+            <param name="VisibleSpeakerName">The visible speaker name, when available.</param>
+            <param name="SourceLanguageCode">The source language persistence code.</param>
+            <param name="GameVersion">The game version that supplied the source text.</param>
+            <param name="DerivationVersion">The quest metadata derivation version.</param>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataRequest.#ctor(System.String,System.String,System.String,System.String,System.String)">
+            <summary>
+                Represents the managed dialogue input used to resolve interlocutor metadata.
+            </summary>
+            <param name="SourceText">The visible source dialogue text.</param>
+            <param name="VisibleSpeakerName">The visible speaker name, when available.</param>
+            <param name="SourceLanguageCode">The source language persistence code.</param>
+            <param name="GameVersion">The game version that supplied the source text.</param>
+            <param name="DerivationVersion">The quest metadata derivation version.</param>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataRequest.SourceText">
+            <summary>The visible source dialogue text.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataRequest.VisibleSpeakerName">
+            <summary>The visible speaker name, when available.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataRequest.SourceLanguageCode">
+            <summary>The source language persistence code.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataRequest.GameVersion">
+            <summary>The game version that supplied the source text.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataRequest.DerivationVersion">
+            <summary>The quest metadata derivation version.</summary>
+        </member>
+        <member name="T:Echoglossian.LiveDialogueActorSnapshot">
+            <summary>
+                Represents a copied live actor state that is safe to retain across awaits.
+            </summary>
+            <param name="Name">The actor name.</param>
+            <param name="DataId">The actor data identifier.</param>
+            <param name="GenderHint">The actor gender hint.</param>
+            <param name="RaceHint">The actor race hint.</param>
+            <param name="BodyTypeHint">The actor body-type hint.</param>
+        </member>
+        <member name="M:Echoglossian.LiveDialogueActorSnapshot.#ctor(System.String,System.UInt32,System.String,System.String,System.String)">
+            <summary>
+                Represents a copied live actor state that is safe to retain across awaits.
+            </summary>
+            <param name="Name">The actor name.</param>
+            <param name="DataId">The actor data identifier.</param>
+            <param name="GenderHint">The actor gender hint.</param>
+            <param name="RaceHint">The actor race hint.</param>
+            <param name="BodyTypeHint">The actor body-type hint.</param>
+        </member>
+        <member name="P:Echoglossian.LiveDialogueActorSnapshot.Name">
+            <summary>The actor name.</summary>
+        </member>
+        <member name="P:Echoglossian.LiveDialogueActorSnapshot.DataId">
+            <summary>The actor data identifier.</summary>
+        </member>
+        <member name="P:Echoglossian.LiveDialogueActorSnapshot.GenderHint">
+            <summary>The actor gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.LiveDialogueActorSnapshot.RaceHint">
+            <summary>The actor race hint.</summary>
+        </member>
+        <member name="P:Echoglossian.LiveDialogueActorSnapshot.BodyTypeHint">
+            <summary>The actor body-type hint.</summary>
+        </member>
+        <member name="T:Echoglossian.DialogueInterlocutorHints">
+            <summary>
+                Carries resolved interlocutor hints for one current dialogue request.
+            </summary>
+            <param name="SpeakerRoleHint">The resolved speaker role hint.</param>
+            <param name="SpeakerGenderHint">The resolved speaker gender hint.</param>
+            <param name="AddresseeHint">The resolved addressee name hint.</param>
+            <param name="AddresseeRoleHint">The resolved addressee role hint.</param>
+            <param name="AddresseeGenderHint">The resolved addressee gender hint.</param>
+            <param name="MetadataProvenance">The source that resolved the metadata.</param>
+            <param name="MetadataConfidenceTier">The confidence tier of the resolved metadata.</param>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorHints.#ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32})">
+            <summary>
+                Carries resolved interlocutor hints for one current dialogue request.
+            </summary>
+            <param name="SpeakerRoleHint">The resolved speaker role hint.</param>
+            <param name="SpeakerGenderHint">The resolved speaker gender hint.</param>
+            <param name="AddresseeHint">The resolved addressee name hint.</param>
+            <param name="AddresseeRoleHint">The resolved addressee role hint.</param>
+            <param name="AddresseeGenderHint">The resolved addressee gender hint.</param>
+            <param name="MetadataProvenance">The source that resolved the metadata.</param>
+            <param name="MetadataConfidenceTier">The confidence tier of the resolved metadata.</param>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.SpeakerRoleHint">
+            <summary>The resolved speaker role hint.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.SpeakerGenderHint">
+            <summary>The resolved speaker gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.AddresseeHint">
+            <summary>The resolved addressee name hint.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.AddresseeRoleHint">
+            <summary>The resolved addressee role hint.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.AddresseeGenderHint">
+            <summary>The resolved addressee gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.MetadataProvenance">
+            <summary>The source that resolved the metadata.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorHints.MetadataConfidenceTier">
+            <summary>The confidence tier of the resolved metadata.</summary>
+        </member>
+        <member name="T:Echoglossian.DialogueInterlocutorMetadata">
+            <summary>
+                Represents the resolved persisted and live dialogue interlocutor hints.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.ResolutionTier">
+            <summary>
+                Gets the evidence tier used for this result.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.Provenance">
+            <summary>
+                Gets the persisted metadata provenance.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.ConfidenceTier">
+            <summary>
+                Gets the persisted numeric confidence tier.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.SpeakerHint">
+            <summary>
+                Gets the persisted speaker hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.AddresseeHint">
+            <summary>
+                Gets the persisted addressee hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.SpeakerRoleHint">
+            <summary>
+                Gets the persisted speaker role hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.AddresseeRoleHint">
+            <summary>
+                Gets the persisted addressee role hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.SpeakerGenderHint">
+            <summary>
+                Gets the resolved speaker gender hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.SpeakerRaceHint">
+            <summary>
+                Gets the resolved speaker race hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.SpeakerBodyTypeHint">
+            <summary>
+                Gets the resolved speaker body-type hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.AddresseeGenderHint">
+            <summary>
+                Gets the resolved addressee gender hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.AddresseeRaceHint">
+            <summary>
+                Gets the resolved addressee race hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.AddresseeBodyTypeHint">
+            <summary>
+                Gets the resolved addressee body-type hint.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.SpeakerActor">
+            <summary>
+                Gets the copied live speaker actor, when one matched.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadata.AddresseeActor">
+            <summary>
+                Gets the copied live addressee actor, when one matched.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.DialogueInterlocutorMetadataResolver">
+            <summary>
+                Resolves exact persisted quest dialogue metadata and enriches it with
+                managed live actor and player-state hints.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.#ctor(Echoglossian.Echoglossian)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.DialogueInterlocutorMetadataResolver" /> class.
+            </summary>
+            <param name="plugin">The plugin that owns exact database lookups.</param>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.#ctor(System.Func{System.Collections.Generic.IReadOnlyList{System.UInt32}},System.Func{System.UInt32,System.Byte},System.Func{System.UInt32,System.Byte,System.Threading.CancellationToken,System.Nullable{Echoglossian.QuestProgressSnapshot}},System.Func{Echoglossian.QuestProgressSnapshot,System.Threading.CancellationToken,System.Collections.Generic.IReadOnlyList{Echoglossian.QuestDialogueSheetEntry}},System.Func{Echoglossian.QuestDialogueMetadataLookup,System.Threading.CancellationToken,System.Threading.Tasks.Task{Echoglossian.EFCoreSqlite.Models.Journal.QuestDialogueMetadata}},System.Func{System.Collections.Generic.IReadOnlyList{Echoglossian.LiveDialogueActorSnapshot}},System.Func{Echoglossian.LiveDialogueActorSnapshot},System.Func{System.String},System.Func{System.String},System.Func{System.Action,System.Threading.CancellationToken,System.Threading.Tasks.Task})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Echoglossian.DialogueInterlocutorMetadataResolver" /> class.
+            </summary>
+            <param name="tryCollectAcceptedQuestIds">The accepted quest identifier collector.</param>
+            <param name="captureQuestSequence">The live quest sequence capture.</param>
+            <param name="tryResolveQuestProgress">The live quest progress resolver.</param>
+            <param name="readDialogueEntries">The quest dialogue row reader.</param>
+            <param name="findMetadataAsync">The exact persisted metadata lookup.</param>
+            <param name="captureLiveActors">The managed live actor snapshot collector.</param>
+            <param name="captureTargetActor">The managed current target actor snapshot collector.</param>
+            <param name="localPlayerName">The managed local player name reader.</param>
+            <param name="playerSexHint">The managed local player sex hint reader.</param>
+            <param name="runOnFrameworkThreadAsync">The native capture scheduler.</param>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.ResolveAsync(Echoglossian.DialogueInterlocutorMetadataRequest,System.Threading.CancellationToken)">
+            <summary>
+                Resolves exact accepted-quest dialogue metadata for one visible text payload.
+            </summary>
+            <param name="request">The visible dialogue source values.</param>
+            <param name="cancellationToken">The token that cancels asynchronous database lookups.</param>
+            <returns>The resolved dialogue metadata; otherwise, <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.CaptureSnapshot">
+            <summary>
+                Captures native resolver inputs into immutable managed values before
+                asynchronous work begins.
+            </summary>
+            <returns>The immutable resolver capture.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.FindMatchingRows(System.Collections.Generic.IReadOnlyList{Echoglossian.DialogueInterlocutorMetadataResolver.AcceptedQuestCapture},System.String,System.Threading.CancellationToken)">
+            <summary>
+                Resolves exact accepted-quest dialogue rows outside the native capture
+                scheduler using the copied accepted quest identifiers.
+            </summary>
+            <param name="acceptedQuests">The accepted quest identifiers and sequences captured on the framework thread.</param>
+            <param name="sourceText">The visible source text requiring an exact match.</param>
+            <param name="cancellationToken">The token that cancels traversal.</param>
+            <returns>The exact matching quest snapshots and dialogue entries.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.RunOnFrameworkThreadAsync(System.Action,System.Threading.CancellationToken)">
+            <summary>
+                Marshals one native capture action onto the Dalamud framework thread.
+            </summary>
+            <param name="capture">The native capture action.</param>
+            <param name="cancellationToken">The token that cancels the resolver operation.</param>
+            <returns>A task representing the framework-thread capture.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.RunInlineAsync(System.Action,System.Threading.CancellationToken)">
+            <summary>
+                Runs managed capture delegates inline for native-free unit tests.
+            </summary>
+            <param name="capture">The managed capture action.</param>
+            <param name="cancellationToken">The token that cancels the resolver operation.</param>
+            <returns>A completed task after capture.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.CaptureTargetActor">
+            <summary>
+                Captures the current target as immutable managed actor values.
+            </summary>
+            <returns>The captured target actor; otherwise, <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.CaptureActorSnapshot(Dalamud.Game.ClientState.Objects.Types.ICharacter)">
+            <summary>
+                Copies one live character into immutable managed dialogue metadata values.
+            </summary>
+            <param name="character">The framework-thread character to copy.</param>
+            <returns>The immutable managed actor snapshot.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.FindMatchingTargetSpeaker(Echoglossian.LiveDialogueActorSnapshot,System.String,System.String)">
+            <summary>
+                Returns the current target only when it is confirmed as the visible
+                and resolved dialogue speaker.
+            </summary>
+            <param name="targetActor">The captured current target actor.</param>
+            <param name="visibleSpeakerName">The speaker name displayed by the addon.</param>
+            <param name="resolvedSpeakerName">The speaker name resolved from metadata.</param>
+            <returns>The target speaker; otherwise, <see langword="null" />.</returns>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.BuildVisibleSpeakerLiveActorFallback(System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.LiveDialogueActorSnapshot},Echoglossian.LiveDialogueActorSnapshot,System.String,System.String)">
+            <summary>
+                Builds a live-actor-only fallback when the visible speaker uniquely
+                matches a loaded actor but exact persisted quest metadata is not yet
+                available.
+            </summary>
+            <param name="visibleSpeakerName">The current visible speaker name.</param>
+            <param name="liveActors">The copied live actor snapshot.</param>
+            <param name="localPlayerName">The copied local player name.</param>
+            <param name="playerSexHint">The copied local player sex hint.</param>
+            <returns>The live-only fallback metadata; otherwise, <see langword="null" />.</returns>
+        </member>
+        <member name="T:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot">
+            <summary>
+                Carries immutable managed resolver state across the database await boundary.
+            </summary>
+            <param name="LiveActors">The copied live actor snapshots.</param>
+            <param name="TargetActor">The copied current target actor snapshot.</param>
+            <param name="LocalPlayerName">The copied local player name.</param>
+            <param name="PlayerSexHint">The copied local player sex hint.</param>
+            <param name="AcceptedQuests">The copied accepted quest identifiers and sequences.</param>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot.#ctor(System.Collections.Generic.IReadOnlyList{Echoglossian.LiveDialogueActorSnapshot},Echoglossian.LiveDialogueActorSnapshot,System.String,System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.DialogueInterlocutorMetadataResolver.AcceptedQuestCapture})">
+            <summary>
+                Carries immutable managed resolver state across the database await boundary.
+            </summary>
+            <param name="LiveActors">The copied live actor snapshots.</param>
+            <param name="TargetActor">The copied current target actor snapshot.</param>
+            <param name="LocalPlayerName">The copied local player name.</param>
+            <param name="PlayerSexHint">The copied local player sex hint.</param>
+            <param name="AcceptedQuests">The copied accepted quest identifiers and sequences.</param>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot.LiveActors">
+            <summary>The copied live actor snapshots.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot.TargetActor">
+            <summary>The copied current target actor snapshot.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot.LocalPlayerName">
+            <summary>The copied local player name.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot.PlayerSexHint">
+            <summary>The copied local player sex hint.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.ResolverCaptureSnapshot.AcceptedQuests">
+            <summary>The copied accepted quest identifiers and sequences.</summary>
+        </member>
+        <member name="T:Echoglossian.DialogueInterlocutorMetadataResolver.AcceptedQuestCapture">
+            <summary>
+                Carries one accepted quest's native identity and sequence beyond the
+                framework-thread capture boundary.
+            </summary>
+            <param name="QuestId">The accepted quest identifier.</param>
+            <param name="QuestSequence">The captured live quest sequence.</param>
+        </member>
+        <member name="M:Echoglossian.DialogueInterlocutorMetadataResolver.AcceptedQuestCapture.#ctor(System.UInt32,System.Byte)">
+            <summary>
+                Carries one accepted quest's native identity and sequence beyond the
+                framework-thread capture boundary.
+            </summary>
+            <param name="QuestId">The accepted quest identifier.</param>
+            <param name="QuestSequence">The captured live quest sequence.</param>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.AcceptedQuestCapture.QuestId">
+            <summary>The accepted quest identifier.</summary>
+        </member>
+        <member name="P:Echoglossian.DialogueInterlocutorMetadataResolver.AcceptedQuestCapture.QuestSequence">
+            <summary>The captured live quest sequence.</summary>
+        </member>
         <member name="T:Echoglossian.QuestCanonicalData">
             <summary>
                 Represents the current canonical quest payload resolved from Lumina and
@@ -31866,6 +32852,14 @@
                  change detection, not a security primitive).
              </summary>
         </member>
+        <member name="M:Echoglossian.QuestContentHash.ComputeLine(System.String,System.String)">
+            <summary>
+                Computes the stable fingerprint for one exact quest text row.
+            </summary>
+            <param name="sourceRowKey">The canonical quest text row key.</param>
+            <param name="sourceText">The evaluated source text.</param>
+            <returns>A 16-character lowercase hex string fingerprint.</returns>
+        </member>
         <member name="M:Echoglossian.QuestContentHash.Compute(System.Collections.Generic.IReadOnlyList{Echoglossian.QuestProgressEntry},System.Collections.Generic.IReadOnlyList{Echoglossian.QuestProgressEntry},System.Collections.Generic.IReadOnlyList{Echoglossian.QuestProgressEntry})">
             <summary>
                 Computes the content hash from classified quest text rows.
@@ -31874,6 +32868,134 @@
             <param name="todoRows">TODO (objective) rows.</param>
             <param name="systemRows">SYSTEM (cinematic caption) rows.</param>
             <returns>A 16-character lowercase hex string fingerprint.</returns>
+        </member>
+        <member name="T:Echoglossian.QuestDialogueMetadataDerivation">
+            <summary>
+                Derives deterministic speaker and addressee metadata from one quest's
+                raw dialogue sheet rows.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.ReadDialogueEntries(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Reads populated dialogue and speaker-name rows from the quest text
+                sheet in their original source order.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+            <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.ReadDialogueEntries(Echoglossian.QuestProgressSnapshot,System.Threading.CancellationToken)">
+            <summary>
+                Reads populated dialogue and speaker-name rows while observing
+                cancellation during sheet traversal.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+            <param name="cancellationToken">The token that cancels sheet traversal.</param>
+            <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.ReadDialogueEntries(Echoglossian.QuestProgressSnapshot,System.Collections.Generic.IReadOnlyList{Echoglossian.QuestDialogueSheetEntry})">
+            <summary>
+                Filters evaluated raw quest rows while carrying each latest SEQ
+                boundary onto retained dialogue and speaker-name rows.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+            <param name="rawEntries">The source-ordered evaluated raw sheet rows.</param>
+            <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.ReadDialogueEntries(Echoglossian.QuestProgressSnapshot,System.Collections.Generic.IReadOnlyList{Echoglossian.QuestDialogueSheetEntry},System.Threading.CancellationToken)">
+            <summary>
+                Filters evaluated raw quest rows while observing cancellation during
+                source-ordered traversal.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+            <param name="rawEntries">The source-ordered evaluated raw sheet rows.</param>
+            <param name="cancellationToken">The token that cancels row traversal.</param>
+            <returns>The ordered dialogue and speaker-name sheet entries.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.BuildEntries(Echoglossian.QuestProgressSnapshot,System.Collections.Generic.IReadOnlyList{Echoglossian.QuestDialogueSheetEntry},System.String,System.String,System.String,System.DateTime)">
+            <summary>
+                Builds persistent metadata rows from source-ordered quest sheet entries.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+            <param name="dialogueEntries">The source-ordered quest sheet entries.</param>
+            <param name="sourceLanguageCode">The source language code.</param>
+            <param name="gameVersion">The game version that supplied the rows.</param>
+            <param name="derivationVersion">The derivation algorithm version.</param>
+            <param name="observedAtUtc">The UTC timestamp for the derived rows.</param>
+            <returns>The derived metadata rows for paired dialogue text entries.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.BuildEntries(Echoglossian.QuestProgressSnapshot,System.Collections.Generic.IReadOnlyList{Echoglossian.QuestDialogueSheetEntry},System.String,System.String,System.String,System.DateTime,System.Threading.CancellationToken)">
+            <summary>
+                Builds persistent metadata rows while observing cancellation during
+                dialogue pairing and candidate scans.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+            <param name="dialogueEntries">The source-ordered quest sheet entries.</param>
+            <param name="sourceLanguageCode">The source language code.</param>
+            <param name="gameVersion">The game version that supplied the rows.</param>
+            <param name="derivationVersion">The derivation algorithm version.</param>
+            <param name="observedAtUtc">The UTC timestamp for the derived rows.</param>
+            <param name="cancellationToken">The token that cancels metadata derivation.</param>
+            <returns>The derived metadata rows for paired dialogue text entries.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.SequenceRowPattern">
+            <remarks>
+            Pattern:<br/>
+            <code>_SEQ_(\\d+)$</code><br/>
+            Options:<br/>
+            <code>RegexOptions.CultureInvariant</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match the string "_SEQ_".<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a Unicode digit atomically at least once.<br/>
+            ○ Match if at the end of the string or if before an ending newline.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueMetadataDerivation.DialogueSuffixPattern">
+            <remarks>
+            Pattern:<br/>
+            <code>\\d{3}_\\d{3}$</code><br/>
+            Options:<br/>
+            <code>RegexOptions.CultureInvariant</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match a Unicode digit exactly 3 times.<br/>
+            ○ Match '_'.<br/>
+            ○ Match a Unicode digit exactly 3 times.<br/>
+            ○ Match if at the end of the string or if before an ending newline.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="T:Echoglossian.QuestDialogueSheetEntry">
+            <summary>
+                Represents one evaluated quest dialogue sheet row in source order.
+            </summary>
+            <param name="RowKey">The evaluated source row key.</param>
+            <param name="Text">The evaluated source text.</param>
+            <param name="SourceOrder">The zero-based source row order.</param>
+            <param name="QuestSequence">The latest preceding SEQ boundary value.</param>
+        </member>
+        <member name="M:Echoglossian.QuestDialogueSheetEntry.#ctor(System.String,System.String,System.Int32,System.UInt16)">
+            <summary>
+                Represents one evaluated quest dialogue sheet row in source order.
+            </summary>
+            <param name="RowKey">The evaluated source row key.</param>
+            <param name="Text">The evaluated source text.</param>
+            <param name="SourceOrder">The zero-based source row order.</param>
+            <param name="QuestSequence">The latest preceding SEQ boundary value.</param>
+        </member>
+        <member name="P:Echoglossian.QuestDialogueSheetEntry.RowKey">
+            <summary>The evaluated source row key.</summary>
+        </member>
+        <member name="P:Echoglossian.QuestDialogueSheetEntry.Text">
+            <summary>The evaluated source text.</summary>
+        </member>
+        <member name="P:Echoglossian.QuestDialogueSheetEntry.SourceOrder">
+            <summary>The zero-based source row order.</summary>
+        </member>
+        <member name="P:Echoglossian.QuestDialogueSheetEntry.QuestSequence">
+            <summary>The latest preceding SEQ boundary value.</summary>
         </member>
         <member name="T:Echoglossian.QuestLuminaResolver">
             <summary>
@@ -31995,6 +33117,41 @@
             <param name="questIdText">The quest id resolved from Lumina.</param>
             <param name="snapshot">The resolved progression snapshot, if any.</param>
             <returns>True when progression data could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.QuestProgressResolver.TryResolveQuestProgress(Echoglossian.QuestProgressCapture,System.Threading.CancellationToken,Echoglossian.QuestProgressSnapshot@)">
+            <summary>
+                Resolves a managed quest progression snapshot from native values
+                captured before the worker handoff.
+            </summary>
+            <param name="capture">The captured quest identity, sequence, and client language.</param>
+            <param name="cancellationToken">The token that cancels sheet traversal.</param>
+            <param name="snapshot">The resolved managed progression snapshot, if any.</param>
+            <returns><see langword="true" /> when progression data could be resolved.</returns>
+        </member>
+        <member name="T:Echoglossian.QuestProgressCapture">
+            <summary>
+                Carries lightweight native quest values across a worker handoff.
+            </summary>
+            <param name="QuestId">The accepted quest identifier.</param>
+            <param name="QuestSequence">The accepted quest sequence captured from the quest manager.</param>
+            <param name="ClientLanguage">The client language captured with the quest state.</param>
+        </member>
+        <member name="M:Echoglossian.QuestProgressCapture.#ctor(System.UInt32,System.Byte,Dalamud.Game.ClientLanguage)">
+            <summary>
+                Carries lightweight native quest values across a worker handoff.
+            </summary>
+            <param name="QuestId">The accepted quest identifier.</param>
+            <param name="QuestSequence">The accepted quest sequence captured from the quest manager.</param>
+            <param name="ClientLanguage">The client language captured with the quest state.</param>
+        </member>
+        <member name="P:Echoglossian.QuestProgressCapture.QuestId">
+            <summary>The accepted quest identifier.</summary>
+        </member>
+        <member name="P:Echoglossian.QuestProgressCapture.QuestSequence">
+            <summary>The accepted quest sequence captured from the quest manager.</summary>
+        </member>
+        <member name="P:Echoglossian.QuestProgressCapture.ClientLanguage">
+            <summary>The client language captured with the quest state.</summary>
         </member>
         <member name="T:Echoglossian.QuestProgressSnapshot">
             <summary>
@@ -32536,6 +33693,52 @@
             </summary>
             <param name="components">The ordered signature components.</param>
             <returns>The stable signature string.</returns>
+        </member>
+        <member name="T:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilityUiHelper">
+            <summary>
+                Resolves LLM configuration control state from the shared capability
+                policy used for provider request payloads.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilityUiHelper.GetTemperatureSliderState(Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.Single,System.Single)">
+            <summary>
+                Gets the temperature slider state for the active LLM capability
+                scope.
+            </summary>
+            <param name="scope">The active capability lookup scope.</param>
+            <param name="fallbackMin">The engine-specific default minimum value.</param>
+            <param name="fallbackMax">The engine-specific default maximum value.</param>
+            <returns>The effective slider state and disabled-control explanation.</returns>
+        </member>
+        <member name="T:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilitySliderState">
+            <summary>
+                Describes the effective UI state for an LLM temperature slider.
+            </summary>
+            <param name="IsEnabled">Whether the control may accept user input.</param>
+            <param name="MinValue">The inclusive slider minimum value.</param>
+            <param name="MaxValue">The inclusive slider maximum value.</param>
+            <param name="TooltipText">The explanation shown for a disabled control.</param>
+        </member>
+        <member name="M:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilitySliderState.#ctor(System.Boolean,System.Single,System.Single,System.String)">
+            <summary>
+                Describes the effective UI state for an LLM temperature slider.
+            </summary>
+            <param name="IsEnabled">Whether the control may accept user input.</param>
+            <param name="MinValue">The inclusive slider minimum value.</param>
+            <param name="MaxValue">The inclusive slider maximum value.</param>
+            <param name="TooltipText">The explanation shown for a disabled control.</param>
+        </member>
+        <member name="P:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilitySliderState.IsEnabled">
+            <summary>Whether the control may accept user input.</summary>
+        </member>
+        <member name="P:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilitySliderState.MinValue">
+            <summary>The inclusive slider minimum value.</summary>
+        </member>
+        <member name="P:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilitySliderState.MaxValue">
+            <summary>The inclusive slider maximum value.</summary>
+        </member>
+        <member name="P:Echoglossian.PluginUI.EngineConfigUI.LlmCapabilitySliderState.TooltipText">
+            <summary>The explanation shown for a disabled control.</summary>
         </member>
         <member name="T:Echoglossian.PluginUI.EngineConfigUI.LmStudioEngineUI">
             <summary>
@@ -35296,6 +36499,21 @@
                 Pesquisa uma cadeia de caracteres localizada semelhante a Temperature.
             </summary>
         </member>
+        <member name="P:Echoglossian.Properties.Resources.TemperatureControlDefaultOnlyTooltip">
+            <summary>
+                Looks up a localized string similar to Temperature is unavailable because the selected model requires the provider default-only setting..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TemperatureControlUnknownTooltip">
+            <summary>
+                Looks up a localized string similar to Temperature support for the selected model is unknown, so the setting is disabled and omitted from requests..
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Properties.Resources.TemperatureControlUnsupportedTooltip">
+            <summary>
+                Looks up a localized string similar to Temperature is unavailable for the selected model..
+            </summary>
+        </member>
         <member name="P:Echoglossian.Properties.Resources.TipDoubleClickARowToEdit">
             <summary>
                 Pesquisa uma cadeia de caracteres localizada semelhante a Tip: Double-click a row to edit..
@@ -36426,6 +37644,570 @@
             <param name="targetLanguage"></param>
             <returns></returns>
         </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityErrorClassifier">
+            <summary>
+                Classifies provider failures without retaining raw response bodies.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityErrorClassifier.TryClassify(Echoglossian.Translators.Capabilities.LlmCapabilityScope,Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,System.Nullable{System.Int32},System.String)">
+            <summary>
+                Classifies a provider response as an exact-model promotable failure,
+                an observation-only client error, or an unclassified failure.
+            </summary>
+            <param name="scope">The capability scope associated with the request.</param>
+            <param name="parameterName">The parameter sent in the failed request.</param>
+            <param name="statusCode">The provider response status code.</param>
+            <param name="responseText">The provider response body.</param>
+            <returns>A bounded, sanitized failure classification.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityErrorClassifier.SensitiveValueRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>(?i)\\b(api[_-]?key|authorization|bearer|token|password|secret)\\s*[:=]\\s*[^\\s,;]+</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at a word boundary.<br/>
+            ○ 1st capture group.<br/>
+                ○ Match with 5 alternative expressions.<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match with 2 alternative expressions.<br/>
+                            ○ Match a sequence of expressions.<br/>
+                                ○ Match a character in the set [Pp].<br/>
+                                ○ Match a character in the set [Ii].<br/>
+                                ○ Match a character in the set [\-_] atomically, optionally.<br/>
+                                ○ Match a character in the set [Kk\u212A].<br/>
+                                ○ Match a character in the set [Ee].<br/>
+                                ○ Match a character in the set [Yy].<br/>
+                            ○ Match a sequence of expressions.<br/>
+                                ○ Match a character in the set [Uu].<br/>
+                                ○ Match a character in the set [Tt].<br/>
+                                ○ Match a character in the set [Hh].<br/>
+                                ○ Match a character in the set [Oo].<br/>
+                                ○ Match a character in the set [Rr].<br/>
+                                ○ Match a character in the set [Ii].<br/>
+                                ○ Match a character in the set [Zz].<br/>
+                                ○ Match a character in the set [Aa].<br/>
+                                ○ Match a character in the set [Tt].<br/>
+                                ○ Match a character in the set [Ii].<br/>
+                                ○ Match a character in the set [Oo].<br/>
+                                ○ Match a character in the set [Nn].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Bb].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Tt].<br/>
+                        ○ Match a character in the set [Oo].<br/>
+                        ○ Match a character in the set [Kk\u212A].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Nn].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Pp].<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match a character in the set [Ss] exactly 2 times.<br/>
+                        ○ Match a character in the set [Ww].<br/>
+                        ○ Match a character in the set [Oo].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                        ○ Match a character in the set [Dd].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Ss].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Cc].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Tt].<br/>
+            ○ Match a whitespace character atomically any number of times.<br/>
+            ○ Match a character in the set [:=].<br/>
+            ○ Match a whitespace character greedily any number of times.<br/>
+            ○ Match a character in the set [^,;\s] atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityErrorClassifier.WhitespaceRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>\\s+</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match a whitespace character atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityErrorClassifier.ProviderErrorCodeRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>^[A-Za-z0-9_-]{1,64}$</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at the beginning of the string.<br/>
+            ○ Match a character in the set [\-0-9A-Z_a-z] atomically at least 1 and at most 64 times.<br/>
+            ○ Match if at the end of the string or if before an ending newline.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification">
+            <summary>
+                Describes the safe, bounded interpretation of a provider failure.
+            </summary>
+            <param name="ObservationRecorded">Whether the failure is eligible for an audit observation.</param>
+            <param name="RulePromoted">Whether the failure is eligible for exact-model rule promotion.</param>
+            <param name="FailureKind">The bounded failure classification.</param>
+            <param name="ProviderErrorCode">The sanitized provider error code.</param>
+            <param name="MessageExcerpt">The sanitized provider error excerpt.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification.#ctor(System.Boolean,System.Boolean,System.String,System.String,System.String)">
+            <summary>
+                Describes the safe, bounded interpretation of a provider failure.
+            </summary>
+            <param name="ObservationRecorded">Whether the failure is eligible for an audit observation.</param>
+            <param name="RulePromoted">Whether the failure is eligible for exact-model rule promotion.</param>
+            <param name="FailureKind">The bounded failure classification.</param>
+            <param name="ProviderErrorCode">The sanitized provider error code.</param>
+            <param name="MessageExcerpt">The sanitized provider error excerpt.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification.ObservationRecorded">
+            <summary>Whether the failure is eligible for an audit observation.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification.RulePromoted">
+            <summary>Whether the failure is eligible for exact-model rule promotion.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification.FailureKind">
+            <summary>The bounded failure classification.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification.ProviderErrorCode">
+            <summary>The sanitized provider error code.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityFailureClassification.MessageExcerpt">
+            <summary>The sanitized provider error excerpt.</summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision">
+            <summary>
+                Describes the resolved policy for one LLM capability parameter.
+            </summary>
+            <param name="SupportState">The resolved support state.</param>
+            <param name="MinValue">The inclusive lower bound, when known.</param>
+            <param name="MaxValue">The inclusive upper bound, when known.</param>
+            <param name="OmitWhenDefaultOnly">
+                Whether the parameter must be omitted when only its implicit default is
+                allowed.
+            </param>
+            <param name="Source">The source that supplied the resolved decision.</param>
+            <param name="Reason">The reason supplied by the resolved decision source.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.#ctor(Echoglossian.Translators.Capabilities.LlmCapabilitySupportState,System.Nullable{System.Single},System.Nullable{System.Single},System.Boolean,System.String,System.String)">
+            <summary>
+                Describes the resolved policy for one LLM capability parameter.
+            </summary>
+            <param name="SupportState">The resolved support state.</param>
+            <param name="MinValue">The inclusive lower bound, when known.</param>
+            <param name="MaxValue">The inclusive upper bound, when known.</param>
+            <param name="OmitWhenDefaultOnly">
+                Whether the parameter must be omitted when only its implicit default is
+                allowed.
+            </param>
+            <param name="Source">The source that supplied the resolved decision.</param>
+            <param name="Reason">The reason supplied by the resolved decision source.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.SupportState">
+            <summary>The resolved support state.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.MinValue">
+            <summary>The inclusive lower bound, when known.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.MaxValue">
+            <summary>The inclusive upper bound, when known.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.OmitWhenDefaultOnly">
+            <summary>
+                Whether the parameter must be omitted when only its implicit default is
+                allowed.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.Source">
+            <summary>The source that supplied the resolved decision.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision.Reason">
+            <summary>The reason supplied by the resolved decision source.</summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName">
+            <summary>
+                Identifies an LLM request parameter governed by the capability matrix.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.Temperature">
+            <summary>
+                Identifies the temperature parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.TopP">
+            <summary>
+                Identifies the top-p parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.TopK">
+            <summary>
+                Identifies the top-k parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.PresencePenalty">
+            <summary>
+                Identifies the presence-penalty parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.FrequencyPenalty">
+            <summary>
+                Identifies the frequency-penalty parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.ReasoningEffort">
+            <summary>
+                Identifies the reasoning-effort parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityParameterName.StructuredToolCalling">
+            <summary>
+                Identifies structured tool calling support.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityPolicyService">
+            <summary>
+                Provides the shared runtime policy path for LLM capability decisions.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityPolicyService.CreateScope(Echoglossian.Echoglossian.TransEngines,System.String,System.String,System.String)">
+            <summary>
+                Creates a conservatively normalized capability lookup scope.
+            </summary>
+            <param name="engine">The active translation engine.</param>
+            <param name="providerScope">The provider identity within the engine.</param>
+            <param name="endpointScope">The endpoint identity within the provider.</param>
+            <param name="modelId">The selected model identifier.</param>
+            <returns>A normalized capability lookup scope.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityPolicyService.GetSnapshot(Echoglossian.Translators.Capabilities.LlmCapabilityScope)">
+            <summary>
+                Gets the effective capability snapshot without querying SQLite.
+            </summary>
+            <param name="scope">The active capability lookup scope.</param>
+            <returns>The resolved capability snapshot.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityPolicyService.TryResolveTemperature(Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.Single,System.Single@,Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision@)">
+            <summary>
+                Resolves a temperature value for provider payload use.
+            </summary>
+            <param name="scope">The active capability lookup scope.</param>
+            <param name="configuredValue">The configured temperature value.</param>
+            <param name="sanitizedValue">When this method returns, contains the safe value when it may be sent. This parameter is treated as uninitialized.</param>
+            <param name="decision">When this method returns, contains the resolved temperature decision. This parameter is treated as uninitialized.</param>
+            <returns><see langword="true" /> if the value may be sent; otherwise, <see langword="false" />.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityPolicyService.LearnFromProviderFailure(Echoglossian.Translators.Capabilities.LlmCapabilityScope,Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,System.Nullable{System.Int32},System.String)">
+            <summary>
+                Learns from a bounded, classified provider failure.
+            </summary>
+            <param name="scope">The capability scope associated with the request.</param>
+            <param name="parameterName">The parameter sent in the failed request.</param>
+            <param name="statusCode">The provider response status code.</param>
+            <param name="responseText">The provider response body.</param>
+            <returns>The persisted observation and promotion outcome.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityLearningResult">
+            <summary>
+                Describes the persisted outcome of provider failure learning.
+            </summary>
+            <param name="ObservationRecorded">Whether a sanitized observation was persisted.</param>
+            <param name="RulePromoted">Whether an exact-model rule was persisted.</param>
+            <param name="FailureKind">The bounded failure classification.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityLearningResult.#ctor(System.Boolean,System.Boolean,System.String)">
+            <summary>
+                Describes the persisted outcome of provider failure learning.
+            </summary>
+            <param name="ObservationRecorded">Whether a sanitized observation was persisted.</param>
+            <param name="RulePromoted">Whether an exact-model rule was persisted.</param>
+            <param name="FailureKind">The bounded failure classification.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityLearningResult.ObservationRecorded">
+            <summary>Whether a sanitized observation was persisted.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityLearningResult.RulePromoted">
+            <summary>Whether an exact-model rule was persisted.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityLearningResult.FailureKind">
+            <summary>The bounded failure classification.</summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityRefreshPromoter">
+            <summary>
+                Promotes discovered model identifiers into exact-model capability
+                overlays derived from known family policy.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityRefreshPromoter.PromoteDiscoveredModels(Echoglossian.Echoglossian.TransEngines,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.DateTime)">
+            <summary>
+                Persists exact-model overlays for discovered models that match known
+                static family policy.
+            </summary>
+            <param name="engine">The active translation engine.</param>
+            <param name="providerScope">The provider identity within the engine.</param>
+            <param name="endpointScope">The endpoint identity within the provider.</param>
+            <param name="modelIds">The discovered model identifiers.</param>
+            <param name="observedAtUtc">The UTC refresh observation time.</param>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityRequestPayloadSanitizer">
+            <summary>
+                Applies shared LLM capability decisions to mutable provider payloads.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityRequestPayloadSanitizer.TryAddTemperature(System.Collections.Generic.IDictionary{System.String,System.Object},Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.Single)">
+            <summary>
+                Adds the configured temperature to a provider payload only when the
+                shared policy permits the parameter for the active scope.
+            </summary>
+            <param name="payload">The mutable provider request payload.</param>
+            <param name="scope">The active capability scope.</param>
+            <param name="configuredTemperature">The configured temperature value.</param>
+            <returns>
+                <see langword="true" /> when temperature was added; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityResolver">
+            <summary>
+                Resolves static defaults and persisted overlays into one capability
+                snapshot.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityResolver.Resolve(Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition})">
+            <summary>
+                Resolves the effective capability policy for a scope.
+            </summary>
+            <param name="scope">The active capability lookup scope.</param>
+            <param name="overlayRules">The persisted capability overlay rules.</param>
+            <returns>The resolved capability snapshot.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition">
+            <summary>
+                Defines one static or persisted LLM capability rule.
+            </summary>
+            <param name="Engine">The engine identifier to match.</param>
+            <param name="ProviderScope">The provider identity to match.</param>
+            <param name="EndpointScope">The endpoint identity to match.</param>
+            <param name="MatchType">The model matching strategy.</param>
+            <param name="MatchValue">The model identifier or family prefix to match.</param>
+            <param name="ParameterName">The governed capability parameter.</param>
+            <param name="SupportState">The known support state.</param>
+            <param name="MinValue">The inclusive lower bound, when known.</param>
+            <param name="MaxValue">The inclusive upper bound, when known.</param>
+            <param name="OmitWhenDefaultOnly">
+                Whether the parameter must be omitted when only its implicit default is
+                allowed.
+            </param>
+            <param name="Source">The source that established the rule.</param>
+            <param name="Reason">The explanation for the rule.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.#ctor(System.String,System.String,System.String,Echoglossian.Translators.Capabilities.LlmCapabilityRuleMatchType,System.String,Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,Echoglossian.Translators.Capabilities.LlmCapabilitySupportState,System.Nullable{System.Single},System.Nullable{System.Single},System.Boolean,System.String,System.String)">
+            <summary>
+                Defines one static or persisted LLM capability rule.
+            </summary>
+            <param name="Engine">The engine identifier to match.</param>
+            <param name="ProviderScope">The provider identity to match.</param>
+            <param name="EndpointScope">The endpoint identity to match.</param>
+            <param name="MatchType">The model matching strategy.</param>
+            <param name="MatchValue">The model identifier or family prefix to match.</param>
+            <param name="ParameterName">The governed capability parameter.</param>
+            <param name="SupportState">The known support state.</param>
+            <param name="MinValue">The inclusive lower bound, when known.</param>
+            <param name="MaxValue">The inclusive upper bound, when known.</param>
+            <param name="OmitWhenDefaultOnly">
+                Whether the parameter must be omitted when only its implicit default is
+                allowed.
+            </param>
+            <param name="Source">The source that established the rule.</param>
+            <param name="Reason">The explanation for the rule.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.Engine">
+            <summary>The engine identifier to match.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.ProviderScope">
+            <summary>The provider identity to match.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.EndpointScope">
+            <summary>The endpoint identity to match.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.MatchType">
+            <summary>The model matching strategy.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.MatchValue">
+            <summary>The model identifier or family prefix to match.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.ParameterName">
+            <summary>The governed capability parameter.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.SupportState">
+            <summary>The known support state.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.MinValue">
+            <summary>The inclusive lower bound, when known.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.MaxValue">
+            <summary>The inclusive upper bound, when known.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.OmitWhenDefaultOnly">
+            <summary>
+                Whether the parameter must be omitted when only its implicit default is
+                allowed.
+            </summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.Source">
+            <summary>The source that established the rule.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.Reason">
+            <summary>The explanation for the rule.</summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.ExactModel(System.String,System.String,System.String,System.String,Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,Echoglossian.Translators.Capabilities.LlmCapabilitySupportState,System.Nullable{System.Single},System.Nullable{System.Single},System.Boolean,System.String,System.String)">
+            <summary>
+                Creates a rule that applies to one complete model identifier.
+            </summary>
+            <param name="engine">The engine identifier to match.</param>
+            <param name="providerScope">The provider identity to match.</param>
+            <param name="endpointScope">The endpoint identity to match.</param>
+            <param name="modelId">The complete model identifier to match.</param>
+            <param name="parameterName">The governed capability parameter.</param>
+            <param name="supportState">The known support state.</param>
+            <param name="minValue">The inclusive lower bound, when known.</param>
+            <param name="maxValue">The inclusive upper bound, when known.</param>
+            <param name="omitWhenDefaultOnly">
+                <see langword="true" /> to omit the parameter when only its implicit
+                default is allowed; otherwise, <see langword="false" />.
+            </param>
+            <param name="source">The source that established the rule.</param>
+            <param name="reason">The explanation for the rule.</param>
+            <returns>An exact-model capability rule.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition.FamilyPrefix(System.String,System.String,System.String,System.String,Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,Echoglossian.Translators.Capabilities.LlmCapabilitySupportState,System.Nullable{System.Single},System.Nullable{System.Single},System.Boolean,System.String,System.String)">
+            <summary>
+                Creates a rule that applies to models in one identifier family.
+            </summary>
+            <param name="engine">The engine identifier to match.</param>
+            <param name="providerScope">The provider identity to match.</param>
+            <param name="endpointScope">The endpoint identity to match.</param>
+            <param name="modelPrefix">The model identifier prefix to match.</param>
+            <param name="parameterName">The governed capability parameter.</param>
+            <param name="supportState">The known support state.</param>
+            <param name="minValue">The inclusive lower bound, when known.</param>
+            <param name="maxValue">The inclusive upper bound, when known.</param>
+            <param name="omitWhenDefaultOnly">
+                <see langword="true" /> to omit the parameter when only its implicit
+                default is allowed; otherwise, <see langword="false" />.
+            </param>
+            <param name="source">The source that established the rule.</param>
+            <param name="reason">The explanation for the rule.</param>
+            <returns>A family-prefix capability rule.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityRuleMatchType">
+            <summary>
+                Describes how a capability rule identifies an LLM model.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityRuleMatchType.ExactModel">
+            <summary>
+                Matches one complete model identifier.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilityRuleMatchType.FamilyPrefix">
+            <summary>
+                Matches model identifiers that begin with a family prefix.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityScope">
+            <summary>
+                Identifies the active engine, provider, endpoint, and model for a
+                capability lookup.
+            </summary>
+            <param name="Engine">The active translation engine.</param>
+            <param name="ProviderScope">The provider identity within the engine.</param>
+            <param name="EndpointScope">The endpoint identity within the provider.</param>
+            <param name="ModelId">The active model identifier.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityScope.#ctor(Echoglossian.Echoglossian.TransEngines,System.String,System.String,System.String)">
+            <summary>
+                Identifies the active engine, provider, endpoint, and model for a
+                capability lookup.
+            </summary>
+            <param name="Engine">The active translation engine.</param>
+            <param name="ProviderScope">The provider identity within the engine.</param>
+            <param name="EndpointScope">The endpoint identity within the provider.</param>
+            <param name="ModelId">The active model identifier.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityScope.Engine">
+            <summary>The active translation engine.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityScope.ProviderScope">
+            <summary>The provider identity within the engine.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityScope.EndpointScope">
+            <summary>The endpoint identity within the provider.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Capabilities.LlmCapabilityScope.ModelId">
+            <summary>The active model identifier.</summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilitySnapshot">
+            <summary>
+                Represents the immutable resolved capability policy for one LLM scope.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilitySnapshot.GetDecision(Echoglossian.Translators.Capabilities.LlmCapabilityParameterName)">
+            <summary>
+                Gets the resolved decision for a capability parameter.
+            </summary>
+            <param name="parameterName">The capability parameter.</param>
+            <returns>The resolved parameter decision.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilitySnapshot.Create(Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.Collections.Generic.IEnumerable{Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition},System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.Capabilities.LlmCapabilityRuleDefinition})">
+            <summary>
+                Creates a snapshot from matching static definitions and overlay rules.
+            </summary>
+            <param name="scope">The active capability lookup scope.</param>
+            <param name="staticDefinitions">The committed static capability rules.</param>
+            <param name="overlayRules">The persisted capability overlay rules.</param>
+            <returns>The resolved capability snapshot.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilityStaticCatalog">
+            <summary>
+                Provides committed conservative capability defaults by LLM engine.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Capabilities.LlmCapabilityStaticCatalog.GetDefinitions(Echoglossian.Echoglossian.TransEngines)">
+            <summary>
+                Gets the static capability definitions for an engine.
+            </summary>
+            <param name="engine">The translation engine.</param>
+            <returns>The static capability definitions for <paramref name="engine" />.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Capabilities.LlmCapabilitySupportState">
+            <summary>
+                Describes the known support state for an LLM capability parameter.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilitySupportState.Unknown">
+            <summary>
+                Indicates that support has not been established.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilitySupportState.Supported">
+            <summary>
+                Indicates that the parameter is supported.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Capabilities.LlmCapabilitySupportState.Unsupported">
+            <summary>
+                Indicates that the parameter is unsupported.
+            </summary>
+        </member>
         <member name="M:Echoglossian.Translators.ChatGPTTranslator.#ctor(Dalamud.Plugin.Services.IPluginLog,Echoglossian.Config)">
             <summary>
                 Initializes a new instance of the <see cref="T:Echoglossian.Translators.ChatGPTTranslator" /> class.
@@ -36504,6 +38286,42 @@
             <param name="completion">The provider completion.</param>
             <returns>The raw structured payload string, if any.</returns>
         </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.ApplyTemperaturePolicy(OpenAI.Chat.ChatCompletionOptions)">
+            <summary>
+                Applies the shared temperature decision to an OpenAI SDK request.
+            </summary>
+            <param name="options">The completion options to sanitize.</param>
+            <returns>
+                <see langword="true" /> when temperature was added; otherwise,
+                <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.ApplyStructuredReasoningEffortPolicy(OpenAI.Chat.ChatCompletionOptions)">
+            <summary>
+                Applies the effective structured reasoning-effort capability policy
+                to an OpenAI SDK completion request.
+            </summary>
+            <param name="options">The completion options to sanitize.</param>
+            <returns>
+                <see langword="true" /> when a configured reasoning-effort value
+                or an explicit provider disable remains eligible for transmission;
+                otherwise, <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.LearnTemperatureFailure(System.Exception)">
+            <summary>
+                Records a sanitized exact-model temperature observation from an
+                OpenAI SDK request failure.
+            </summary>
+            <param name="exception">The provider exception associated with the request.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.ChatGPTTranslator.LearnReasoningEffortFailure(System.Exception)">
+            <summary>
+                Records exact-model reasoning-effort feedback from a structured
+                OpenAI SDK request failure.
+            </summary>
+            <param name="exception">The provider exception associated with the request.</param>
+        </member>
         <member name="T:Echoglossian.Translators.ClaudeTranslator">
             <summary>
                 Translator implementation for Anthropic Claude using the Messages API.
@@ -36550,6 +38368,14 @@
                 The structured translated text when successful; otherwise
                 <see langword="null" /> so the legacy path can run.
             </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.ClaudeTranslator.LearnTemperatureFailureAsync(System.Net.Http.HttpResponseMessage,System.Boolean)">
+            <summary>
+                Records a sanitized exact-model temperature observation from a
+                failed Anthropic request that included temperature.
+            </summary>
+            <param name="response">The provider response associated with the request.</param>
+            <param name="temperatureWasSent">Whether the request included temperature.</param>
         </member>
         <member name="T:Echoglossian.Translators.Claude.ClaudeModelManager">
             <summary>
@@ -36730,6 +38556,14 @@
                 <see langword="null" /> so the legacy path can run.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.DeepSeekTranslator.LearnTemperatureFailureAsync(System.Net.Http.HttpResponseMessage,System.Boolean)">
+            <summary>
+                Records a sanitized exact-model temperature observation from a
+                failed DeepSeek request that included temperature.
+            </summary>
+            <param name="response">The provider response associated with the request.</param>
+            <param name="temperatureWasSent">Whether the request included temperature.</param>
+        </member>
         <member name="T:Echoglossian.Translators.DeepSeek.DeepSeekModelManager">
             <summary>
                 Manages the DeepSeek live model list used by the configuration UI.
@@ -36754,6 +38588,15 @@
             <param name="baseUrl">The configured DeepSeek base URL.</param>
             <returns>The normalized DeepSeek models endpoint.</returns>
         </member>
+        <member name="M:Echoglossian.Translators.DeepSeek.DeepSeekModelManager.ApplyRefreshSuccess(System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.OpenAI.LlmTextModel},System.DateTime)">
+            <summary>
+                Applies a successful DeepSeek model discovery result and promotes
+                any known capability overlays without risking the discovered list.
+            </summary>
+            <param name="baseUrl">The configured DeepSeek base URL.</param>
+            <param name="models">The discovered supported model list.</param>
+            <param name="observedAtUtc">The UTC discovery observation time.</param>
+        </member>
         <member name="T:Echoglossian.Translators.DialogueTranslationContext">
             <summary>
                 Holds runtime-only short-lived dialogue session context for one live
@@ -36763,8 +38606,15 @@
             <param name="SessionKey">The runtime session key within that namespace.</param>
             <param name="SpeakerName">The visible speaker name when available.</param>
             <param name="PriorTurns">The rolling source-side history preceding the current request.</param>
+            <param name="SpeakerRoleHint">The resolved current speaker role hint.</param>
+            <param name="SpeakerGenderHint">The resolved current speaker gender hint.</param>
+            <param name="AddresseeHint">The resolved current addressee name hint.</param>
+            <param name="AddresseeRoleHint">The resolved current addressee role hint.</param>
+            <param name="AddresseeGenderHint">The resolved current addressee gender hint.</param>
+            <param name="MetadataProvenance">The source that resolved the current metadata.</param>
+            <param name="MetadataConfidenceTier">The confidence tier of the current metadata.</param>
         </member>
-        <member name="M:Echoglossian.Translators.DialogueTranslationContext.#ctor(System.String,System.String,System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.DialogueTranslationTurn})">
+        <member name="M:Echoglossian.Translators.DialogueTranslationContext.#ctor(System.String,System.String,System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.DialogueTranslationTurn},System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32})">
             <summary>
                 Holds runtime-only short-lived dialogue session context for one live
                 translation request.
@@ -36773,6 +38623,13 @@
             <param name="SessionKey">The runtime session key within that namespace.</param>
             <param name="SpeakerName">The visible speaker name when available.</param>
             <param name="PriorTurns">The rolling source-side history preceding the current request.</param>
+            <param name="SpeakerRoleHint">The resolved current speaker role hint.</param>
+            <param name="SpeakerGenderHint">The resolved current speaker gender hint.</param>
+            <param name="AddresseeHint">The resolved current addressee name hint.</param>
+            <param name="AddresseeRoleHint">The resolved current addressee role hint.</param>
+            <param name="AddresseeGenderHint">The resolved current addressee gender hint.</param>
+            <param name="MetadataProvenance">The source that resolved the current metadata.</param>
+            <param name="MetadataConfidenceTier">The confidence tier of the current metadata.</param>
         </member>
         <member name="P:Echoglossian.Translators.DialogueTranslationContext.SessionNamespace">
             <summary>The isolated dialogue session namespace, such as Talk or BattleTalk.</summary>
@@ -36785,6 +38642,27 @@
         </member>
         <member name="P:Echoglossian.Translators.DialogueTranslationContext.PriorTurns">
             <summary>The rolling source-side history preceding the current request.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.SpeakerRoleHint">
+            <summary>The resolved current speaker role hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.SpeakerGenderHint">
+            <summary>The resolved current speaker gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.AddresseeHint">
+            <summary>The resolved current addressee name hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.AddresseeRoleHint">
+            <summary>The resolved current addressee role hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.AddresseeGenderHint">
+            <summary>The resolved current addressee gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.MetadataProvenance">
+            <summary>The source that resolved the current metadata.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.DialogueTranslationContext.MetadataConfidenceTier">
+            <summary>The confidence tier of the current metadata.</summary>
         </member>
         <member name="T:Echoglossian.Translators.DialogueTranslationSessionSnapshot">
             <summary>
@@ -36827,7 +38705,7 @@
                 session-aware LLM translation requests.
             </summary>
         </member>
-        <member name="M:Echoglossian.Translators.DialogueTranslationSessionStore.BuildContext(System.String,System.String,System.String,System.String,System.Int32,System.TimeSpan,System.Nullable{System.DateTime})">
+        <member name="M:Echoglossian.Translators.DialogueTranslationSessionStore.BuildContext(System.String,System.String,System.String,System.String,System.Int32,System.TimeSpan,System.Nullable{System.DateTime},System.Nullable{Echoglossian.DialogueInterlocutorHints})">
             <summary>
                 Builds a runtime-only dialogue context from the retained session
                 history, then appends the current turn for future requests.
@@ -36839,6 +38717,7 @@
             <param name="historyLimit">The maximum number of prior turns to retain.</param>
             <param name="ttl">The maximum session idle age.</param>
             <param name="observedAtUtc">Optional explicit observation time for tests.</param>
+            <param name="interlocutorHints">Optional resolved hints for only the current request.</param>
             <returns>The current runtime-only dialogue context.</returns>
         </member>
         <member name="M:Echoglossian.Translators.DialogueTranslationSessionStore.Clear">
@@ -36908,6 +38787,14 @@
                 The structured translated text when successful; otherwise
                 <see langword="null" /> so the legacy path can run.
             </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.GeminiTranslator.LearnTemperatureFailureAsync(System.Net.Http.HttpResponseMessage,System.Boolean)">
+            <summary>
+                Records a sanitized exact-model temperature observation from a
+                failed Gemini request that included temperature.
+            </summary>
+            <param name="response">The provider response associated with the request.</param>
+            <param name="temperatureWasSent">Whether the request included temperature.</param>
         </member>
         <member name="T:Echoglossian.Translators.GoogleTranslator">
             <summary>
@@ -37032,14 +38919,34 @@
         </member>
         <member name="M:Echoglossian.Translators.Helpers.DialogueContextPromptHelper.HasUsableDialogueContext(Echoglossian.Translators.DialogueTranslationContext)">
             <summary>
-                Returns whether the provided dialogue context has prior turns that
-                can materially influence a translation request.
+                Returns whether the provided captured dialogue context can
+                materially influence a translation request.
             </summary>
             <param name="dialogueContext">The dialogue context to inspect.</param>
             <returns>
-                <see langword="true" /> when prior turns are available;
+                <see langword="true" /> when captured dialogue context is available;
                 otherwise <see langword="false" />.
             </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueContextPromptHelper.HasMaterialDialogueMetadata(Echoglossian.Translators.DialogueTranslationContext)">
+            <summary>
+                Returns whether the captured context contains any actual speaker,
+                hint, or history metadata beyond a bare dialogue session identity.
+            </summary>
+            <param name="dialogueContext">The dialogue context to inspect.</param>
+            <returns>
+                <see langword="true" /> when the context carries speaker, hint, or
+                history metadata; otherwise <see langword="false" />.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueContextPromptHelper.SummarizeDialogueContextForDiagnostics(Echoglossian.Translators.DialogueTranslationContext)">
+            <summary>
+                Builds a non-sensitive one-line diagnostic summary for the captured
+                dialogue context without logging speaker names, addressee names, or
+                prior dialogue text.
+            </summary>
+            <param name="dialogueContext">The dialogue context to summarize.</param>
+            <returns>The diagnostic summary line content.</returns>
         </member>
         <member name="M:Echoglossian.Translators.Helpers.DialogueContextPromptHelper.BuildDialogueContextCacheKey(System.String,System.String,System.String,Echoglossian.Translators.DialogueTranslationContext)">
             <summary>
@@ -37054,12 +38961,195 @@
         </member>
         <member name="M:Echoglossian.Translators.Helpers.DialogueContextPromptHelper.AppendDialogueContext(System.String,Echoglossian.Translators.DialogueTranslationContext,System.Func{System.String,System.String})">
             <summary>
-                Appends bounded prior dialogue turns to an already-rendered prompt.
+                Appends captured dialogue metadata and bounded prior dialogue turns
+                to an already-rendered prompt.
             </summary>
             <param name="prompt">The already-rendered prompt for the current text.</param>
             <param name="dialogueContext">The dialogue context to append.</param>
             <param name="sanitizeText">A text sanitizer used on prior turns.</param>
-            <returns>The prompt, optionally enriched with prior-turn context.</returns>
+            <returns>The prompt, optionally enriched with dialogue context.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector">
+            <summary>
+                Protects exact dialogue glossary terms with deterministic opaque markers
+                before provider translation and restores configured targets after the
+                provider returns those markers unchanged.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult">
+            <summary>
+                Captures the protected source text plus the marker-to-target mapping
+                required to restore the final translated output.
+            </summary>
+            <param name="OriginalText">The original visible source text.</param>
+            <param name="ProtectedText">The source text rewritten with opaque markers.</param>
+            <param name="MarkerPrefix">The deterministic marker prefix chosen for the request.</param>
+            <param name="Occurrences">The protected glossary occurrences in source order.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult.#ctor(System.String,System.String,System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectedOccurrence})">
+            <summary>
+                Captures the protected source text plus the marker-to-target mapping
+                required to restore the final translated output.
+            </summary>
+            <param name="OriginalText">The original visible source text.</param>
+            <param name="ProtectedText">The source text rewritten with opaque markers.</param>
+            <param name="MarkerPrefix">The deterministic marker prefix chosen for the request.</param>
+            <param name="Occurrences">The protected glossary occurrences in source order.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult.OriginalText">
+            <summary>The original visible source text.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult.ProtectedText">
+            <summary>The source text rewritten with opaque markers.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult.MarkerPrefix">
+            <summary>The deterministic marker prefix chosen for the request.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult.Occurrences">
+            <summary>The protected glossary occurrences in source order.</summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectedOccurrence">
+            <summary>
+                Captures one protected glossary occurrence.
+            </summary>
+            <param name="Marker">The opaque marker inserted into the protected text.</param>
+            <param name="SourceText">The matched source glossary term.</param>
+            <param name="TargetText">The configured target glossary term.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectedOccurrence.#ctor(System.String,System.String,System.String)">
+            <summary>
+                Captures one protected glossary occurrence.
+            </summary>
+            <param name="Marker">The opaque marker inserted into the protected text.</param>
+            <param name="SourceText">The matched source glossary term.</param>
+            <param name="TargetText">The configured target glossary term.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectedOccurrence.Marker">
+            <summary>The opaque marker inserted into the protected text.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectedOccurrence.SourceText">
+            <summary>The matched source glossary term.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectedOccurrence.TargetText">
+            <summary>The configured target glossary term.</summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.RestoreResult">
+            <summary>
+                Describes the outcome of restoring protected glossary markers from a
+                provider response.
+            </summary>
+            <param name="Succeeded">Whether restoration succeeded.</param>
+            <param name="RestoredText">The restored text when successful.</param>
+            <param name="FailureReason">The stable failure reason when restoration failed.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.RestoreResult.#ctor(System.Boolean,System.String,System.String)">
+            <summary>
+                Describes the outcome of restoring protected glossary markers from a
+                provider response.
+            </summary>
+            <param name="Succeeded">Whether restoration succeeded.</param>
+            <param name="RestoredText">The restored text when successful.</param>
+            <param name="FailureReason">The stable failure reason when restoration failed.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.RestoreResult.Succeeded">
+            <summary>Whether restoration succeeded.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.RestoreResult.RestoredText">
+            <summary>The restored text when successful.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.RestoreResult.FailureReason">
+            <summary>The stable failure reason when restoration failed.</summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.Protect(System.String,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.StructuredDialogueGlossaryEntry})">
+            <summary>
+                Rewrites source glossary terms in the current source text to stable
+                opaque markers using longest-match-first phrase matching.
+            </summary>
+            <param name="sourceText">The current visible source text.</param>
+            <param name="glossaryEntries">The glossary entries active for the request.</param>
+            <returns>The protected text plus the marker mapping required for restoration.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.TryRestore(System.String,Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult)">
+            <summary>
+                Restores configured glossary targets from one provider response that
+                must preserve every required opaque marker exactly once.
+            </summary>
+            <param name="translatedText">The provider response text.</param>
+            <param name="protectionResult">The protection mapping for the request.</param>
+            <returns>The restoration result.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IndexedGlossaryEntry">
+            <summary>
+                Holds one glossary row plus its original order so ties remain stable.
+            </summary>
+            <param name="Index">The original glossary row order.</param>
+            <param name="Entry">The glossary row.</param>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IndexedGlossaryEntry.#ctor(System.Int32,Echoglossian.Translators.StructuredDialogueGlossaryEntry)">
+            <summary>
+                Holds one glossary row plus its original order so ties remain stable.
+            </summary>
+            <param name="Index">The original glossary row order.</param>
+            <param name="Entry">The glossary row.</param>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IndexedGlossaryEntry.Index">
+            <summary>The original glossary row order.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IndexedGlossaryEntry.Entry">
+            <summary>The glossary row.</summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.FindMatch(System.String,System.Int32,System.Collections.Generic.IReadOnlyList{Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IndexedGlossaryEntry})">
+            <summary>
+                Finds the longest glossary entry that matches the current cursor.
+            </summary>
+            <param name="sourceText">The current source text.</param>
+            <param name="cursor">The current cursor position.</param>
+            <param name="candidates">The ordered glossary candidates.</param>
+            <returns>The matching glossary entry, or <see langword="null"/>.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IsWholeTermMatch(System.String,System.Int32,System.String)">
+            <summary>
+                Determines whether a matching glossary term stays outside unrelated
+                larger words.
+            </summary>
+            <param name="sourceText">The current source text.</param>
+            <param name="cursor">The match cursor.</param>
+            <param name="sourceTerm">The matched glossary term.</param>
+            <returns><see langword="true"/> when the match is safe to protect.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.IsWordLike(System.Char)">
+            <summary>
+                Determines whether one character should participate in whole-term
+                boundary checks.
+            </summary>
+            <param name="value">The character to inspect.</param>
+            <returns><see langword="true"/> when the character is word-like.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ResolveMarkerPrefix(System.String)">
+            <summary>
+                Chooses a deterministic marker prefix that does not already appear in
+                the current source text.
+            </summary>
+            <param name="sourceText">The current source text.</param>
+            <returns>The unique marker prefix for this request.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.BuildMarker(System.String,System.Int32)">
+            <summary>
+                Builds one deterministic marker from the chosen prefix and
+                occurrence order.
+            </summary>
+            <param name="markerPrefix">The chosen request marker prefix.</param>
+            <param name="occurrenceIndex">The protected occurrence index.</param>
+            <returns>The marker text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.CountOccurrences(System.String,System.String)">
+            <summary>
+                Counts exact ordinal occurrences of one marker in one provider
+                response string.
+            </summary>
+            <param name="translatedText">The provider response text.</param>
+            <param name="marker">The exact marker to count.</param>
+            <returns>The occurrence count.</returns>
         </member>
         <member name="T:Echoglossian.Translators.Helpers.StructuredDialogueAnthropicToolHelper">
             <summary>
@@ -37096,6 +39186,58 @@
                 <see langword="null" /> when no compatible tool call was found.
             </returns>
         </member>
+        <member name="T:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode">
+            <summary>
+                Identifies how a resolved capability parameter was represented in a
+                provider request.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode.SentConfigured">
+            <summary>
+                The configured parameter value was sent.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode.OmittedUnsupported">
+            <summary>
+                The parameter was omitted because the provider does not support it.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode.OmittedDefaultOnly">
+            <summary>
+                The parameter was omitted because only its implicit default is allowed.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode.OmittedUnknown">
+            <summary>
+                The parameter was omitted because its support state is unknown.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode.OmittedSupported">
+            <summary>
+                The parameter is supported but no configured value was available
+                to send for this request.
+            </summary>
+        </member>
+        <member name="F:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode.ExplicitDisable">
+            <summary>
+                The parameter was sent with its explicit disable value.
+            </summary>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityDecisionLogFormatter">
+            <summary>
+                Formats compact, provider-independent capability decision tokens for
+                structured dialogue diagnostics.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityDecisionLogFormatter.Format(Echoglossian.Translators.Capabilities.LlmCapabilityParameterName,Echoglossian.Translators.Capabilities.LlmCapabilityParameterDecision,Echoglossian.Translators.Helpers.StructuredDialogueCapabilityEmissionMode)">
+            <summary>
+                Formats one capability decision using its effective request emission.
+            </summary>
+            <param name="parameterName">The governed provider request parameter.</param>
+            <param name="decision">The resolved capability decision.</param>
+            <param name="emissionMode">How the request represented the decision.</param>
+            <returns>The compact diagnostic token.</returns>
+        </member>
         <member name="T:Echoglossian.Translators.Helpers.StructuredDialogueCapabilityHelper">
             <summary>
                 Resolves the current best-effort structured dialogue capability for one
@@ -37109,6 +39251,200 @@
             </summary>
             <param name="engine">The effective translation engine.</param>
             <returns>The preferred structured dialogue capability.</returns>
+        </member>
+        <member name="T:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper">
+            <summary>
+                Formats standardized structured-dialogue downgrade diagnostics without
+                leaking secrets into runtime logs.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.FormatStructuredFallbackMessage(System.String,System.String,Echoglossian.Translators.StructuredDialogueProviderCapability,System.String,System.String,System.Nullable{System.Int32},System.String,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Nullable{System.Boolean})">
+            <summary>
+                Builds one standardized structured-dialogue fallback diagnostic.
+            </summary>
+            <param name="providerName">The provider family name.</param>
+            <param name="modelName">The selected model name when known.</param>
+            <param name="capability">The structured capability attempted.</param>
+            <param name="stage">The downgrade stage such as validation or exception.</param>
+            <param name="failureReason">The failure reason or message.</param>
+            <param name="statusCode">The HTTP status code when available.</param>
+            <param name="responseExcerpt">The short provider error excerpt when available.</param>
+            <param name="endpointScope">The effective provider endpoint identity.</param>
+            <param name="route">The provider request route when known.</param>
+            <param name="capabilityDecisionTokens">The effective capability decision tokens.</param>
+            <param name="glossaryApplied">Whether glossary entries were included.</param>
+            <returns>The formatted diagnostic message.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.SecretAssignmentPattern">
+            <remarks>
+            Pattern:<br/>
+            <code>\\b(?&lt;key&gt;api[_-]?key|token|authorization|password|secret|key)\\b"?\\s*[=:]\\s*(?:"[^"]*"|'[^']*'|[^,\\s;}\\]]+)</code><br/>
+            Options:<br/>
+            <code>RegexOptions.IgnoreCase</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at a word boundary.<br/>
+            ○ "key" capture group.<br/>
+                ○ Match with 6 alternative expressions.<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match a character in the set [Pp].<br/>
+                        ○ Match a character in the set [Ii].<br/>
+                        ○ Match a character in the set [\-_] atomically, optionally.<br/>
+                        ○ Match a character in the set [Kk\u212A].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Yy].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Tt].<br/>
+                        ○ Match a character in the set [Oo].<br/>
+                        ○ Match a character in the set [Kk\u212A].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Nn].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match a character in the set [Uu].<br/>
+                        ○ Match a character in the set [Tt].<br/>
+                        ○ Match a character in the set [Hh].<br/>
+                        ○ Match a character in the set [Oo].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                        ○ Match a character in the set [Ii].<br/>
+                        ○ Match a character in the set [Zz].<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match a character in the set [Tt].<br/>
+                        ○ Match a character in the set [Ii].<br/>
+                        ○ Match a character in the set [Oo].<br/>
+                        ○ Match a character in the set [Nn].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Pp].<br/>
+                        ○ Match a character in the set [Aa].<br/>
+                        ○ Match a character in the set [Ss] exactly 2 times.<br/>
+                        ○ Match a character in the set [Ww].<br/>
+                        ○ Match a character in the set [Oo].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                        ○ Match a character in the set [Dd].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Ss].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Cc].<br/>
+                        ○ Match a character in the set [Rr].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Tt].<br/>
+                    ○ Match a sequence of expressions.<br/>
+                        ○ Match a character in the set [Kk\u212A].<br/>
+                        ○ Match a character in the set [Ee].<br/>
+                        ○ Match a character in the set [Yy].<br/>
+            ○ Match if at a word boundary.<br/>
+            ○ Match '"' atomically, optionally.<br/>
+            ○ Match a whitespace character atomically any number of times.<br/>
+            ○ Match a character in the set [:=].<br/>
+            ○ Match a whitespace character greedily any number of times.<br/>
+            ○ Match with 3 alternative expressions, atomically.<br/>
+                ○ Match a sequence of expressions.<br/>
+                    ○ Match '"'.<br/>
+                    ○ Match a character other than '"' atomically any number of times.<br/>
+                    ○ Match '"'.<br/>
+                ○ Match a sequence of expressions.<br/>
+                    ○ Match '\''.<br/>
+                    ○ Match a character other than '\'' atomically any number of times.<br/>
+                    ○ Match '\''.<br/>
+                ○ Match a character in the set [^,;]}\s] atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.BearerCredentialPattern">
+            <remarks>
+            Pattern:<br/>
+            <code>\\bBearer\\s+[A-Za-z0-9._~+/=-]+</code><br/>
+            Options:<br/>
+            <code>RegexOptions.IgnoreCase</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at a word boundary.<br/>
+            ○ Match a character in the set [Bb].<br/>
+            ○ Match a character in the set [Ee].<br/>
+            ○ Match a character in the set [Aa].<br/>
+            ○ Match a character in the set [Rr].<br/>
+            ○ Match a character in the set [Ee].<br/>
+            ○ Match a character in the set [Rr].<br/>
+            ○ Match a whitespace character atomically at least once.<br/>
+            ○ Match a character in the set [+\--9=A-Z_a-z~\u212A] atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.BearerTokenPattern">
+            <remarks>
+            Pattern:<br/>
+            <code>\\b(?:sk|rk)-[A-Za-z0-9_-]+\\b</code><br/>
+            Options:<br/>
+            <code>RegexOptions.IgnoreCase</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at a word boundary.<br/>
+            ○ Match with 2 alternative expressions.<br/>
+                ○ Match a sequence of expressions.<br/>
+                    ○ Match a character in the set [Ss].<br/>
+                    ○ Match a character in the set [Kk\u212A].<br/>
+                ○ Match a sequence of expressions.<br/>
+                    ○ Match a character in the set [Rr].<br/>
+                    ○ Match a character in the set [Kk\u212A].<br/>
+            ○ Match '-'.<br/>
+            ○ Match a character in the set [\-0-9A-Z_a-z\u212A] greedily at least once.<br/>
+            ○ Match if at a word boundary.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.MultiWhitespacePattern">
+            <remarks>
+            Pattern:<br/>
+            <code>\\s+</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match a whitespace character atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.NonTokenCharacterPattern">
+            <remarks>
+            Pattern:<br/>
+            <code>[^a-z0-9]+</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match a character in the set [^0-9a-z] atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.FormatStructuredStartMessage(Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.String,Echoglossian.Translators.StructuredDialogueProviderCapability,System.String,System.Int32,System.Int32,System.Boolean,System.Boolean,System.Int32,System.Nullable{System.Int32},System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String})">
+            <summary>
+                Builds a structured-dialogue request-start diagnostic.
+            </summary>
+            <param name="scope">The effective capability lookup scope.</param>
+            <param name="route">The provider request route.</param>
+            <param name="capability">The structured capability used for the request.</param>
+            <param name="sessionNamespace">The dialogue session namespace.</param>
+            <param name="priorTurns">The number of preceding dialogue turns.</param>
+            <param name="glossaryCount">The number of glossary entries included.</param>
+            <param name="speakerMetadataPresent">Whether speaker metadata was present.</param>
+            <param name="addresseeMetadataPresent">Whether addressee metadata was present.</param>
+            <param name="requestPromptLength">The generated prompt length.</param>
+            <param name="requestJsonLength">The serialized request length when applicable.</param>
+            <param name="promptPreview">The generated prompt preview.</param>
+            <param name="sourcePreview">The source text preview.</param>
+            <param name="capabilityDecisionTokens">The effective capability decision tokens.</param>
+            <returns>The formatted diagnostic message.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.Helpers.StructuredDialogueDiagnosticsHelper.FormatStructuredSuccessMessage(Echoglossian.Translators.Capabilities.LlmCapabilityScope,System.String,Echoglossian.Translators.StructuredDialogueProviderCapability,System.Boolean,System.Int32,System.Int32,System.String,System.String)">
+            <summary>
+                Builds a structured-dialogue request-success diagnostic.
+            </summary>
+            <param name="scope">The effective capability lookup scope.</param>
+            <param name="route">The provider request route.</param>
+            <param name="capability">The structured capability used for the request.</param>
+            <param name="glossaryApplied">Whether glossary entries were included.</param>
+            <param name="rawPayloadLength">The raw provider payload length.</param>
+            <param name="translatedLength">The extracted translation length.</param>
+            <param name="rawPayloadPreview">The raw provider payload preview.</param>
+            <param name="translatedPreview">The translated text preview.</param>
+            <returns>The formatted diagnostic message.</returns>
         </member>
         <member name="T:Echoglossian.Translators.Helpers.StructuredDialogueGlossaryLoader">
             <summary>
@@ -37534,6 +39870,14 @@
                 <see langword="null" /> so the legacy path can run.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.LmStudioTranslator.LearnTemperatureFailureAsync(System.Net.Http.HttpResponseMessage,System.Boolean)">
+            <summary>
+                Records a sanitized exact-model temperature observation from a
+                failed LM Studio request that included temperature.
+            </summary>
+            <param name="response">The provider response associated with the request.</param>
+            <param name="temperatureWasSent">Whether the request included temperature.</param>
+        </member>
         <member name="T:Echoglossian.Translators.LmStudio.LmStudioModelManager">
             <summary>
                 Manages dynamic model fetching for LM Studio.
@@ -37605,6 +39949,14 @@
                 The structured translated text when successful; otherwise
                 <see langword="null" /> so the legacy path can run.
             </returns>
+        </member>
+        <member name="M:Echoglossian.Translators.OllamaTranslator.LearnTemperatureFailureAsync(System.Net.Http.HttpResponseMessage,System.Boolean)">
+            <summary>
+                Records a sanitized exact-model temperature observation from a
+                failed Ollama request that included temperature.
+            </summary>
+            <param name="response">The provider response associated with the request.</param>
+            <param name="temperatureWasSent">Whether the request included temperature.</param>
         </member>
         <member name="T:Echoglossian.Translators.OpenAI.OpenAIModelManager.OpenAiModelRefreshSnapshot">
             <summary>
@@ -37892,6 +40244,14 @@
                 <see langword="null" /> so the legacy path can run.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.OpenRouterTranslator.LearnTemperatureFailureAsync(System.Net.Http.HttpResponseMessage,System.Boolean)">
+            <summary>
+                Records a sanitized exact-model temperature observation from a
+                failed OpenRouter request that included temperature.
+            </summary>
+            <param name="response">The provider response associated with the request.</param>
+            <param name="temperatureWasSent">Whether the request included temperature.</param>
+        </member>
         <member name="T:Echoglossian.Translators.StructuredDialogueContextTurn">
             <summary>
                 Represents one prior dialogue turn included in a structured LLM request.
@@ -38150,10 +40510,16 @@
             <param name="QuestNameOriginal">The original quest name when relevant.</param>
             <param name="SpeakerOriginal">The original visible speaker name.</param>
             <param name="SpeakerRoleHint">An optional role hint such as npc or player.</param>
+            <param name="SpeakerGenderHint">An optional resolved speaker gender hint.</param>
+            <param name="AddresseeOriginal">An optional resolved addressee name.</param>
+            <param name="AddresseeRoleHint">An optional resolved addressee role hint.</param>
+            <param name="AddresseeGenderHint">An optional resolved addressee gender hint.</param>
+            <param name="MetadataProvenance">An optional metadata source label.</param>
+            <param name="MetadataConfidenceTier">An optional metadata confidence tier.</param>
             <param name="PronounHint">An optional operator or runtime pronoun hint.</param>
             <param name="SubjectHint">An optional omitted-subject hint.</param>
         </member>
-        <member name="M:Echoglossian.Translators.StructuredDialogueTranslationMetadata.#ctor(System.String,System.String,System.String,System.String,System.String)">
+        <member name="M:Echoglossian.Translators.StructuredDialogueTranslationMetadata.#ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable{System.Int32},System.String,System.String)">
             <summary>
                 Carries optional structured metadata that may help LLM dialogue
                 translation quality without changing the core source text itself.
@@ -38161,6 +40527,12 @@
             <param name="QuestNameOriginal">The original quest name when relevant.</param>
             <param name="SpeakerOriginal">The original visible speaker name.</param>
             <param name="SpeakerRoleHint">An optional role hint such as npc or player.</param>
+            <param name="SpeakerGenderHint">An optional resolved speaker gender hint.</param>
+            <param name="AddresseeOriginal">An optional resolved addressee name.</param>
+            <param name="AddresseeRoleHint">An optional resolved addressee role hint.</param>
+            <param name="AddresseeGenderHint">An optional resolved addressee gender hint.</param>
+            <param name="MetadataProvenance">An optional metadata source label.</param>
+            <param name="MetadataConfidenceTier">An optional metadata confidence tier.</param>
             <param name="PronounHint">An optional operator or runtime pronoun hint.</param>
             <param name="SubjectHint">An optional omitted-subject hint.</param>
         </member>
@@ -38172,6 +40544,24 @@
         </member>
         <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.SpeakerRoleHint">
             <summary>An optional role hint such as npc or player.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.SpeakerGenderHint">
+            <summary>An optional resolved speaker gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.AddresseeOriginal">
+            <summary>An optional resolved addressee name.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.AddresseeRoleHint">
+            <summary>An optional resolved addressee role hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.AddresseeGenderHint">
+            <summary>An optional resolved addressee gender hint.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.MetadataProvenance">
+            <summary>An optional metadata source label.</summary>
+        </member>
+        <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.MetadataConfidenceTier">
+            <summary>An optional metadata confidence tier.</summary>
         </member>
         <member name="P:Echoglossian.Translators.StructuredDialogueTranslationMetadata.PronounHint">
             <summary>An optional operator or runtime pronoun hint.</summary>
@@ -38294,7 +40684,7 @@
                 translation.
             </param>
         </member>
-        <member name="M:Echoglossian.Translators.TranslationService.#ctor(System.Func{System.String,System.String},Echoglossian.Translators.ITranslator,System.Int32,System.Func{System.String,System.String,System.String,System.Int32,System.Boolean},System.Action{System.String,System.String,System.String,System.Int32,System.String,System.String},System.Action{System.Int32,Echoglossian.Translators.TranslationRequestMetricOutcome,System.TimeSpan,System.String,System.Boolean},System.Action{System.String,System.String,System.String,System.Int32,System.String,System.TimeSpan},System.Action{System.Int32,Echoglossian.TranslationFailureClassification},System.Func{Echoglossian.Translators.TranslationSurfaceGroup,Echoglossian.Translators.TranslationService.TranslatorResolution},System.Func{System.String,System.Nullable{Echoglossian.SourceClientLanguage}})">
+        <member name="M:Echoglossian.Translators.TranslationService.#ctor(System.Func{System.String,System.String},Echoglossian.Translators.ITranslator,System.Int32,System.Func{System.String,System.String,System.String,System.Int32,System.Boolean},System.Action{System.String,System.String,System.String,System.Int32,System.String,System.String},System.Action{System.Int32,Echoglossian.Translators.TranslationRequestMetricOutcome,System.TimeSpan,System.String,System.Boolean},System.Action{System.String,System.String,System.String,System.Int32,System.String,System.TimeSpan},System.Action{System.Int32,Echoglossian.TranslationFailureClassification},System.Func{Echoglossian.Translators.TranslationSurfaceGroup,Echoglossian.Translators.TranslationService.TranslatorResolution},System.Func{System.String,System.Nullable{Echoglossian.SourceClientLanguage}},System.Action{System.String})">
             <summary>
                 Initializes a new instance of the <see cref="T:Echoglossian.Translators.TranslationService" /> class
                 with test-friendly dependencies.
@@ -38372,6 +40762,19 @@
                 contains the translated text as a string.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,System.String,System.String,System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">Source text language.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+            <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+            <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+            <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
         <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.String,System.String,System.String)">
             <summary>
                 Translates text asynchronously using an operation-captured source
@@ -38380,6 +40783,20 @@
             <param name="text">Text to translate.</param>
             <param name="sourceLanguage">The captured source-language contract.</param>
             <param name="targetLanguage">Target translation language.</param>
+            <param name="originContext">Optional explicit origin context.</param>
+            <param name="callerMemberName">The caller member name.</param>
+            <param name="callerFilePath">The caller file path.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously using a captured source contract while
+                observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
             <param name="originContext">Optional explicit origin context.</param>
             <param name="callerMemberName">The caller member name.</param>
             <param name="callerFilePath">The caller file path.</param>
@@ -38402,6 +40819,20 @@
                 contains the translated text as a string.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,System.String,System.String,Echoglossian.Translators.TranslationSurfaceGroup,System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously for a surface group while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">Source text language.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+            <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+            <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+            <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
         <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,Echoglossian.Translators.TranslationSurfaceGroup,System.String,System.String,System.String)">
             <summary>
                 Translates text asynchronously for a surface group using an
@@ -38411,6 +40842,21 @@
             <param name="sourceLanguage">The captured source-language contract.</param>
             <param name="targetLanguage">Target translation language.</param>
             <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="originContext">Optional explicit origin context.</param>
+            <param name="callerMemberName">The caller member name.</param>
+            <param name="callerFilePath">The caller file path.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,Echoglossian.Translators.TranslationSurfaceGroup,System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously for a surface group using a captured
+                source contract while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
             <param name="originContext">Optional explicit origin context.</param>
             <param name="callerMemberName">The caller member name.</param>
             <param name="callerFilePath">The caller file path.</param>
@@ -38431,6 +40877,19 @@
             <param name="originContext">Optional explicit origin context.</param>
             <returns>A task containing the translated or sanitized source text.</returns>
         </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,Echoglossian.Translators.TranslationSurfaceGroup,Echoglossian.Translators.TranslationService.TranslatorResolution,System.Threading.CancellationToken,System.String)">
+            <summary>
+                Translates text using a captured translator resolution while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="translatorResolution">The engine and translator instance captured for the operation.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+            <param name="originContext">Optional explicit origin context.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
         <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,System.String,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},System.String,System.String,System.String)">
             <summary>
                 Translates the given text from the source language to the target language
@@ -38448,6 +40907,20 @@
                 contains the translated text as a string.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,System.String,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously with dialogue context while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">Source text language.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="dialogueContext">Optional runtime-only short-lived dialogue context.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+            <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+            <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+            <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
         <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},System.String,System.String,System.String)">
             <summary>
                 Translates text asynchronously with dialogue context and an
@@ -38457,6 +40930,21 @@
             <param name="sourceLanguage">The captured source-language contract.</param>
             <param name="targetLanguage">Target translation language.</param>
             <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+            <param name="originContext">Optional explicit origin context.</param>
+            <param name="callerMemberName">The caller member name.</param>
+            <param name="callerFilePath">The caller file path.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously with dialogue context and a captured
+                source contract while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
             <param name="originContext">Optional explicit origin context.</param>
             <param name="callerMemberName">The caller member name.</param>
             <param name="callerFilePath">The caller file path.</param>
@@ -38475,6 +40963,21 @@
             <param name="translatorResolution">
             The engine and translator instance captured for the operation.
             </param>
+            <param name="originContext">Optional explicit origin context.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},Echoglossian.Translators.TranslationSurfaceGroup,Echoglossian.Translators.TranslationService.TranslatorResolution,System.Threading.CancellationToken,System.String)">
+            <summary>
+                Translates dialogue text using a captured translator resolution while
+                observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="translatorResolution">The engine and translator instance captured for the operation.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
             <param name="originContext">Optional explicit origin context.</param>
             <returns>A task containing the translated or sanitized source text.</returns>
         </member>
@@ -38497,6 +41000,22 @@
                 contains the translated text as a string.
             </returns>
         </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,System.String,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},Echoglossian.Translators.TranslationSurfaceGroup,System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously with dialogue context and surface
+                routing while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">Source text language.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="dialogueContext">Optional runtime-only short-lived dialogue context.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+            <param name="originContext">Optional explicit origin context for diagnostics and persistence.</param>
+            <param name="callerMemberName">The caller member name when no explicit origin context is provided.</param>
+            <param name="callerFilePath">The caller file path when no explicit origin context is provided.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
         <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},Echoglossian.Translators.TranslationSurfaceGroup,System.String,System.String,System.String)">
             <summary>
                 Translates text asynchronously with dialogue and surface routing while
@@ -38512,7 +41031,23 @@
             <param name="callerFilePath">The caller file path.</param>
             <returns>A task containing the translated or sanitized source text.</returns>
         </member>
-        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsyncCore(System.String,System.String,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},Echoglossian.Translators.TranslationSurfaceGroup,System.Nullable{Echoglossian.SourceClientLanguage},System.String,System.String,System.String,System.Nullable{Echoglossian.Translators.TranslationService.TranslatorResolution})">
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsync(System.String,Echoglossian.SourceClientLanguage,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},Echoglossian.Translators.TranslationSurfaceGroup,System.Threading.CancellationToken,System.String,System.String,System.String)">
+            <summary>
+                Translates text asynchronously with dialogue context, surface routing,
+                and a captured source contract while observing cancellation.
+            </summary>
+            <param name="text">Text to translate.</param>
+            <param name="sourceLanguage">The captured source-language contract.</param>
+            <param name="targetLanguage">Target translation language.</param>
+            <param name="dialogueContext">Optional runtime-only dialogue context.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="cancellationToken">Token that cancels waiting for the provider result.</param>
+            <param name="originContext">Optional explicit origin context.</param>
+            <param name="callerMemberName">The caller member name.</param>
+            <param name="callerFilePath">The caller file path.</param>
+            <returns>A task containing the translated or sanitized source text.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.TranslateAsyncCore(System.String,System.String,System.String,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},Echoglossian.Translators.TranslationSurfaceGroup,System.Nullable{Echoglossian.SourceClientLanguage},System.String,System.String,System.String,System.Threading.CancellationToken,System.Nullable{Echoglossian.Translators.TranslationService.TranslatorResolution})">
             <summary>
                 Executes one asynchronous translation with an optional captured source
                 contract.
@@ -38553,7 +41088,7 @@
             <param name="dialogueContext">The optional dialogue context.</param>
             <returns>
                 <see langword="true" /> when the active translator supports dialogue
-                context and at least one prior turn is available; otherwise,
+                context; otherwise,
                 <see langword="false" />.
             </returns>
         </member>
@@ -38568,7 +41103,7 @@
             </param>
             <returns>
                 <see langword="true" /> when the captured translator supports
-                dialogue context and at least one prior turn is available; otherwise,
+                dialogue context; otherwise,
                 <see langword="false" />.
             </returns>
         </member>
@@ -38614,6 +41149,34 @@
             <param name="surfaceGroup">The coarse translation surface group.</param>
             <param name="originContext">The resolved surface or caller context.</param>
         </member>
+        <member name="M:Echoglossian.Translators.TranslationService.AcceptDialogueGlossaryResultOrFallback(System.String,Echoglossian.Translators.Helpers.DialogueGlossaryTermProtector.ProtectionResult,System.String,System.String,System.String,System.String,System.String,System.Int32,Echoglossian.Translators.TranslationSurfaceGroup)">
+            <summary>
+                Accepts one dialogue translation result after restoring any protected
+                glossary markers; otherwise records a transient glossary failure and
+                falls back to the sanitized source text.
+            </summary>
+            <param name="translatedText">The translated text candidate.</param>
+            <param name="glossaryProtection">The protected glossary request state.</param>
+            <param name="parsedText">The parsed source text sent to the translator.</param>
+            <param name="sanitizedText">The sanitized source text shown on fallback.</param>
+            <param name="normalizedSourceLanguage">The normalized source language code.</param>
+            <param name="normalizedTargetLanguage">The normalized target language code.</param>
+            <param name="resolvedOriginContext">The resolved origin context for diagnostics.</param>
+            <param name="translationEngineId">The effective translation engine identifier.</param>
+            <param name="surfaceGroup">The translation surface group.</param>
+            <returns>The accepted translation result or the sanitized fallback.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.LogDialogueContextSummary(System.Boolean,System.Nullable{Echoglossian.Translators.DialogueTranslationContext},System.Int32,Echoglossian.Translators.TranslationSurfaceGroup,System.String)">
+            <summary>
+                Writes a non-sensitive dialogue-context summary when the current
+                request will actually use the captured dialogue contract.
+            </summary>
+            <param name="useDialogueContext">Whether the translator will consume the dialogue context.</param>
+            <param name="dialogueContext">The optional captured dialogue context.</param>
+            <param name="translationEngineId">The effective translation engine id.</param>
+            <param name="surfaceGroup">The coarse translation surface group.</param>
+            <param name="originContext">The resolved origin context.</param>
+        </member>
         <member name="M:Echoglossian.Translators.TranslationService.GetSurfaceScope(Echoglossian.Translators.TranslationSurfaceGroup,System.String)">
             <summary>
                 Resolves the square-bracketed diagnostic scope for one translation
@@ -38622,6 +41185,17 @@
             <param name="surfaceGroup">The coarse translation surface group.</param>
             <param name="originContext">The resolved surface or caller context.</param>
             <returns>The best available diagnostic scope.</returns>
+        </member>
+        <member name="M:Echoglossian.Translators.TranslationService.ProtectDialogueGlossaryTerms(System.String,System.String,System.String,System.Boolean)">
+            <summary>
+                Protects exact glossary terms for dialogue-family LLM requests while
+                leaving non-dialogue and glossary-free requests untouched.
+            </summary>
+            <param name="parsedText">The parsed visible source text.</param>
+            <param name="sourceLanguage">The provider source language code.</param>
+            <param name="targetLanguage">The requested target language code.</param>
+            <param name="useDialogueContext">Whether the active request uses dialogue context.</param>
+            <returns>The protected glossary state for the request.</returns>
         </member>
         <member name="M:Echoglossian.Translators.TranslationService.CheckTextToTranslate(System.String)">
             <summary>
@@ -41334,6 +43908,294 @@
             <param name="inputSpan">The text being scanned by the regular expression.</param>
             <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
         </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SequenceRowPattern_1">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the SequenceRowPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SequenceRowPattern_1.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the DialogueSuffixPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.DialogueSuffixPattern_2.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the SensitiveValueRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SensitiveValueRegex_3.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.WhitespaceRegex_4">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the WhitespaceRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.WhitespaceRegex_4.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the ProviderErrorCodeRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ProviderErrorCodeRegex_5.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the SecretAssignmentPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.SecretAssignmentPattern_6.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the BearerCredentialPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerCredentialPattern_7.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BearerTokenPattern_8">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the BearerTokenPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BearerTokenPattern_8.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the NonTokenCharacterPattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.NonTokenCharacterPattern_9.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
         <member name="T:System.Text.RegularExpressions.Generated.Utilities">
             <summary>Helper methods used by generated <see cref="T:System.Text.RegularExpressions.Regex"/>-derived implementations.</summary>
         </member>
@@ -41342,6 +44204,51 @@
         </member>
         <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_hasTimeout">
             <summary>Whether <see cref="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout"/> is non-infinite.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.Utilities.IsBoundary(System.ReadOnlySpan{System.Char},System.Int32)">
+            <summary>Determines whether the specified index is a boundary.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.Utilities.IsBoundaryWordChar(System.Char)">
+            <summary>Determines whether the specified index is a boundary word character.</summary>
+            <remarks>This is the same as \w plus U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER.</remarks>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.Utilities.IsPostWordCharBoundary(System.ReadOnlySpan{System.Char},System.Int32)">
+            <summary>Determines whether the specified index is a boundary.</summary>
+            <remarks>This variant is only employed when the previous character has already been validated as a word character.</remarks>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.Utilities.IsPreWordCharBoundary(System.ReadOnlySpan{System.Char},System.Int32)">
+            <summary>Determines whether the specified index is a boundary.</summary>
+            <remarks>This variant is only employed when the subsequent character will separately be validated as a word character.</remarks>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.WordCategoriesMask">
+            <summary>Provides a mask of Unicode categories that combine to form [\w].</summary>
+        </member>
+        <member name="P:System.Text.RegularExpressions.Generated.Utilities.WordCharBitmap">
+            <summary>Gets a bitmap for whether each character 0 through 127 is in [\w]</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_asciiLettersAndDigitsAndDashUnderscoreKelvinSign">
+            <summary>Supports searching for characters in or not in "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyzK".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_asciiLettersLowerAndDigits">
+            <summary>Supports searching for characters in or not in "0123456789abcdefghijklmnopqrstuvwxyz".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfAnyStrings_OrdinalIgnoreCase_1CD3F7B5C4DB29EC6C616ECF66A111E271CD9522654ADF7A25297DDF824CCC0E">
+            <summary>Supports searching for the specified strings.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString__SEQ__Ordinal">
+            <summary>Supports searching for the string "_SEQ_".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString_bearer_OrdinalIgnoreCase">
+            <summary>Supports searching for the string "bearer".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_nonAscii_01B625B8F4FD2395283E9ADD057571AB8858A54AF943E8E9D678EA1F73B98889">
+            <summary>Supports searching for characters in or not in "AKPSTakpstK".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_nonAscii_10E4EA2219CF5AA8C94D1BDCF39F541399EFD76AB9C6C906C8EB478A2A307567">
+            <summary>Supports searching for characters in or not in "+-./0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~K".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_whitespace">
+            <summary>Supports searching for characters in or not in "\t\n\v\f\r \u0085             \u2028\u2029  　".</summary>
         </member>
     </members>
 </doc>


### PR DESCRIPTION
## Summary

- prepare submitted release `v4.2601.0815.1339` from the current `v4-series` head after PR #262
- bump `Echoglossian.csproj` version metadata and regenerate `Echoglossian.xml` from the validated build
- add a concise submitted-release changelog entry for the first-line dialogue speaker context, quest dialogue interlocutor metadata, glossary enforcement, and capability-aware structured LLM follow-up now queued for official submission

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [ ] in-game verification was performed when runtime UI behavior changed
- [x] `dotnet build Echoglossian.csproj -c Release --no-restore`

Validation notes:
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build` initially failed because `Echoglossian.sln` does not build `Echoglossian.Tests`; I then ran `dotnet restore .\Echoglossian.Tests\Echoglossian.Tests.csproj` and `dotnet build .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore`, after which the exact `--no-build` test command passed with `1247` tests and `0` failures.
- no additional runtime behavior changed on this release-prep branch itself; this PR only prepares the next submission from the already-merged `v4-series` content.

## AI Usage Disclosure

- [x] `Assist` — human-led work with AI used for specific tasks
- [ ] `Pair` — active human/AI collaboration throughout
- [ ] `Copilot` — AI did most of the writing while the human planned and reviewed
- [ ] `Auto` — AI acted mostly autonomously with minimal human direction

```text
AI scope:
- tooling used: Codex desktop agent plus local shell and git tooling
- files or areas most affected: release version metadata, submitted changelog entry, regenerated XML docs, and release validation execution
- how the result was reviewed/tested: reviewed local diff, ran debug build, explicit test-project build plus no-build test suite, and release build before opening this PR
```

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```