### PR TITLE
chore: prepare v4.2601.0816.1235 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
+## Submitted Release `v4.2601.0816.1235`
+
+This package is prepared for official Dalamud submission from the current
+`v4-series` head after [PR #271](https://github.com/lokinmodar/Echoglossian/pull/271).
+It focuses on the remaining dialogue LLM release follow-ups: prompt save and
+async glossary refresh completion, per-surface runtime invalidation when the
+dialogue-only LLM override is active, and shutdown-safe cancellation for live
+model discovery.
+
+Official `DalamudPluginsD17` submission is pending.
+
+Highlights:
+
+- completes the remaining `#252` follow-up by saving LLM prompt edits through
+  the shared persistence flow and refreshing structured dialogue glossaries
+  asynchronously instead of blocking the caller path
+- fixes `#270` so dialogue-only LLM override changes and quest/map surface
+  toggles rebuild the right runtime state, keeping disabled surfaces such as
+  Journal, RecommendList, and AreaMap turned off
+- cancels in-flight live model discovery during plugin shutdown or reload so
+  provider model catalogs and capability overlays cannot keep updating after
+  teardown
+
 ## Published Release `v4.2601.0815.1339`
 
 This package was published to the official Dalamud feed after

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0815</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">1339</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0816</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">1235</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -3013,10 +3013,6 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
-                Hosts debug-only automatic addon-probe watches that start on login for
-                selected addons with early hidden-state value.
-            </summary>
-            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
             </summary>
@@ -3026,11 +3022,6 @@
             </summary>
             <summary>
                 Handles bootstrap and teardown for the NamePlateGui translation runtime.
-            </summary>
-            <summary>
-                Handles the quest probe command used to inspect the complete quest data
-                shape from Lumina, the live quest progress resolver, and the current
-                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -3048,9 +3039,6 @@
             <summary>
                 Handles bootstrap and teardown for the alternate callback-owned
                 ToastGui route that owns supported normal and error toasts.
-            </summary>
-            <summary>
-            Handles the temporary tooltip-registration diagnostic command.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -3965,11 +3953,6 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
-        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
-            <summary>
-            Holds the currently active addon structure probe watch, if any.
-            </summary>
-        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -4158,11 +4141,6 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
-            <summary>
-                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -6189,109 +6167,6 @@
             <param name="cancellationToken">The handler-owned cancellation token.</param>
             <returns>The resolved hints for the current dialogue request.</returns>
         </member>
-        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
-            <summary>
-                Ticks manual and automatic addon-probe watches, including the
-                debug-only login bootstrap for the default watch set.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
-            <summary>
-                Gets how many addon-probe watches are currently active across manual
-                and managed watch sets.
-            </summary>
-            <returns>The active probe-watch count.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
-            <summary>
-                Stops every active addon-probe watch known to the plugin.
-            </summary>
-            <param name="suppressAutoUntilLogout">
-                Whether the current login session should suppress the default
-                automatic watch set after the stop completes.
-            </param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
-            <summary>
-                Ticks the currently active manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
-            <summary>
-                Ticks every managed addon-probe watch and prunes the disposed ones.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic addon-probe watch set when the player
-                logs in, then resets the gate on logout.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic watch set used to capture early
-                structural state for pooled dialogue addons.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
-            <summary>
-                Starts one managed addon-probe watch and tracks it for later stop or
-                pruning.
-            </summary>
-            <param name="addonName">The addon name to watch.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="duration">How long the watch should stay alive.</param>
-            <param name="reason">The debug log reason attached to the startup.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
-            <summary>
-                Stops the current manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
-            <summary>
-                Stops every managed automatic addon-probe watch.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log so we can
-            inspect its live node tree, component roots, and likely overlay anchors.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
-            <summary>
-            Parses the addon probe command arguments into an addon name, optional index,
-            and optional watch duration.
-            </summary>
-            <param name="args">The raw command arguments.</param>
-            <returns>The addon name, index, and duration to probe.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
-            <summary>
-            Parses one addon-probe duration token such as "90s" or "15m".
-            </summary>
-            <param name="token">The raw duration token.</param>
-            <param name="duration">Receives the parsed duration.</param>
-            <returns><see langword="true"/> when the token parsed successfully.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
-            <summary>
-            Determines whether a token looks like an addon-probe duration even when the
-            value is outside the accepted range.
-            </summary>
-            <param name="token">The token to inspect.</param>
-            <returns><see langword="true"/> when the token resembles a duration.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
-            <summary>
-            Formats one addon-probe watch duration for chat feedback.
-            </summary>
-            <param name="duration">The duration to format.</param>
-            <returns>The human-readable duration string.</returns>
-        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -6739,102 +6614,6 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
-            <summary>
-                Handles the quest probe command.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
-            <summary>
-                Tries to resolve the quest probe target from either a quest id or a
-                quest name.
-            </summary>
-            <param name="input">The command argument.</param>
-            <param name="questIdText">The resolved quest id as text.</param>
-            <param name="questName">The resolved quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>True when the quest could be resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the quest data structure for inspection.
-            </summary>
-            <param name="questIdText">The quest id as text.</param>
-            <param name="questName">The quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the raw Lumina quest row properties.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs all rows from the quest text sheet, not just the live todo
-                entries, so we can inspect the full structure of the quest sheet.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
-            <summary>
-                Logs the QuestPlate rows currently stored for the quest.
-            </summary>
-            <param name="questIdText">The quest id text.</param>
-            <param name="questName">The quest name.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
-            <summary>
-                Logs the resolved live quest progression snapshot.
-            </summary>
-            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves a human-readable quest name from a quest row.
-            </summary>
-            <param name="questRow">The quest row.</param>
-            <returns>The resolved quest name, if available.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
-            <summary>
-                Converts quest text to a readable string for probe output.
-            </summary>
-            <param name="text">The quest text.</param>
-            <returns>The evaluated text string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
-            <summary>
-                Formats a probe value for log output.
-            </summary>
-            <param name="value">The value to format.</param>
-            <returns>A human-readable value string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Builds the raw quest sheet name used by the game files.
-            </summary>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>The quest text sheet name, if it can be derived.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest row id as text through reflection so the probe
-                stays compatible with generated sheet shapes.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest row id as text, or an empty string if unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest sheet identifier used to mount the quest text
-                sheet path.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -7675,14 +7454,6 @@
                 Unregisters the alternate supported-toast runtime from Dalamud's
                 normal and error-toast callbacks.
             </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloTooltipRegisterLoggingCommand(System.String,System.String)">
-            <summary>
-            Starts or stops temporary logging for hover-tooltip registrations and
-            hover-hit transitions.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
             <summary>
@@ -28194,46 +27965,6 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
-            <summary>
-                Encapsulates the login-session gating rules for debug-only automatic
-                addon-probe watches.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
-            <summary>
-                Determines whether the current login session should start the default
-                automatic addon-probe watch set.
-            </summary>
-            <param name="isLoggedIn">Whether the client is currently logged in.</param>
-            <param name="hasStartedForCurrentLogin">
-                Whether the current login session already started its automatic probe
-                set.
-            </param>
-            <param name="isSuppressedUntilLogout">
-                Whether the user explicitly suppressed the automatic probe set until
-                the next logout.
-            </param>
-            <param name="activeManagedWatchCount">
-                How many managed automatic probe watches are currently alive.
-            </param>
-            <returns>
-                <see langword="true" /> when the automatic probe set should start.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
-            <summary>
-                Determines whether the automatic login-session gate should reset
-                because the player logged out.
-            </summary>
-            <param name="wasLoggedIn">
-                Whether the client was logged in on the previous tick.
-            </param>
-            <param name="isLoggedIn">Whether the client is logged in now.</param>
-            <returns>
-                <see langword="true" /> when the automatic probe gate should reset.
-            </returns>
-        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -34884,7 +34615,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -43143,109 +42874,6 @@
             <param name="maxDistance">The distance at which the overlay becomes hidden.</param>
             <param name="minScale">The minimum scale reached at the maximum distance.</param>
             <returns>The resolved distance-aware presentation state.</returns>
-        </member>
-        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics">
-            <summary>
-            Emits temporary, deduplicated diagnostics for texture-backed overlay render
-            passes while complex-script overlay regressions are under investigation.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureUnavailable(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,Echoglossian.UIOverlays.TextPresentation.TextureRenderAttemptOutcome,System.ValueTuple{System.Int32,System.Int64,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32})">
-            <summary>
-            Logs one texture-backed overlay render pass that did not reach a drawn
-            state because the backing texture was unavailable.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <param name="surfaceId">The overlay surface identifier.</param>
-            <param name="request">The active overlay render request.</param>
-            <param name="textRequest">The resolved text-layout request.</param>
-            <param name="outcome">The texture-render decision.</param>
-            <param name="stats">The current RTL texture backend stats.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureDrawn(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
-            <summary>
-            Logs one successful texture-backed overlay draw.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <param name="surfaceId">The overlay surface identifier.</param>
-            <param name="request">The active overlay render request.</param>
-            <param name="textRequest">The resolved text-layout request.</param>
-            <param name="renderedPosition">The actual rendered window position.</param>
-            <param name="renderedSize">The actual rendered window size.</param>
-            <param name="bodySize">The measured body-text size.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldLog(Echoglossian.Config)">
-            <summary>
-            Determines whether texture-overlay diagnostics should run for the current
-            language mode.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <returns><see langword="true" /> when diagnostics should log.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldEmit(System.String,System.String)">
-            <summary>
-            Determines whether a deduplicated diagnostic line should be emitted.
-            </summary>
-            <param name="key">The stable diagnostic event key.</param>
-            <param name="signature">The event-state signature.</param>
-            <returns><see langword="true" /> when the line should be emitted.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreviewKey(System.String)">
-            <summary>
-            Builds the preview key used for deduplication.
-            </summary>
-            <param name="text">The source text.</param>
-            <returns>The stable preview key.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreview(System.String)">
-            <summary>
-            Builds a short preview for diagnostic log lines.
-            </summary>
-            <param name="text">The source text.</param>
-            <returns>The shortened preview text.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundVector(System.Numerics.Vector2,System.Single)">
-            <summary>
-            Rounds a vector to a coarse step size for deduplication.
-            </summary>
-            <param name="value">The source vector.</param>
-            <param name="step">The coarse rounding step.</param>
-            <returns>The rounded vector.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundToStep(System.Single,System.Single)">
-            <summary>
-            Rounds a scalar to the requested step size.
-            </summary>
-            <param name="value">The source value.</param>
-            <param name="step">The rounding step.</param>
-            <returns>The rounded scalar.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.FormatVector(System.Numerics.Vector2)">
-            <summary>
-            Formats a vector for diagnostic log output.
-            </summary>
-            <param name="value">The vector value.</param>
-            <returns>The formatted vector.</returns>
-        </member>
-        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState">
-            <summary>
-            Captures the last emitted signature and time for one diagnostic key.
-            </summary>
-            <param name="Signature">The emitted diagnostic-state signature.</param>
-            <param name="EmittedAtUtc">The time the signature was emitted.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.#ctor(System.String,System.DateTime)">
-            <summary>
-            Captures the last emitted signature and time for one diagnostic key.
-            </summary>
-            <param name="Signature">The emitted diagnostic-state signature.</param>
-            <param name="EmittedAtUtc">The time the signature was emitted.</param>
-        </member>
-        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.Signature">
-            <summary>The emitted diagnostic-state signature.</summary>
-        </member>
-        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.EmittedAtUtc">
-            <summary>The time the signature was emitted.</summary>
         </member>
         <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay.RenderScale">
             <summary>


### PR DESCRIPTION
## Summary

- prepare release `v4.2601.0816.1235` from the current `v4-series` head after [#271](https://github.com/lokinmodar/Echoglossian/pull/271)
- ship the remaining dialogue LLM release follow-ups that are now in `v4-series`:
  - finish `#252` prompt save and async structured glossary refresh behavior
  - fix `#270` so dialogue-only LLM override changes and quest/map surface toggles rebuild the right runtime state
  - cancel in-flight live model discovery during plugin shutdown or reload
- update the tracked release metadata for the exact validated package version

## Validation

- [x] `dotnet build .\Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [ ] in-game verification was performed when runtime UI behavior changed
- [x] `dotnet build .\Echoglossian.csproj -c Release --no-restore`

## AI Usage Disclosure

- [x] `Assist` — human-led work with AI used for specific tasks
- [ ] `Pair` — active human/AI collaboration throughout
- [ ] `Copilot` — AI did most of the writing while the human planned and reviewed
- [ ] `Auto` — AI acted mostly autonomously with minimal human direction

```text
AI scope:
- tooling used: Codex for bounded release-prep editing, validation orchestration, and PR drafting
- files or areas most affected: Echoglossian.csproj, CHANGELOG.md, Echoglossian.xml
- how the result was reviewed/tested: exact version bump and changelog entry reviewed, local Debug build/tests run, local Release build run
```

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```