### PR TITLE
chore: prepare v4.2601.0829.2219 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This changelog is curated from two sources:
 
 It is intentionally high-signal rather than a verbatim dump of every commit.
 
+## Submitted Release `v4.2601.0829.2219`
+
+This package is prepared for submission after the `#274` Arabic RTL overlay
+investigation and fix. It keeps configured target-language identity consistent
+from translator request through overlay presentation, adds a deterministic
+Arabic Previewer regression gate with the bundled font path, and hardens
+startup engine-selection migration against stale global language state exposed
+by hosted validation.
+
+Highlights:
+
+- fixes `#274` by making `Config.Lang` plus the language dictionary
+  authoritative for target-language runtime synchronization across startup,
+  config refresh, and overlay presentation
+- makes `GTranslateTranslator` honor the per-call target-language argument and
+  removes the overlay's dependency on `SelectedLanguage.Code` for RTL backend
+  selection
+- adds a real Arabic raster test, deterministic Previewer scenario and sample
+  config, and a Mock-validated guard against constructor-time engine migration
+  reading stale global language state
+
 ## Published Release `v4.2601.0816.1235`
 
 This package was published to the official Dalamud feed after

--- a/Echoglossian.Previewer.Tests/Fonts/PreviewFontCatalogTests.cs
+++ b/Echoglossian.Previewer.Tests/Fonts/PreviewFontCatalogTests.cs
@@ -246,14 +246,29 @@ public sealed class PreviewFontCatalogTests
     [Fact]
     public void InitializePreviewLanguageRuntime_AppliesSupportAndPresentationFlags()
     {
+        var previousLanguageInt = global::Echoglossian.Echoglossian.LanguageInt;
+        var previousSelectedLanguage = global::Echoglossian.Echoglossian.SelectedLanguage;
+        var previousLanguages = global::Echoglossian.Echoglossian.LangDict;
         var configuration = new Config { Lang = 21 };
 
-        var (languages, selectedLanguage) = Program.InitializePreviewLanguageRuntime(configuration);
+        try
+        {
+            var (languages, selectedLanguage) = Program.InitializePreviewLanguageRuntime(configuration);
 
-        Assert.Same(languages[21], selectedLanguage);
-        Assert.Contains(2, selectedLanguage.SupportedEngines!);
-        Assert.True(configuration.OverlayOnlyLanguage);
-        Assert.False(configuration.UnsupportedLanguage);
+            Assert.Same(languages[21], selectedLanguage);
+            Assert.Same(languages, global::Echoglossian.Echoglossian.LangDict);
+            Assert.Equal(21, global::Echoglossian.Echoglossian.LanguageInt);
+            Assert.Same(selectedLanguage, global::Echoglossian.Echoglossian.SelectedLanguage);
+            Assert.Contains(2, selectedLanguage.SupportedEngines!);
+            Assert.True(configuration.OverlayOnlyLanguage);
+            Assert.False(configuration.UnsupportedLanguage);
+        }
+        finally
+        {
+            global::Echoglossian.Echoglossian.LanguageInt = previousLanguageInt;
+            global::Echoglossian.Echoglossian.SelectedLanguage = previousSelectedLanguage;
+            global::Echoglossian.Echoglossian.LangDict = previousLanguages;
+        }
     }
 
     /// <summary>

--- a/Echoglossian.Previewer.Tests/Scenarios/PreviewScenarioCatalogTests.cs
+++ b/Echoglossian.Previewer.Tests/Scenarios/PreviewScenarioCatalogTests.cs
@@ -16,10 +16,10 @@ namespace Echoglossian.Previewer.Tests.Scenarios;
 public sealed class PreviewScenarioCatalogTests
 {
     /// <summary>
-    /// Ensures every runtime overlay surface has exactly one default preview scenario.
+    /// Ensures every runtime overlay surface has at least one default preview scenario.
     /// </summary>
     [Fact]
-    public void Defaults_ContainsOneScenarioForEachRuntimeOverlaySurface()
+    public void Defaults_ContainsScenarioForEachRuntimeOverlaySurface()
     {
         var expectedSurfaces = new[]
         {
@@ -39,18 +39,33 @@ public sealed class PreviewScenarioCatalogTests
 
         var scenarios = PreviewScenarioCatalog.Defaults;
 
-        Assert.Equal(expectedSurfaces.Length, scenarios.Count);
         foreach (var surface in expectedSurfaces)
         {
-            var scenario = Assert.Single(
-                scenarios,
+            var scenario = scenarios.FirstOrDefault(
                 candidate => candidate.SurfaceId == surface);
+            Assert.NotNull(scenario);
             Assert.False(string.IsNullOrWhiteSpace(scenario.Key));
             Assert.True(scenario.Visible);
             Assert.False(string.IsNullOrWhiteSpace(scenario.TranslatedText));
             Assert.True(scenario.AddonBounds.Width > 0f);
             Assert.True(scenario.AddonBounds.Height > 0f);
         }
+    }
+
+    /// <summary>
+    /// Ensures the issue #274 Arabic Talk scenario remains available and uses
+    /// stable preview bounds.
+    /// </summary>
+    [Fact]
+    public void ResolveScenario_Issue274Arabic_ReturnsTalkScenarioWithArabicText()
+    {
+        var scenario = PreviewScenarioCatalog.ResolveScenario("talk-arabic-274");
+
+        Assert.Equal("talk-arabic-274", scenario.Key);
+        Assert.Equal(TranslationOverlaySurfaceId.Talk, scenario.SurfaceId);
+        Assert.Contains('أ', scenario.TranslatedText);
+        Assert.True(scenario.AddonBounds.Width > 0f);
+        Assert.True(scenario.AddonBounds.Height > 0f);
     }
 
     /// <summary>

--- a/Echoglossian.Previewer.Tests/Session/PreviewSessionLoaderTests.cs
+++ b/Echoglossian.Previewer.Tests/Session/PreviewSessionLoaderTests.cs
@@ -220,6 +220,38 @@ public sealed class PreviewSessionLoaderTests
     }
 
     /// <summary>
+    /// Ensures the tracked issue #274 preview sample loads the expected Arabic
+    /// overlay settings without modifying the source file.
+    /// </summary>
+    [Fact]
+    public void Load_Issue274ArabicSample_PreservesSourceAndExpectedSettings()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var samplePath = Path.Combine(
+            repositoryRoot.FullName,
+            "Echoglossian.Previewer",
+            "Samples",
+            "issue-274-arabic.json");
+        var originalSample = File.Exists(samplePath)
+            ? File.ReadAllText(samplePath)
+            : string.Empty;
+
+        using (var session = PreviewSessionLoader.Load(
+            new PreviewSessionSourceOptions(samplePath, null, null)))
+        {
+            Assert.Equal(2, session.EditableConfiguration.Lang);
+            Assert.True(session.EditableConfiguration.Translate);
+            Assert.True(session.EditableConfiguration.TranslateTalk);
+            Assert.Equal(
+                JournalTranslationDisplayMode.TooltipTranslation,
+                session.EditableConfiguration.TalkTranslationDisplayMode);
+            Assert.Equal(originalSample, File.ReadAllText(samplePath));
+        }
+
+        Assert.Equal(originalSample, File.ReadAllText(samplePath));
+    }
+
+    /// <summary>
     /// Creates a WAL-mode database with a committed row that remains outside the main database file.
     /// </summary>
     /// <param name="databasePath">The SQLite database file to create.</param>
@@ -259,5 +291,27 @@ public sealed class PreviewSessionLoaderTests
         using var command = connection.CreateCommand();
         command.CommandText = "SELECT Value FROM SessionData LIMIT 1;";
         return command.ExecuteScalar() as string;
+    }
+
+    /// <summary>
+    /// Finds the repository root from the current test output directory.
+    /// </summary>
+    /// <returns>The absolute repository root path.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Echoglossian.sln")))
+            {
+                return directory;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the Echoglossian repository root.");
     }
 }

--- a/Echoglossian.Previewer/Program.cs
+++ b/Echoglossian.Previewer/Program.cs
@@ -570,8 +570,9 @@ internal static class Program
         ArgumentNullException.ThrowIfNull(configuration);
         var languages = Echoglossian.CreateLanguagesDictionary();
         LanguageEngineSupport.ApplySupportTo(languages);
-        var selectedLanguage = NormalizePreviewLanguage(languages, configuration);
-        LanguagePresentationPolicy.ApplyLanguageFlags(configuration);
+        var selectedLanguage = global::Echoglossian.TargetLanguageRuntimeState.Synchronize(
+            configuration,
+            languages);
         return (languages, selectedLanguage);
     }
 

--- a/Echoglossian.Previewer/README.md
+++ b/Echoglossian.Previewer/README.md
@@ -117,8 +117,8 @@ windows only; overlay preview remains on the existing standalone pipeline.
 
 Registered Phase A scenario keys are `talk`, `battle-talk`, `talk-subtitle`,
 `mini-talk`, `cutscene-select-string`, `text-gimmick-hint`, `wide-text-toast`,
-`error-toast`, `area-toast`, `class-change-toast`, `quest-toast`, and
-`chat-bubble`.
+`error-toast`, `area-toast`, `class-change-toast`, `quest-toast`,
+`chat-bubble`, and `talk-arabic-274`.
 
 Built-in viewport presets are `1280x720`, `1920x1080`, `2560x1440`, and
 `3440x1440`; arbitrary positive `widthxheight` values are also accepted.
@@ -151,6 +151,7 @@ dotnet run --project Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Deb
 dotnet run --project Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-build -- --screenshot surface --scenario talk --viewport 1920x1080 --output artifacts\previewer\screenshots\surface
 dotnet run --project Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-build -- --screenshot batch --viewport 1920x1080 --output artifacts\previewer\screenshots\batch
 dotnet run --project Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-build -- --screenshot full --capture-target config-window --scenario talk --viewport 1920x1080 --output artifacts\previewer\screenshots\config-window
+dotnet run --project .\Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-build -- --config .\Echoglossian.Previewer\Samples\issue-274-arabic.json --scenario talk-arabic-274 --viewport 1920x1080 --screenshot surface --output .\artifacts\previewer\issue-274
 ```
 
 Batch mode with a single viewport writes 12 overlay PNG files plus

--- a/Echoglossian.Previewer/Samples/issue-274-arabic.json
+++ b/Echoglossian.Previewer/Samples/issue-274-arabic.json
@@ -1,0 +1,6 @@
+{
+  "Lang": 2,
+  "Translate": true,
+  "TranslateTalk": true,
+  "TalkTranslationDisplayMode": 1
+}

--- a/Echoglossian.Previewer/Scenarios/PreviewScenarioCatalog.cs
+++ b/Echoglossian.Previewer/Scenarios/PreviewScenarioCatalog.cs
@@ -29,6 +29,7 @@ internal static class PreviewScenarioCatalog
     internal static IReadOnlyList<PreviewScenario> Defaults { get; } =
     [
         Create("talk", "Talk", TranslationOverlaySurfaceId.Talk, 440, 690, 1040, 240, "The road opens before us. Keep your eyes on the horizon.", "Alphinaud"),
+        Create("talk-arabic-274", "Talk Arabic #274", TranslationOverlaySurfaceId.Talk, 440, 690, 1040, 240, "أعتذر، ولكن أخشى أنني يجب أن أبعدك في الوقت الحالي. يرجى العودة في وقت لاحق.", "Alisaie"),
         Create("battle-talk", "Battle Talk", TranslationOverlaySurfaceId.BattleTalk, 360, 620, 1200, 210, "Steel yourself. The next strike will decide the field.", "Thancred"),
         Create("talk-subtitle", "Talk Subtitle", TranslationOverlaySurfaceId.TalkSubtitle, 300, 780, 1320, 120, "A gentle wind carries the sound of distant bells.", null),
         Create("mini-talk", "Mini Talk", TranslationOverlaySurfaceId.MiniTalk, 1260, 180, 420, 150, "This device is older than it looks.", "Y'shtola"),

--- a/Echoglossian.Tests/GTranslateTranslatorTargetLanguageTests.cs
+++ b/Echoglossian.Tests/GTranslateTranslatorTargetLanguageTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="GTranslateTranslatorTargetLanguageTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.LanguagesHandling;
+using Echoglossian.Translators;
+
+using GTranslate;
+
+using Xunit;
+
+using PluginEntry = Echoglossian.Echoglossian;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+/// Covers target-language resolution at the GTranslate provider boundary.
+/// </summary>
+public sealed class GTranslateTranslatorTargetLanguageTests
+{
+    /// <summary>
+    /// Ensures provider target resolution uses the requested method argument
+    /// instead of the mutable global selected language.
+    /// </summary>
+    /// <param name="requestedTargetLanguage">The requested target language code.</param>
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ar")]
+    [InlineData("fa")]
+    [InlineData("ur")]
+    public void ResolveRequestedTargetLanguage_UsesMethodArgumentNotSelectedGlobal(
+        string requestedTargetLanguage)
+    {
+        var previousSelectedLanguage = PluginEntry.SelectedLanguage;
+
+        try
+        {
+            PluginEntry.SelectedLanguage = new LanguageInfo(
+                "ar",
+                "Arabic",
+                "NotoSansArabic-Medium.ttf",
+                string.Empty,
+                []);
+
+            var resolved =
+                GTranslateTranslator.ResolveRequestedTargetLanguage(
+                    requestedTargetLanguage);
+
+            Assert.Equal(
+                Language.GetLanguage(requestedTargetLanguage).Name,
+                resolved.Name);
+        }
+        finally
+        {
+            PluginEntry.SelectedLanguage = previousSelectedLanguage;
+        }
+    }
+
+    /// <summary>
+    /// Ensures empty or whitespace requests fail before any provider call is attempted.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ResolveRequestedTargetLanguage_EmptyCode_ThrowsArgumentException(
+        string requestedTargetLanguage)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            GTranslateTranslator.ResolveRequestedTargetLanguage(
+                requestedTargetLanguage));
+    }
+}

--- a/Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs
+++ b/Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs
@@ -77,6 +77,35 @@ public sealed class RuntimeConfigurationRefreshContractTests
     }
 
     /// <summary>
+    /// Ensures live configuration refresh synchronizes the authoritative
+    /// target-language runtime state before translation signatures and
+    /// translator rebuilds are evaluated.
+    /// </summary>
+    [Fact]
+    public void Translation_refresh_synchronizes_target_language_before_signature_and_rebuild()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "GeneralHelpers",
+            "RuntimeConfigurationRefresh.cs"));
+
+        var synchronizeCall = source.IndexOf(
+            "TargetLanguageRuntimeState.Synchronize(",
+            StringComparison.Ordinal);
+        var signatureCall = source.IndexOf(
+            "this.ComputeTranslationRuntimeSignature();",
+            StringComparison.Ordinal);
+        var rebuildCall = source.IndexOf(
+            "this.RebuildTranslationServiceSafely();",
+            StringComparison.Ordinal);
+
+        Assert.True(synchronizeCall >= 0);
+        Assert.True(signatureCall > synchronizeCall);
+        Assert.True(rebuildCall > synchronizeCall);
+    }
+
+    /// <summary>
     ///     Ensures a live translator rebuild also recreates the NamePlate
     ///     runtime so it cannot keep using a stale captured
     ///     <c>TranslationService</c> instance after language or provider

--- a/Echoglossian.Tests/TargetLanguageRuntimeStateTests.cs
+++ b/Echoglossian.Tests/TargetLanguageRuntimeStateTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="TargetLanguageRuntimeStateTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.LanguagesHandling;
+
+using Xunit;
+
+using PluginEntry = Echoglossian.Echoglossian;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+/// Covers synchronization of runtime target-language state derived from the
+/// persisted configuration language.
+/// </summary>
+public sealed class TargetLanguageRuntimeStateTests
+{
+    /// <summary>
+    /// Ensures Arabic configuration repairs stale runtime mirrors and applies
+    /// the current overlay presentation flags.
+    /// </summary>
+    [Fact]
+    public void Synchronize_ArabicConfiguration_RepairsStaleLegacyMirrors()
+    {
+        var previousLanguageInt = PluginEntry.LanguageInt;
+        var previousSelectedLanguage = PluginEntry.SelectedLanguage;
+        var previousLanguages = PluginEntry.LangDict;
+
+        try
+        {
+            var languages = PluginEntry.CreateLanguagesDictionary();
+            var configuration = new Config { Lang = 2 };
+            PluginEntry.LanguageInt = 28;
+            PluginEntry.SelectedLanguage = languages[28];
+
+            var selected = TargetLanguageRuntimeState.Synchronize(
+                configuration,
+                languages);
+
+            Assert.Same(languages[2], selected);
+            Assert.Equal(2, PluginEntry.LanguageInt);
+            Assert.Same(languages[2], PluginEntry.SelectedLanguage);
+            Assert.Same(languages, PluginEntry.LangDict);
+            Assert.True(configuration.OverlayOnlyLanguage);
+            Assert.False(configuration.UnsupportedLanguage);
+        }
+        finally
+        {
+            PluginEntry.LanguageInt = previousLanguageInt;
+            PluginEntry.SelectedLanguage = previousSelectedLanguage;
+            PluginEntry.LangDict = previousLanguages;
+        }
+    }
+
+    /// <summary>
+    /// Ensures an unknown language identifier fails before mutating any legacy
+    /// runtime mirrors.
+    /// </summary>
+    [Fact]
+    public void Synchronize_UnknownLanguage_DoesNotPartiallyMutateLegacyMirrors()
+    {
+        var previousLanguageInt = PluginEntry.LanguageInt;
+        var previousSelectedLanguage = PluginEntry.SelectedLanguage;
+        var previousLanguages = PluginEntry.LangDict;
+
+        try
+        {
+            var languages = PluginEntry.CreateLanguagesDictionary();
+            var configuration = new Config { Lang = 999 };
+            PluginEntry.LanguageInt = 28;
+            PluginEntry.SelectedLanguage = languages[28];
+            PluginEntry.LangDict = languages;
+
+            Assert.Throws<KeyNotFoundException>(() =>
+                TargetLanguageRuntimeState.Synchronize(
+                    configuration,
+                    languages));
+
+            Assert.Equal(28, PluginEntry.LanguageInt);
+            Assert.Same(languages[28], PluginEntry.SelectedLanguage);
+            Assert.Same(languages, PluginEntry.LangDict);
+            Assert.False(configuration.OverlayOnlyLanguage);
+            Assert.False(configuration.UnsupportedLanguage);
+        }
+        finally
+        {
+            PluginEntry.LanguageInt = previousLanguageInt;
+            PluginEntry.SelectedLanguage = previousSelectedLanguage;
+            PluginEntry.LangDict = previousLanguages;
+        }
+    }
+}

--- a/Echoglossian.Tests/TextImageRendererTests.cs
+++ b/Echoglossian.Tests/TextImageRendererTests.cs
@@ -17,6 +17,38 @@ namespace Echoglossian.Tests;
 public class TextImageRendererTests
 {
     /// <summary>
+    /// Ensures the bundled Arabic font renders the issue #274 sentence with
+    /// visible pixels without falling back to a system font.
+    /// </summary>
+    [Fact]
+    public void RenderShapedText_Issue274Arabic_UsesBundledFontAndDrawsPixels()
+    {
+        var fontPath = Path.Combine(
+            FindRepositoryRoot().FullName,
+            "Font",
+            "NotoSansArabic-Medium.ttf");
+        const string text =
+            "أعتذر، ولكن أخشى أنني يجب أن أبعدك في الوقت الحالي. " +
+            "يرجى العودة في وقت لاحق.";
+
+        using var renderer = new TextImageRenderer(
+            fontPath,
+            24f,
+            FontStyle.Regular,
+            1f);
+        using var bitmap = renderer.RenderShapedText(
+            text,
+            Color.White,
+            Color.Transparent,
+            480);
+
+        Assert.False(renderer.FallbackFontUsed);
+        Assert.InRange(bitmap.Width, 1, 2048);
+        Assert.InRange(bitmap.Height, 1, 2048);
+        Assert.True(ContainsVisiblePixel(bitmap));
+    }
+
+    /// <summary>
     /// Ensures texture-backed LTR text uses normal direction and near
     /// alignment instead of inheriting the RTL rasterization format.
     /// </summary>
@@ -168,5 +200,46 @@ public class TextImageRendererTests
 
         Assert.InRange(bitmap.Width, 1, 2048);
         Assert.InRange(bitmap.Height, 1, 2048);
+    }
+
+    /// <summary>
+    /// Finds the repository root from the current test output directory.
+    /// </summary>
+    /// <returns>The repository root directory.</returns>
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Echoglossian.sln")))
+            {
+                return current;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    /// <summary>
+    /// Determines whether a bitmap contains at least one visible pixel.
+    /// </summary>
+    /// <param name="bitmap">The bitmap to scan.</param>
+    /// <returns><see langword="true" /> when a visible pixel exists.</returns>
+    private static bool ContainsVisiblePixel(Bitmap bitmap)
+    {
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y).A > 0)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/Echoglossian.Tests/TextPresentationResolverTests.cs
+++ b/Echoglossian.Tests/TextPresentationResolverTests.cs
@@ -18,6 +18,38 @@ namespace Echoglossian.Tests;
 public class TextPresentationResolverTests
 {
     /// <summary>
+    /// Ensures consistent configured language identifiers and codes resolve to
+    /// the expected presentation backend.
+    /// </summary>
+    /// <param name="languageId">The configured target-language identifier.</param>
+    /// <param name="languageCode">The configured target-language code.</param>
+    /// <param name="expectedBackend">The expected presentation backend name.</param>
+    [Theory]
+    [InlineData(2, "ar", "RtlTexture")]
+    [InlineData(28, "en", "PlainImGui")]
+    public void Resolve_ConsistentConfiguredLanguageMetadata_UsesExpectedBackend(
+        int languageId,
+        string languageCode,
+        string expectedBackend)
+    {
+        var request = new TextLayoutRequest(
+            "Hello world",
+            languageId,
+            languageCode,
+            400f,
+            1.0f,
+            false,
+            Vector4.One,
+            new Vector4(0f, 0f, 0f, 0f),
+            TranslationOverlaySurfaceId.Talk,
+            false);
+
+        Assert.Equal(
+            expectedBackend,
+            TextPresentationResolver.ResolveBackendKind(request).ToString());
+    }
+
+    /// <summary>
     /// Ensures plain LTR requests keep using the plain ImGui backend.
     /// </summary>
     [Fact]

--- a/Echoglossian.Tests/TranslationEngineSelectionContractTests.cs
+++ b/Echoglossian.Tests/TranslationEngineSelectionContractTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="TranslationEngineSelectionContractTests.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Xunit;
+
+namespace Echoglossian.Tests;
+
+/// <summary>
+/// Guards source-level startup contracts around translation-engine migration.
+/// </summary>
+public sealed class TranslationEngineSelectionContractTests
+{
+    /// <summary>
+    /// Ensures startup translation-engine migration reads the plugin-owned
+    /// language dictionary instead of the static global mirror so it remains
+    /// safe before target-language synchronization runs.
+    /// </summary>
+    [Fact]
+    public void MigrateTranslationEngineSelection_UsesInstanceLanguageDictionary()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "GeneralHelpers",
+            "Utils.cs"));
+        var methodBody = ExtractMethodBody(
+            source,
+            "public void MigrateTranslationEngineSelection(int loadedConfigVersion)");
+
+        Assert.Contains(
+            "this.languagesDictionary.TryGetValue(this.configuration.Lang, out var language)",
+            methodBody,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "LangDict.TryGetValue(this.configuration.Lang, out var language)",
+            methodBody,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Finds the repository root from the current test output directory.
+    /// </summary>
+    /// <returns>The absolute repository-root path.</returns>
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Echoglossian.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the Echoglossian repository root.");
+    }
+
+    /// <summary>
+    /// Extracts one method body, including braces, from a source file.
+    /// </summary>
+    /// <param name="source">The source file text.</param>
+    /// <param name="signature">The method signature to locate.</param>
+    /// <returns>The extracted method body.</returns>
+    private static string ExtractMethodBody(string source, string signature)
+    {
+        var signatureIndex = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(signatureIndex >= 0, $"Could not find method signature: {signature}");
+
+        var bodyStart = source.IndexOf('{', signatureIndex);
+        Assert.True(bodyStart >= 0, $"Could not find body start for: {signature}");
+
+        var depth = 0;
+        for (var index = bodyStart; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(bodyStart, (index - bodyStart) + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find body end for: {signature}");
+    }
+}

--- a/Echoglossian.Tests/TranslationOverlayRendererContractTests.cs
+++ b/Echoglossian.Tests/TranslationOverlayRendererContractTests.cs
@@ -72,6 +72,30 @@ public sealed class TranslationOverlayRendererContractTests
     }
 
     /// <summary>
+    /// Ensures overlay text-layout requests derive both target-language
+    /// metadata values from the configured language instead of mixing config
+    /// identifiers with the mutable global selected-language code.
+    /// </summary>
+    [Fact]
+    public void Draw_UsesConfiguredTargetLanguageCodeForTextLayoutRequest()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            this.RepositoryRoot,
+            "UIOverlays",
+            "TranslationOverlay",
+            "TranslationOverlayRenderer.cs"));
+
+        Assert.Contains(
+            "RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(this.configuration.Lang)",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "SelectedLanguage.Code",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Gets the repository root discovered from the test output directory.
     /// </summary>
     private string RepositoryRoot => FindRepositoryRoot();

--- a/Echoglossian.cs
+++ b/Echoglossian.cs
@@ -253,9 +253,7 @@ public partial class Echoglossian : IDalamudPlugin
 
     Sanitizer = PluginInterface.Sanitizer as Sanitizer;
 
-    LangDict = this.languagesDictionary;
-
-    LanguageEngineSupport.ApplySupportTo(LangDict);
+    LanguageEngineSupport.ApplySupportTo(this.languagesDictionary);
 
     try
     {
@@ -315,19 +313,20 @@ public partial class Echoglossian : IDalamudPlugin
 
     this.EnsureConfigDefaultsPersistedForMissingKeys();
 
-    SelectedLanguage = this.languagesDictionary[this.configuration.Lang];
     var languagePolicyChanged =
         this.configuration.UnsupportedLanguage !=
         LanguagePresentationPolicy.IsUnsupportedLanguage(this.configuration.Lang) ||
         this.configuration.OverlayOnlyLanguage !=
         LanguagePresentationPolicy.RequiresOverlayOnly(this.configuration.Lang);
-    LanguagePresentationPolicy.ApplyLanguageFlags(this.configuration);
+    var selectedLanguage = TargetLanguageRuntimeState.Synchronize(
+        this.configuration,
+        this.languagesDictionary);
     if (languagePolicyChanged)
     {
       SaveConfig(this.configuration);
     }
 
-    AssetsManager.RefreshPluginAssetsState(SelectedLanguage);
+    AssetsManager.RefreshPluginAssetsState(selectedLanguage);
     this.configuration.PluginAssetsDownloaded = AssetsManager.PluginAssetsDownloaded;
 
     this.pluginAssetsState = this.configuration.PluginAssetsDownloaded;
@@ -337,9 +336,9 @@ public partial class Echoglossian : IDalamudPlugin
     PluginRuntimeLog.Debug($"Assets state var: {this.pluginAssetsState}");
 
     if (!this.pluginAssetsState &&
-        AssetsManager.RequiresDownloadedAssets(SelectedLanguage))
+        AssetsManager.RequiresDownloadedAssets(selectedLanguage))
     {
-      AssetsManager.PluginAssetsChecker(SelectedLanguage);
+      AssetsManager.PluginAssetsChecker(selectedLanguage);
     }
 
     this.EnforceTranslationActivationConstraints();
@@ -366,11 +365,9 @@ public partial class Echoglossian : IDalamudPlugin
         loadedConfigVersion,
         currentConfigVersion);
 
-    LanguageInt = this.configuration.Lang;
-
     fontSize = this.configuration.FontSize;
 
-    this.LangToTranslateTo = LangDict[LanguageInt].Code;
+    this.LangToTranslateTo = selectedLanguage.Code;
 
     MountFontPaths();
 

--- a/Echoglossian.csproj
+++ b/Echoglossian.csproj
@@ -20,8 +20,8 @@
     <VersionSeries Condition="'$(VersionSeries)' == ''">01</VersionSeries>
     <VersionMinor>$(VersionYear)$(VersionSeries)</VersionMinor>
     <!-- Release pattern: 4.yy01.mmdd.HHmm. Keep year, patch, and revision manual so release numbering only changes when explicitly updated. -->
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0816</VersionPatch>
-    <VersionRevision Condition="'$(VersionRevision)' == ''">1235</VersionRevision>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">0829</VersionPatch>
+    <VersionRevision Condition="'$(VersionRevision)' == ''">2219</VersionRevision>
     <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -3013,10 +3013,6 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
-                Hosts debug-only automatic addon-probe watches that start on login for
-                selected addons with early hidden-state value.
-            </summary>
-            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
             </summary>
@@ -3026,11 +3022,6 @@
             </summary>
             <summary>
                 Handles bootstrap and teardown for the NamePlateGui translation runtime.
-            </summary>
-            <summary>
-                Handles the quest probe command used to inspect the complete quest data
-                shape from Lumina, the live quest progress resolver, and the current
-                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -3048,9 +3039,6 @@
             <summary>
                 Handles bootstrap and teardown for the alternate callback-owned
                 ToastGui route that owns supported normal and error toasts.
-            </summary>
-            <summary>
-            Handles the temporary tooltip-registration diagnostic command.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -3965,11 +3953,6 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
-        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
-            <summary>
-            Holds the currently active addon structure probe watch, if any.
-            </summary>
-        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -4158,11 +4141,6 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
-            <summary>
-                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -6189,109 +6167,6 @@
             <param name="cancellationToken">The handler-owned cancellation token.</param>
             <returns>The resolved hints for the current dialogue request.</returns>
         </member>
-        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
-            <summary>
-                Ticks manual and automatic addon-probe watches, including the
-                debug-only login bootstrap for the default watch set.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
-            <summary>
-                Gets how many addon-probe watches are currently active across manual
-                and managed watch sets.
-            </summary>
-            <returns>The active probe-watch count.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
-            <summary>
-                Stops every active addon-probe watch known to the plugin.
-            </summary>
-            <param name="suppressAutoUntilLogout">
-                Whether the current login session should suppress the default
-                automatic watch set after the stop completes.
-            </param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
-            <summary>
-                Ticks the currently active manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
-            <summary>
-                Ticks every managed addon-probe watch and prunes the disposed ones.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic addon-probe watch set when the player
-                logs in, then resets the gate on logout.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
-            <summary>
-                Starts the default automatic watch set used to capture early
-                structural state for pooled dialogue addons.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
-            <summary>
-                Starts one managed addon-probe watch and tracks it for later stop or
-                pruning.
-            </summary>
-            <param name="addonName">The addon name to watch.</param>
-            <param name="index">The addon instance index.</param>
-            <param name="duration">How long the watch should stay alive.</param>
-            <param name="reason">The debug log reason attached to the startup.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
-            <summary>
-                Stops the current manual addon-probe watch, if any.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
-            <summary>
-                Stops every managed automatic addon-probe watch.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
-            <summary>
-            Dumps a recursive probe of the requested addon to the log so we can
-            inspect its live node tree, component roots, and likely overlay anchors.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
-            <summary>
-            Parses the addon probe command arguments into an addon name, optional index,
-            and optional watch duration.
-            </summary>
-            <param name="args">The raw command arguments.</param>
-            <returns>The addon name, index, and duration to probe.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
-            <summary>
-            Parses one addon-probe duration token such as "90s" or "15m".
-            </summary>
-            <param name="token">The raw duration token.</param>
-            <param name="duration">Receives the parsed duration.</param>
-            <returns><see langword="true"/> when the token parsed successfully.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
-            <summary>
-            Determines whether a token looks like an addon-probe duration even when the
-            value is outside the accepted range.
-            </summary>
-            <param name="token">The token to inspect.</param>
-            <returns><see langword="true"/> when the token resembles a duration.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
-            <summary>
-            Formats one addon-probe watch duration for chat feedback.
-            </summary>
-            <param name="duration">The duration to format.</param>
-            <returns>The human-readable duration string.</returns>
-        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -6739,102 +6614,6 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
-            <summary>
-                Handles the quest probe command.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
-            <summary>
-                Tries to resolve the quest probe target from either a quest id or a
-                quest name.
-            </summary>
-            <param name="input">The command argument.</param>
-            <param name="questIdText">The resolved quest id as text.</param>
-            <param name="questName">The resolved quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>True when the quest could be resolved.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the quest data structure for inspection.
-            </summary>
-            <param name="questIdText">The quest id as text.</param>
-            <param name="questName">The quest name.</param>
-            <param name="questRow">The resolved Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs the raw Lumina quest row properties.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Logs all rows from the quest text sheet, not just the live todo
-                entries, so we can inspect the full structure of the quest sheet.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
-            <summary>
-                Logs the QuestPlate rows currently stored for the quest.
-            </summary>
-            <param name="questIdText">The quest id text.</param>
-            <param name="questName">The quest name.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
-            <summary>
-                Logs the resolved live quest progression snapshot.
-            </summary>
-            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves a human-readable quest name from a quest row.
-            </summary>
-            <param name="questRow">The quest row.</param>
-            <returns>The resolved quest name, if available.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
-            <summary>
-                Converts quest text to a readable string for probe output.
-            </summary>
-            <param name="text">The quest text.</param>
-            <returns>The evaluated text string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
-            <summary>
-                Formats a probe value for log output.
-            </summary>
-            <param name="value">The value to format.</param>
-            <returns>A human-readable value string.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Builds the raw quest sheet name used by the game files.
-            </summary>
-            <param name="questRow">The resolved Lumina quest row.</param>
-            <returns>The quest text sheet name, if it can be derived.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest row id as text through reflection so the probe
-                stays compatible with generated sheet shapes.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest row id as text, or an empty string if unavailable.</returns>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
-            <summary>
-                Resolves the quest sheet identifier used to mount the quest text
-                sheet path.
-            </summary>
-            <param name="questRow">The Lumina quest row.</param>
-            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -7675,14 +7454,6 @@
                 Unregisters the alternate supported-toast runtime from Dalamud's
                 normal and error-toast callbacks.
             </summary>
-        </member>
-        <member name="M:Echoglossian.Echoglossian.OnEgloTooltipRegisterLoggingCommand(System.String,System.String)">
-            <summary>
-            Starts or stops temporary logging for hover-tooltip registrations and
-            hover-hit transitions.
-            </summary>
-            <param name="command">Command name.</param>
-            <param name="args">Command arguments.</param>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
             <summary>
@@ -28213,46 +27984,6 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
-        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
-            <summary>
-                Encapsulates the login-session gating rules for debug-only automatic
-                addon-probe watches.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
-            <summary>
-                Determines whether the current login session should start the default
-                automatic addon-probe watch set.
-            </summary>
-            <param name="isLoggedIn">Whether the client is currently logged in.</param>
-            <param name="hasStartedForCurrentLogin">
-                Whether the current login session already started its automatic probe
-                set.
-            </param>
-            <param name="isSuppressedUntilLogout">
-                Whether the user explicitly suppressed the automatic probe set until
-                the next logout.
-            </param>
-            <param name="activeManagedWatchCount">
-                How many managed automatic probe watches are currently alive.
-            </param>
-            <returns>
-                <see langword="true" /> when the automatic probe set should start.
-            </returns>
-        </member>
-        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
-            <summary>
-                Determines whether the automatic login-session gate should reset
-                because the player logged out.
-            </summary>
-            <param name="wasLoggedIn">
-                Whether the client was logged in on the previous tick.
-            </param>
-            <param name="isLoggedIn">Whether the client is logged in now.</param>
-            <returns>
-                <see langword="true" /> when the automatic probe gate should reset.
-            </returns>
-        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -34903,7 +34634,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -43170,109 +42901,6 @@
             <param name="maxDistance">The distance at which the overlay becomes hidden.</param>
             <param name="minScale">The minimum scale reached at the maximum distance.</param>
             <returns>The resolved distance-aware presentation state.</returns>
-        </member>
-        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics">
-            <summary>
-            Emits temporary, deduplicated diagnostics for texture-backed overlay render
-            passes while complex-script overlay regressions are under investigation.
-            </summary>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureUnavailable(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,Echoglossian.UIOverlays.TextPresentation.TextureRenderAttemptOutcome,System.ValueTuple{System.Int32,System.Int64,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32})">
-            <summary>
-            Logs one texture-backed overlay render pass that did not reach a drawn
-            state because the backing texture was unavailable.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <param name="surfaceId">The overlay surface identifier.</param>
-            <param name="request">The active overlay render request.</param>
-            <param name="textRequest">The resolved text-layout request.</param>
-            <param name="outcome">The texture-render decision.</param>
-            <param name="stats">The current RTL texture backend stats.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureDrawn(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
-            <summary>
-            Logs one successful texture-backed overlay draw.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <param name="surfaceId">The overlay surface identifier.</param>
-            <param name="request">The active overlay render request.</param>
-            <param name="textRequest">The resolved text-layout request.</param>
-            <param name="renderedPosition">The actual rendered window position.</param>
-            <param name="renderedSize">The actual rendered window size.</param>
-            <param name="bodySize">The measured body-text size.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldLog(Echoglossian.Config)">
-            <summary>
-            Determines whether texture-overlay diagnostics should run for the current
-            language mode.
-            </summary>
-            <param name="configuration">The active plugin configuration.</param>
-            <returns><see langword="true" /> when diagnostics should log.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldEmit(System.String,System.String)">
-            <summary>
-            Determines whether a deduplicated diagnostic line should be emitted.
-            </summary>
-            <param name="key">The stable diagnostic event key.</param>
-            <param name="signature">The event-state signature.</param>
-            <returns><see langword="true" /> when the line should be emitted.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreviewKey(System.String)">
-            <summary>
-            Builds the preview key used for deduplication.
-            </summary>
-            <param name="text">The source text.</param>
-            <returns>The stable preview key.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreview(System.String)">
-            <summary>
-            Builds a short preview for diagnostic log lines.
-            </summary>
-            <param name="text">The source text.</param>
-            <returns>The shortened preview text.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundVector(System.Numerics.Vector2,System.Single)">
-            <summary>
-            Rounds a vector to a coarse step size for deduplication.
-            </summary>
-            <param name="value">The source vector.</param>
-            <param name="step">The coarse rounding step.</param>
-            <returns>The rounded vector.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundToStep(System.Single,System.Single)">
-            <summary>
-            Rounds a scalar to the requested step size.
-            </summary>
-            <param name="value">The source value.</param>
-            <param name="step">The rounding step.</param>
-            <returns>The rounded scalar.</returns>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.FormatVector(System.Numerics.Vector2)">
-            <summary>
-            Formats a vector for diagnostic log output.
-            </summary>
-            <param name="value">The vector value.</param>
-            <returns>The formatted vector.</returns>
-        </member>
-        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState">
-            <summary>
-            Captures the last emitted signature and time for one diagnostic key.
-            </summary>
-            <param name="Signature">The emitted diagnostic-state signature.</param>
-            <param name="EmittedAtUtc">The time the signature was emitted.</param>
-        </member>
-        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.#ctor(System.String,System.DateTime)">
-            <summary>
-            Captures the last emitted signature and time for one diagnostic key.
-            </summary>
-            <param name="Signature">The emitted diagnostic-state signature.</param>
-            <param name="EmittedAtUtc">The time the signature was emitted.</param>
-        </member>
-        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.Signature">
-            <summary>The emitted diagnostic-state signature.</summary>
-        </member>
-        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.EmittedAtUtc">
-            <summary>The time the signature was emitted.</summary>
         </member>
         <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay.RenderScale">
             <summary>

--- a/Echoglossian.xml
+++ b/Echoglossian.xml
@@ -3013,6 +3013,10 @@
                 ItemDetail addons, including trait-aware ActionDetail handling.
             </summary>
             <summary>
+                Hosts debug-only automatic addon-probe watches that start on login for
+                selected addons with early hidden-state value.
+            </summary>
+            <summary>
                 Provides DB-first background prefetch for canonical ItemDetail
                 payloads.
             </summary>
@@ -3022,6 +3026,11 @@
             </summary>
             <summary>
                 Handles bootstrap and teardown for the NamePlateGui translation runtime.
+            </summary>
+            <summary>
+                Handles the quest probe command used to inspect the complete quest data
+                shape from Lumina, the live quest progress resolver, and the current
+                QuestPlate database rows.
             </summary>
             <summary>
                 Handles bootstrap and teardown of the quest-toast runtime that hangs off
@@ -3039,6 +3048,9 @@
             <summary>
                 Handles bootstrap and teardown for the alternate callback-owned
                 ToastGui route that owns supported normal and error toasts.
+            </summary>
+            <summary>
+            Handles the temporary tooltip-registration diagnostic command.
             </summary>
             <summary>
                 Provides DB-first background prefetch for canonical trait payloads.
@@ -3953,6 +3965,11 @@
             Holds the translator debugger and metrics window instance.
             </summary>
         </member>
+        <member name="F:Echoglossian.Echoglossian.addonProbeWatch">
+            <summary>
+            Holds the currently active addon structure probe watch, if any.
+            </summary>
+        </member>
         <member name="F:Echoglossian.Echoglossian.Sanitizer">
             <summary>
             Holds the sanitizer instance for cleaning up text input.
@@ -4141,6 +4158,11 @@
         <member name="F:Echoglossian.Echoglossian.NumericLikePattern">
             <summary>
                 Regex used to help filtering out numeric-like strings.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ListCultureInfos">
+            <summary>
+                Lists all available culture information and writes it to a file.
             </summary>
         </member>
         <member name="M:Echoglossian.Echoglossian.MovePathUp(System.String,System.Int32)">
@@ -6167,6 +6189,109 @@
             <param name="cancellationToken">The handler-owned cancellation token.</param>
             <returns>The resolved hints for the current dialogue request.</returns>
         </member>
+        <member name="M:Echoglossian.Echoglossian.TickAddonProbeInfrastructure">
+            <summary>
+                Ticks manual and automatic addon-probe watches, including the
+                debug-only login bootstrap for the default watch set.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetActiveAddonProbeWatchCount">
+            <summary>
+                Gets how many addon-probe watches are currently active across manual
+                and managed watch sets.
+            </summary>
+            <returns>The active probe-watch count.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopAllAddonProbeWatches(System.Boolean)">
+            <summary>
+                Stops every active addon-probe watch known to the plugin.
+            </summary>
+            <param name="suppressAutoUntilLogout">
+                Whether the current login session should suppress the default
+                automatic watch set after the stop completes.
+            </param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManualAddonProbeWatch">
+            <summary>
+                Ticks the currently active manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickManagedAddonProbeWatches">
+            <summary>
+                Ticks every managed addon-probe watch and prunes the disposed ones.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TickAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic addon-probe watch set when the player
+                logs in, then resets the gate on logout.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartDefaultAutoAddonProbeWatches">
+            <summary>
+                Starts the default automatic watch set used to capture early
+                structural state for pooled dialogue addons.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StartManagedAddonProbeWatch(System.String,System.Int32,System.TimeSpan,System.String)">
+            <summary>
+                Starts one managed addon-probe watch and tracks it for later stop or
+                pruning.
+            </summary>
+            <param name="addonName">The addon name to watch.</param>
+            <param name="index">The addon instance index.</param>
+            <param name="duration">How long the watch should stay alive.</param>
+            <param name="reason">The debug log reason attached to the startup.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManualAddonProbeWatch">
+            <summary>
+                Stops the current manual addon-probe watch, if any.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.StopManagedAddonProbeWatches">
+            <summary>
+                Stops every managed automatic addon-probe watch.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloAddonProbeCommand(System.String,System.String)">
+            <summary>
+            Dumps a recursive probe of the requested addon to the log so we can
+            inspect its live node tree, component roots, and likely overlay anchors.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.ParseAddonProbeArguments(System.String)">
+            <summary>
+            Parses the addon probe command arguments into an addon name, optional index,
+            and optional watch duration.
+            </summary>
+            <param name="args">The raw command arguments.</param>
+            <returns>The addon name, index, and duration to probe.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryParseAddonProbeDuration(System.String,System.TimeSpan@)">
+            <summary>
+            Parses one addon-probe duration token such as "90s" or "15m".
+            </summary>
+            <param name="token">The raw duration token.</param>
+            <param name="duration">Receives the parsed duration.</param>
+            <returns><see langword="true"/> when the token parsed successfully.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LooksLikeAddonProbeDuration(System.String)">
+            <summary>
+            Determines whether a token looks like an addon-probe duration even when the
+            value is outside the accepted range.
+            </summary>
+            <param name="token">The token to inspect.</param>
+            <returns><see langword="true"/> when the token resembles a duration.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatAddonProbeDuration(System.TimeSpan)">
+            <summary>
+            Formats one addon-probe watch duration for chat feedback.
+            </summary>
+            <param name="duration">The duration to format.</param>
+            <returns>The human-readable duration string.</returns>
+        </member>
         <member name="M:Echoglossian.Echoglossian.ParseUi">
             <summary>
                 Parses the UI elements from the Addon sheet in the game data.
@@ -6614,6 +6739,102 @@
                 Builds the shared dependency bundle for standalone quest handlers.
             </summary>
             <returns>The reusable quest-handler dependency bundle.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloQuestProbeCommand(System.String,System.String)">
+            <summary>
+                Handles the quest probe command.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.TryResolveQuestProbeTarget(System.String,System.String@,System.String@,Lumina.Excel.Sheets.Quest@)">
+            <summary>
+                Tries to resolve the quest probe target from either a quest id or a
+                quest name.
+            </summary>
+            <param name="input">The command argument.</param>
+            <param name="questIdText">The resolved quest id as text.</param>
+            <param name="questName">The resolved quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>True when the quest could be resolved.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProbe(System.String,System.String,Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the quest data structure for inspection.
+            </summary>
+            <param name="questIdText">The quest id as text.</param>
+            <param name="questName">The quest name.</param>
+            <param name="questRow">The resolved Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestRow(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs the raw Lumina quest row properties.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestTextSheet(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Logs all rows from the quest text sheet, not just the live todo
+                entries, so we can inspect the full structure of the quest sheet.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestPlateRows(System.String,System.String)">
+            <summary>
+                Logs the QuestPlate rows currently stored for the quest.
+            </summary>
+            <param name="questIdText">The quest id text.</param>
+            <param name="questName">The quest name.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.LogQuestProgressSnapshot(Echoglossian.QuestProgressSnapshot)">
+            <summary>
+                Logs the resolved live quest progression snapshot.
+            </summary>
+            <param name="questProgressSnapshot">The resolved quest progress snapshot.</param>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves a human-readable quest name from a quest row.
+            </summary>
+            <param name="questRow">The quest row.</param>
+            <returns>The resolved quest name, if available.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.EvaluateQuestProbeText(Lumina.Text.ReadOnly.ReadOnlySeString)">
+            <summary>
+                Converts quest text to a readable string for probe output.
+            </summary>
+            <param name="text">The quest text.</param>
+            <returns>The evaluated text string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.FormatProbeValue(System.Object)">
+            <summary>
+                Formats a probe value for log output.
+            </summary>
+            <param name="value">The value to format.</param>
+            <returns>A human-readable value string.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.BuildQuestTextSheetName(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Builds the raw quest sheet name used by the game files.
+            </summary>
+            <param name="questRow">The resolved Lumina quest row.</param>
+            <returns>The quest text sheet name, if it can be derived.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestRowIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest row id as text through reflection so the probe
+                stays compatible with generated sheet shapes.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest row id as text, or an empty string if unavailable.</returns>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.GetQuestSheetIdText(Lumina.Excel.Sheets.Quest)">
+            <summary>
+                Resolves the quest sheet identifier used to mount the quest text
+                sheet path.
+            </summary>
+            <param name="questRow">The Lumina quest row.</param>
+            <returns>The quest sheet identifier as text, or an empty string if unavailable.</returns>
         </member>
         <member name="M:Echoglossian.Echoglossian.CreateQuestToastRuntime">
             <summary>
@@ -7454,6 +7675,14 @@
                 Unregisters the alternate supported-toast runtime from Dalamud's
                 normal and error-toast callbacks.
             </summary>
+        </member>
+        <member name="M:Echoglossian.Echoglossian.OnEgloTooltipRegisterLoggingCommand(System.String,System.String)">
+            <summary>
+            Starts or stops temporary logging for hover-tooltip registrations and
+            hover-hit transitions.
+            </summary>
+            <param name="command">Command name.</param>
+            <param name="args">Command arguments.</param>
         </member>
         <member name="M:Echoglossian.Echoglossian.TickTraitDetailPrefetch">
             <summary>
@@ -13042,6 +13271,25 @@
         </member>
         <member name="P:Echoglossian.SourceClientLanguage.ProviderCode">
             <summary>The code supplied to translation providers.</summary>
+        </member>
+        <member name="T:Echoglossian.TargetLanguageRuntimeState">
+            <summary>
+            Synchronizes the authoritative configured target language into the legacy
+            runtime mirrors consumed across the plugin.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.TargetLanguageRuntimeState.Synchronize(Echoglossian.Config,System.Collections.Generic.Dictionary{System.Int32,Echoglossian.LanguagesHandling.LanguageInfo})">
+            <summary>
+            Synchronizes the configured target language into the shared runtime
+            language dictionary, legacy integer identifier, selected language, and
+            presentation flags.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <param name="languages">The registered runtime language metadata.</param>
+            <returns>The resolved selected language.</returns>
+            <exception cref="T:System.Collections.Generic.KeyNotFoundException">
+            Thrown when the configured language identifier is not registered.
+            </exception>
         </member>
         <member name="T:Echoglossian.TranslationActivationGuard">
             <summary>
@@ -27965,6 +28213,46 @@
             <param name="addonName">The name of the add-on whose logging event listeners are to be removed. Cannot be null or empty.</param>
             <param name="events">Optional lifecycle event set to unlog. Defaults to the full event set.</param>
         </member>
+        <member name="T:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy">
+            <summary>
+                Encapsulates the login-session gating rules for debug-only automatic
+                addon-probe watches.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldStartForCurrentLogin(System.Boolean,System.Boolean,System.Boolean,System.Int32)">
+            <summary>
+                Determines whether the current login session should start the default
+                automatic addon-probe watch set.
+            </summary>
+            <param name="isLoggedIn">Whether the client is currently logged in.</param>
+            <param name="hasStartedForCurrentLogin">
+                Whether the current login session already started its automatic probe
+                set.
+            </param>
+            <param name="isSuppressedUntilLogout">
+                Whether the user explicitly suppressed the automatic probe set until
+                the next logout.
+            </param>
+            <param name="activeManagedWatchCount">
+                How many managed automatic probe watches are currently alive.
+            </param>
+            <returns>
+                <see langword="true" /> when the automatic probe set should start.
+            </returns>
+        </member>
+        <member name="M:Echoglossian.NativeUI.Helpers.AddonProbeAutoWatchPolicy.ShouldResetForLogout(System.Boolean,System.Boolean)">
+            <summary>
+                Determines whether the automatic login-session gate should reset
+                because the player logged out.
+            </summary>
+            <param name="wasLoggedIn">
+                Whether the client was logged in on the previous tick.
+            </param>
+            <param name="isLoggedIn">Whether the client is logged in now.</param>
+            <returns>
+                <see langword="true" /> when the automatic probe gate should reset.
+            </returns>
+        </member>
         <member name="T:Echoglossian.NativeUI.Helpers.AddonStructureProbe">
             <summary>
             Provides a generic recursive addon probe for live UI inspection.
@@ -34615,7 +34903,7 @@
                 Draws the full Overlay tab with vertical sub-tabs.
             </summary>
         </member>
-        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.DrawToastTypePage(Echoglossian.Config,System.String,System.Boolean@,Echoglossian.JournalTranslationDisplayMode@,System.Single@,System.Single@,System.Numerics.Vector2@,System.Numerics.Vector3@,System.Single@,System.Int64@)">
+        <member name="M:Echoglossian.PluginUI.Tabs.OverlayTab.GetToastGuiRouteStateText(Echoglossian.NativeUI.AddonHandlers.Toasts.ToastGuiRouteState)">
             <summary>
                 Maps one effective toast route state to the localized UI label used
                 in the toast general page.
@@ -39030,6 +39318,14 @@
             <param name="pluginLog">The plugin log.</param>
             <param name="config">The configuration settings.</param>
         </member>
+        <member name="M:Echoglossian.Translators.GTranslateTranslator.ResolveRequestedTargetLanguage(System.String)">
+            <summary>
+            Resolves the requested target language using the runtime language
+            normalization contract shared across translation services.
+            </summary>
+            <param name="requestedTargetLanguage">The requested target language code.</param>
+            <returns>The resolved GTranslate language metadata.</returns>
+        </member>
         <member name="M:Echoglossian.Translators.GTranslateTranslator.Translate(System.String,System.String,System.String)">
             <summary>
                 Translates the given text from the source language to the target language
@@ -42874,6 +43170,109 @@
             <param name="maxDistance">The distance at which the overlay becomes hidden.</param>
             <param name="minScale">The minimum scale reached at the maximum distance.</param>
             <returns>The resolved distance-aware presentation state.</returns>
+        </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics">
+            <summary>
+            Emits temporary, deduplicated diagnostics for texture-backed overlay render
+            passes while complex-script overlay regressions are under investigation.
+            </summary>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureUnavailable(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,Echoglossian.UIOverlays.TextPresentation.TextureRenderAttemptOutcome,System.ValueTuple{System.Int32,System.Int64,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32})">
+            <summary>
+            Logs one texture-backed overlay render pass that did not reach a drawn
+            state because the backing texture was unavailable.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <param name="surfaceId">The overlay surface identifier.</param>
+            <param name="request">The active overlay render request.</param>
+            <param name="textRequest">The resolved text-layout request.</param>
+            <param name="outcome">The texture-render decision.</param>
+            <param name="stats">The current RTL texture backend stats.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.LogTextureDrawn(Echoglossian.Config,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlaySurfaceId,Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlayRenderRequest,Echoglossian.UIOverlays.TextPresentation.TextLayoutRequest,System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Logs one successful texture-backed overlay draw.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <param name="surfaceId">The overlay surface identifier.</param>
+            <param name="request">The active overlay render request.</param>
+            <param name="textRequest">The resolved text-layout request.</param>
+            <param name="renderedPosition">The actual rendered window position.</param>
+            <param name="renderedSize">The actual rendered window size.</param>
+            <param name="bodySize">The measured body-text size.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldLog(Echoglossian.Config)">
+            <summary>
+            Determines whether texture-overlay diagnostics should run for the current
+            language mode.
+            </summary>
+            <param name="configuration">The active plugin configuration.</param>
+            <returns><see langword="true" /> when diagnostics should log.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.ShouldEmit(System.String,System.String)">
+            <summary>
+            Determines whether a deduplicated diagnostic line should be emitted.
+            </summary>
+            <param name="key">The stable diagnostic event key.</param>
+            <param name="signature">The event-state signature.</param>
+            <returns><see langword="true" /> when the line should be emitted.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreviewKey(System.String)">
+            <summary>
+            Builds the preview key used for deduplication.
+            </summary>
+            <param name="text">The source text.</param>
+            <returns>The stable preview key.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.BuildPreview(System.String)">
+            <summary>
+            Builds a short preview for diagnostic log lines.
+            </summary>
+            <param name="text">The source text.</param>
+            <returns>The shortened preview text.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundVector(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Rounds a vector to a coarse step size for deduplication.
+            </summary>
+            <param name="value">The source vector.</param>
+            <param name="step">The coarse rounding step.</param>
+            <returns>The rounded vector.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.RoundToStep(System.Single,System.Single)">
+            <summary>
+            Rounds a scalar to the requested step size.
+            </summary>
+            <param name="value">The source value.</param>
+            <param name="step">The rounding step.</param>
+            <returns>The rounded scalar.</returns>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.FormatVector(System.Numerics.Vector2)">
+            <summary>
+            Formats a vector for diagnostic log output.
+            </summary>
+            <param name="value">The vector value.</param>
+            <returns>The formatted vector.</returns>
+        </member>
+        <member name="T:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState">
+            <summary>
+            Captures the last emitted signature and time for one diagnostic key.
+            </summary>
+            <param name="Signature">The emitted diagnostic-state signature.</param>
+            <param name="EmittedAtUtc">The time the signature was emitted.</param>
+        </member>
+        <member name="M:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.#ctor(System.String,System.DateTime)">
+            <summary>
+            Captures the last emitted signature and time for one diagnostic key.
+            </summary>
+            <param name="Signature">The emitted diagnostic-state signature.</param>
+            <param name="EmittedAtUtc">The time the signature was emitted.</param>
+        </member>
+        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.Signature">
+            <summary>The emitted diagnostic-state signature.</summary>
+        </member>
+        <member name="P:Echoglossian.UIOverlays.TranslationOverlay.OverlayTextureRenderDiagnostics.EmissionState.EmittedAtUtc">
+            <summary>The time the signature was emitted.</summary>
         </member>
         <member name="P:Echoglossian.UIOverlays.TranslationOverlay.TranslationOverlay.RenderScale">
             <summary>

--- a/GeneralHelpers/RuntimeConfigurationRefresh.cs
+++ b/GeneralHelpers/RuntimeConfigurationRefresh.cs
@@ -43,6 +43,9 @@ public partial class Echoglossian
     }
 
     this.runtimeConfigurationDirty = false;
+    TargetLanguageRuntimeState.Synchronize(
+        this.configuration,
+        this.languagesDictionary);
     this.EnforceTranslationActivationConstraints();
     this.TryShowTranslationActivationBlockedNotification();
     PluginInterface.UiBuilder.DisableCutsceneUiHide =

--- a/GeneralHelpers/TargetLanguageRuntimeState.cs
+++ b/GeneralHelpers/TargetLanguageRuntimeState.cs
@@ -1,0 +1,47 @@
+// <copyright file="TargetLanguageRuntimeState.cs" company="lokinmodar">
+// Copyright (c) lokinmodar. All rights reserved.
+// Licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License license.
+// </copyright>
+
+using Echoglossian.LanguagesHandling;
+using Echoglossian.UIOverlays.TextPresentation;
+
+namespace Echoglossian;
+
+/// <summary>
+/// Synchronizes the authoritative configured target language into the legacy
+/// runtime mirrors consumed across the plugin.
+/// </summary>
+internal static class TargetLanguageRuntimeState
+{
+    /// <summary>
+    /// Synchronizes the configured target language into the shared runtime
+    /// language dictionary, legacy integer identifier, selected language, and
+    /// presentation flags.
+    /// </summary>
+    /// <param name="configuration">The active plugin configuration.</param>
+    /// <param name="languages">The registered runtime language metadata.</param>
+    /// <returns>The resolved selected language.</returns>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when the configured language identifier is not registered.
+    /// </exception>
+    internal static LanguageInfo Synchronize(
+        Config configuration,
+        Dictionary<int, LanguageInfo> languages)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(languages);
+
+        if (!languages.TryGetValue(configuration.Lang, out var selectedLanguage))
+        {
+            throw new KeyNotFoundException(
+                $"Configured target language id {configuration.Lang} is not registered.");
+        }
+
+        Echoglossian.LangDict = languages;
+        Echoglossian.LanguageInt = configuration.Lang;
+        Echoglossian.SelectedLanguage = selectedLanguage;
+        LanguagePresentationPolicy.ApplyLanguageFlags(configuration);
+        return selectedLanguage;
+    }
+}

--- a/GeneralHelpers/Utils.cs
+++ b/GeneralHelpers/Utils.cs
@@ -479,7 +479,7 @@ public partial class Echoglossian
         .NormalizeAndSyncSelection(
             this.configuration,
             loadedConfigVersion,
-            LangDict.TryGetValue(this.configuration.Lang, out var language)
+            this.languagesDictionary.TryGetValue(this.configuration.Lang, out var language)
                 ? language.SupportedEngines
                 : null);
 

--- a/PluginUI/PluginConfigWindowRenderer.cs
+++ b/PluginUI/PluginConfigWindowRenderer.cs
@@ -31,9 +31,9 @@ public sealed class PluginConfigWindowRenderer
         var changed = false;
         var languages = context.Languages as Dictionary<int, LanguageInfo> ??
                         new Dictionary<int, LanguageInfo>(context.Languages);
-        Echoglossian.LangDict = languages;
-        Echoglossian.LanguageInt = context.Configuration.Lang;
-        Echoglossian.SelectedLanguage = languages[context.Configuration.Lang];
+        TargetLanguageRuntimeState.Synchronize(
+            context.Configuration,
+            languages);
         LanguageDropdownHelper.Initialize(languages);
 
         ImGui.SetNextWindowSizeConstraints(
@@ -249,26 +249,24 @@ public sealed class PluginConfigWindowRenderer
         using (context.PushGeneralFont())
         {
             Echoglossian.LangToRemoveDiacritics =
-                languages.TryGetValue(config.Lang, out var selectedLanguage) &&
-                selectedLanguage.SupportsNativeReplacementDiacriticsFallback;
+                Echoglossian.SelectedLanguage
+                    .SupportsNativeReplacementDiacriticsFallback;
 
             if (LanguageDropdownHelper.DrawLanguageDropdown(
                     ref config.Lang,
                     Resources.LanguageSelectLabelText))
             {
-                Echoglossian.LanguageInt = config.Lang;
-                Echoglossian.SpecialFontFileName = languages[config.Lang].FontName;
-                Echoglossian.SelectedLanguage = languages[config.Lang];
+                var selectedLanguage = TargetLanguageRuntimeState.Synchronize(
+                    config,
+                    languages);
                 Echoglossian.LangToRemoveDiacritics =
-                    Echoglossian.SelectedLanguage
-                        .SupportsNativeReplacementDiacriticsFallback;
-                LanguagePresentationPolicy.ApplyLanguageFlags(config);
+                    selectedLanguage.SupportsNativeReplacementDiacriticsFallback;
 
                 if (TranslationEngineSelectionMigrationHelper
                     .NormalizeAndSyncSelection(
                         config,
                         config.Version,
-                        languages[config.Lang].SupportedEngines))
+                        selectedLanguage.SupportedEngines))
                 {
                     context.RebuildTranslationService();
                     changed = true;
@@ -277,7 +275,7 @@ public sealed class PluginConfigWindowRenderer
                 changed = true;
                 context.ApplyLanguageRuntimeChanges(
                     config,
-                    Echoglossian.SelectedLanguage);
+                    selectedLanguage);
             }
         }
 

--- a/Translators/GTranslateTranslator.cs
+++ b/Translators/GTranslateTranslator.cs
@@ -13,8 +13,6 @@ namespace Echoglossian.Translators;
 /// </summary>
 public class GTranslateTranslator : ITranslator
 {
-    private readonly Config config;
-    private readonly Language gTransTargetLanguage;
     private readonly IPluginLog pluginLog;
     private readonly AggregateTranslator translator;
 
@@ -27,10 +25,29 @@ public class GTranslateTranslator : ITranslator
     public GTranslateTranslator(IPluginLog pluginLog, Config config)
     {
         this.pluginLog = pluginLog;
-        this.config = config;
         this.translator =
             new AggregateTranslator(); // Switch to GoogleTranslator() if you want to force only Google
-        this.gTransTargetLanguage = Language.GetLanguage(SelectedLanguage.Code);
+    }
+
+    /// <summary>
+    /// Resolves the requested target language using the runtime language
+    /// normalization contract shared across translation services.
+    /// </summary>
+    /// <param name="requestedTargetLanguage">The requested target language code.</param>
+    /// <returns>The resolved GTranslate language metadata.</returns>
+    internal static Language ResolveRequestedTargetLanguage(
+        string requestedTargetLanguage)
+    {
+        var normalizedTargetLanguage =
+            RuntimeLanguageHelper.NormalizeLanguage(requestedTargetLanguage);
+        if (string.IsNullOrWhiteSpace(normalizedTargetLanguage))
+        {
+            throw new ArgumentException(
+                "A target language is required.",
+                nameof(requestedTargetLanguage));
+        }
+
+        return Language.GetLanguage(normalizedTargetLanguage);
     }
 
     /// <summary>
@@ -76,17 +93,18 @@ public class GTranslateTranslator : ITranslator
         PluginRuntimeLog.Debug(this.pluginLog, $"GTranslate input: {fixedText}");
 
         PluginRuntimeLog.Debug(this.pluginLog, $"GTranslate source language: {sourceLanguage}");
-        PluginRuntimeLog.Debug(
-            this.pluginLog,
-            $"GTranslate target language: {this.gTransTargetLanguage}");
 
         try
         {
-            // targetLanguage = Echoglossian.NormalizeLanguageCode(targetLanguage);
+            var resolvedTargetLanguage =
+                ResolveRequestedTargetLanguage(targetLanguage);
+            PluginRuntimeLog.Debug(
+                this.pluginLog,
+                $"GTranslate target language: {resolvedTargetLanguage}");
 
             var result = await this.translator.TranslateAsync(
                 fixedText,
-                this.gTransTargetLanguage.Name,
+                resolvedTargetLanguage.Name,
                 sourceLanguage);
             var cleaned = FixText(result.Translation);
             PluginRuntimeLog.Debug(this.pluginLog, $"GTranslate result: {cleaned}");

--- a/UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs
+++ b/UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs
@@ -99,9 +99,12 @@ internal sealed class TranslationOverlayRenderer : IDisposable
         var effectiveFontScale = GetEffectiveOverlayFontScale(
             config.FontScale * runtimeScaleMultiplier);
         var shouldCenterOverlayText = ShouldCenterOverlayText(config.SurfaceId);
+        var presentationLanguageId = this.configuration.Lang;
+        var presentationLanguageCode =
+            RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(this.configuration.Lang);
         var shouldRightAlignOverlayText =
             !shouldCenterOverlayText &&
-            LanguagePresentationPolicy.ShouldRightAlign(this.configuration.Lang);
+            LanguagePresentationPolicy.ShouldRightAlign(presentationLanguageId);
         var horizontalPadding = ImGui.GetStyle().WindowPadding.X * 2f;
         var textureMaxWidthOverride = this.ResolveTextureMaxWidthOverride(
             request,
@@ -121,8 +124,8 @@ internal sealed class TranslationOverlayRenderer : IDisposable
                 config));
         var textRequest = new TextLayoutRequest(
             overlayText,
-            this.configuration.Lang,
-            SelectedLanguage.Code,
+            presentationLanguageId,
+            presentationLanguageCode,
             this.ResolveMeasurementWrapWidth(
                 request,
                 config,

--- a/docs/issue-274-arabic-rtl-overlay-rca.md
+++ b/docs/issue-274-arabic-rtl-overlay-rca.md
@@ -1,0 +1,230 @@
+# Issue #274 RCA: Arabic Overlay Could Bypass the RTL Backend
+
+- **Issue:** [#274 - RTL Arabic Broken after new update](https://github.com/lokinmodar/Echoglossian/issues/274)
+- **Reported:** August 27, 2026
+- **Affected release:** `v4.2601.0816.1235`
+- **Last reported working state:** Before the affected release
+- **Affected surface:** Talk overlay in overlay-only mode
+- **Target language / engine:** Arabic / Google Translate
+- **Status:** Corrective action implemented and locally validated on August 28, 2026; live FFXIV verification still required
+
+## Executive Summary
+
+Issue #274 was not caused by malformed Google output, a changed Arabic font,
+or a direct edit to the RTL renderer in the August 16 release. The screenshot
+is most consistent with Arabic text being drawn by the ordinary ImGui text
+backend instead of the texture-backed RTL backend. That produces the exact
+failure class shown in the report: isolated Arabic glyphs, incorrect visual
+ordering, and right-edge clipping.
+
+The current texture renderer was exercised with the bundled
+`NotoSansArabic-Medium.ttf` and a representative Arabic sentence. It produced
+connected, right-to-left text without using the fallback font. The same
+experiment with a missing bundled font also produced connected text through
+the system fallback. In addition, current Google output for the English text
+shown in the issue contained no bidi control characters and survived the
+plugin's normalization unchanged.
+
+The release comparison is equally important: every file in the RTL selection,
+rasterization, overlay, language-policy, and bundled-font path has the same Git
+object ID in `v4.2601.0815.1339` and `v4.2601.0816.1235`. The same path is also
+unchanged from `v4.2601.0807.1730`. The August 16 release therefore contains no
+direct RTL implementation or asset regression.
+
+The architectural weakness is that translation and presentation do not use
+one authoritative language state. The Google translator captures
+`SelectedLanguage.Code`, while the overlay independently selects its backend
+from `configuration.Lang`. The plugin also maintains `LanguageInt`. If these
+values diverge, Google can return Arabic while the renderer classifies the
+same output as a non-RTL language and sends it to ImGui. That is the only
+current code path that matches both halves of the report: valid Arabic
+translation and visibly unshaped overlay text.
+
+Red/green tests now validate the corrective path directly: stale target-language
+mirrors can be synchronized from `Config.Lang`, the Google translator no longer
+captures `SelectedLanguage.Code`, the overlay no longer mixes `Config.Lang`
+with `SelectedLanguage.Code`, and a deterministic Previewer artifact renders
+the issue sentence through `RtlTexture` with the bundled Arabic font. Hosted
+Mock validation also exposed one adjacent startup-order regression after the
+state-centralization refactor: `MigrateTranslationEngineSelection()` still read
+the static `LangDict` before synchronization. The final fix moved that lookup
+to the plugin-owned `languagesDictionary`, restoring startup safety without
+changing persistence or presentation behavior.
+
+## User Impact
+
+- Arabic, Persian, and Urdu can become unreadable in the Talk overlay when the
+  ordinary ImGui backend receives their translated text.
+- Overlay-only mode leaves the original English native text intact, so the
+  failure is isolated to translated presentation rather than native mutation.
+- The problem can appear engine-specific or translation-specific even though
+  the returned string is valid and the defect occurs after translation.
+
+## Expected and Observed Flow
+
+```text
+Expected
+Arabic target -> RtlTexture backend -> GDI+ raster with RTL format -> connected glyphs
+
+Observed / inferred from screenshot
+Arabic translation -> PlainImGui backend -> ImGui text drawing -> isolated glyphs + clipping
+```
+
+`RtlTexturePresentationService` does not fall back to plain ImGui after a
+texture-rendering failure. It reports the draw as unavailable instead. The
+presence of visibly drawn, disconnected Arabic therefore points to backend
+classification before texture rendering, not failure inside the texture
+renderer.
+
+## Evidence
+
+| Evidence | Result | Interpretation |
+| --- | --- | --- |
+| Issue screenshot | Arabic glyphs are isolated and clipped while native English remains unchanged. | Matches ordinary ImGui rendering in overlay-only mode. |
+| Current production rasterizer with bundled Noto Arabic font | Connected RTL output; `FallbackFontUsed == false`. | The bundled font and current texture renderer can render the reported script correctly. |
+| Rasterizer with an intentionally missing bundled font | Connected RTL output through the system fallback. | A missing font alone does not reproduce the screenshot. |
+| Current Google translation of the reported English sentence | Valid Arabic; no format characters; overlay normalization did not alter it. | No evidence that the translator or normalizer split the glyphs. |
+| `v4.2601.0815.1339` vs. `v4.2601.0816.1235` | RTL renderer, resolver, overlay renderer, language policy, language dictionary, and font objects are identical. | Rules out a direct last-release change to the RTL path. |
+| `v4.2601.0807.1730` vs. `v4.2601.0816.1235` | The same RTL path is unchanged. | The direct renderer path predates both recent releases. |
+| Current backend contract | Arabic language ID `2` resolves to `RtlTexture`; a failed texture draw does not render plain text. | The screenshot implies that the request did not reach the renderer classified as Arabic. |
+| Runtime language ownership | Translator reads `SelectedLanguage.Code`; renderer reads `configuration.Lang`; `LanguageInt` also exists. | A state mismatch can produce Arabic output with a non-RTL presentation backend. |
+
+## Release Comparison
+
+The affected release tag points to commit
+`2901ef0d8b1d68956c6ac86afe97ff3bc098e7f3`; the previous release points to
+`edc589fbe92a4aa52f4e6fa2a23536287d93b9f0`.
+
+The following paths have identical Git object IDs in those two releases:
+
+- `ImageGeneration/TextImageRenderer.cs`
+- `UIOverlays/TextPresentation/RtlTexturePresentationService.cs`
+- `UIOverlays/TextPresentation/LanguagePresentationPolicy.cs`
+- `UIOverlays/TextPresentation/TextPresentationResolver.cs`
+- `UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs`
+- `Font/NotoSansArabic-Medium.ttf`
+- `LanguagesHandling/LanguagesDictionary.cs`
+
+The project dependency on `System.Drawing.Common` also remained `10.0.10`.
+Changes shipped on August 16 covered prompt/configuration behavior and other
+runtime surface settings, not RTL rendering or its font asset. Static analysis
+of those surrounding changes found no direct write that intentionally changes
+the target-language fields, but it cannot reconstruct the reporter's runtime
+state.
+
+## Root Cause and Contributing Factors
+
+### Validated incident mechanism — high confidence
+
+The overlay rendered an RTL translation through `PlainImGui` instead of
+`RtlTexture`. This conclusion is based on the visual signature, successful
+production-rasterizer reproduction in the correct backend, and the renderer's
+no-fallback contract. The branch now enforces one configured target-language
+identity across translator request handling and overlay presentation metadata.
+
+### Architectural root cause — high confidence
+
+Language identity is duplicated across mutable state:
+
+- `configuration.Lang` controls presentation-backend selection;
+- `SelectedLanguage.Code` controls the translator target captured at translator
+  construction; and
+- `LanguageInt` is maintained as an additional runtime value.
+
+No invariant requires these values to agree at the point where translated text
+is presented. The backend request also carries only the numeric configuration
+language rather than the exact translator target that produced the text.
+
+### Reporter-specific runtime trigger — still unobserved
+
+The most likely trigger is stale or divergent target-language state during or
+after configuration/runtime refresh. No normal source path in the release diff
+has yet been shown to create that persistent mismatch. Confirmation requires a
+log or instrumentation capture from an affected installation. The local fix
+addresses the divergence mechanism directly even though the exact field values
+on the reporter's August 27, 2026 installation were never captured.
+
+### Release escape — high confidence
+
+The RTL tests cover policy membership, request values, cache behavior,
+`StringFormat` flags, bitmap dimensions, and texture limits. They do not prove
+the end-to-end invariant:
+
+> the language selected by the translator is the language used to select the
+> presentation backend, and real Arabic output is visually shaped in the Talk
+> overlay.
+
+Several renderer tests intentionally use a missing font, and the overlay
+preview scenarios do not provide an Arabic golden image. Existing hosted tests
+validate startup and policy wiring but do not drive a real Arabic Talk payload
+through capture, translation, backend selection, texture upload, and drawing.
+
+Issue #139 was consequently closed after validating components rather than the
+complete official-build user path. The August 16 release was also shipped
+without an Arabic/Persian/Urdu visual smoke test. That is where the release
+process failed even though the release did not directly modify the RTL code.
+
+## Ruled-Out or Unsupported Hypotheses
+
+- **A direct RTL code regression in the last release:** ruled out by identical
+  Git objects across the release boundary.
+- **A changed or missing bundled Arabic font:** not supported; the font object
+  is identical, and both bundled-font and fallback-font diagnostic renders
+  produced connected glyphs.
+- **Google returning separated Arabic characters:** not reproduced; current
+  Google output is normal Arabic and is unchanged by display normalization.
+- **Texture rendering failing and then falling back to ImGui:** ruled out by
+  the current renderer contract; failure produces no draw, not plain text.
+- **Unicode-format stripping as the immediate cause:** not reproduced for the
+  reported sentence. Broad removal of all Unicode `Format` characters remains
+  a separate RTL robustness risk because some bidi controls and joiners belong
+  to that category.
+
+## Corrective Actions
+
+Implemented locally on August 28, 2026:
+
+1. `Config.Lang` plus the plugin language dictionary now act as the
+   authoritative target-language source through
+   `TargetLanguageRuntimeState.Synchronize(...)`, which repairs `LangDict`,
+   `LanguageInt`, `SelectedLanguage`, and presentation flags together.
+2. `GTranslateTranslator` now resolves the provider target from the
+   `targetLanguage` method argument on every call and no longer captures
+   `SelectedLanguage.Code`.
+3. `TranslationOverlayRenderer` now derives both the language id and language
+   code from the configured target language before it selects the presentation
+   backend or builds `TextLayoutRequest`.
+4. The branch now includes a real bundled-font Arabic raster test, a committed
+   `talk-arabic-274` Previewer scenario, a secret-free sample config, and a
+   deterministic screenshot command. The generated manifest for the validated
+   artifact reported `RtlTexture`.
+5. Hosted Mock validation exposed a startup-order regression after the language
+   synchronization refactor. `MigrateTranslationEngineSelection()` now reads
+   the plugin instance dictionary instead of the static `LangDict`, preventing
+   constructor-time null access before synchronization completes.
+
+## Remaining In-Game Verification Boundary
+
+Previewer and DalaMock validate the configuration, translator, and overlay
+coupling, but they do not reproduce the live FFXIV Talk capture path together
+with the game compositor. The remaining required checks are:
+
+- English client, Google or GTranslate engine, Arabic target, Talk in overlay-only mode.
+- Arabic Talk text uses connected glyphs, correct RTL order, expected wrapping, and no right-edge clipping.
+- Repeat the same check with Persian and Urdu.
+- Switch Arabic -> English -> Arabic without restarting and confirm the backend changes `RtlTexture -> PlainImGui -> RtlTexture` while old-language text clears.
+- Confirm overlay-only mode never mutates native Talk text.
+- Inspect `<PluginConfigDirectory>\Echoglossian.log` for runtime errors.
+
+## Bottom Line
+
+The evidence does not support "we broke the Arabic renderer in the last
+release." The more accurate conclusion is:
+
+> We shipped a system in which translation language and rendering language
+> could diverge, and we lacked the end-to-end Arabic visual test that would
+> catch that divergence before release.
+
+The August 28, 2026 branch fix removes that configuration/renderer split in the
+covered paths and adds deterministic Arabic regression coverage, but live game
+verification is still required before closing issue #274.

--- a/docs/superpowers/plans/2026-08-28-issue-274-rtl-overlay-fix.md
+++ b/docs/superpowers/plans/2026-08-28-issue-274-rtl-overlay-fix.md
@@ -1,0 +1,453 @@
+# Issue #274 RTL Overlay Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure Arabic, Persian, Urdu, and the other texture-backed languages always use one configured target-language identity from translation request through overlay presentation, while adding a reproducible Arabic Talk-overlay visual gate.
+
+**Architecture:** Treat `Config.Lang` plus `Echoglossian.LangDict` as the authoritative runtime target-language source. Synchronize the legacy `LanguageInt` and `SelectedLanguage` mirrors through one helper, make GTranslate honor the `targetLanguage` argument on every call, and make the overlay derive both language ID and language code from the configured source rather than mixing `Config.Lang` with `SelectedLanguage.Code`. Keep capture, translation, and presentation separate; do not add queues, caches, DB changes, or native UI mutation.
+
+**Tech Stack:** C# 14, .NET 10, Dalamud, GTranslate, System.Drawing.Common 10.0.10, xUnit, Echoglossian.Previewer/Veldrid.
+
+**Spec:** `docs/issue-274-arabic-rtl-overlay-rca.md`
+
+## Global Constraints
+
+- Work on branch `issue-274-rtl-overlay-rendering` created from the freshly fetched `origin/v4-series` commit `017ddef7ab74e656c4f89839d00139b7092663ee` or a newer `origin/v4-series` if the remote advances before execution.
+- Preserve overlay-only behavior: never mutate native addon nodes, text nodes, or `AtkValue`s for Arabic/RTL output.
+- Keep `Config.Lang` as the persisted source of truth; `LanguageInt` and `SelectedLanguage` are compatibility mirrors only.
+- Do not introduce a parallel translation path, cache, queue, or persistence migration.
+- Route plugin-owned logs through `PluginRuntimeLog`; never log translated dialogue, prompts, keys, or secrets.
+- Keep hot-path logging silent. Any mismatch diagnostic must be edge-triggered or deduplicated and contain language metadata only.
+- Follow the repository header, XML documentation, braces, and `this.` call rules.
+- Use PowerShell and Windows-safe commands.
+- Commit each stable task with `#274` in the commit subject.
+
+---
+
+### Task 1: Centralize configured target-language synchronization
+
+**Files:**
+- Create: `GeneralHelpers/TargetLanguageRuntimeState.cs`
+- Create: `Echoglossian.Tests/TargetLanguageRuntimeStateTests.cs`
+- Modify: `Echoglossian.cs:250-375`
+- Modify: `PluginUI/PluginConfigWindowRenderer.cs:25-40,250-275`
+- Modify: `GeneralHelpers/RuntimeConfigurationRefresh.cs:30-85`
+- Modify: `Echoglossian.Tests/RuntimeConfigurationRefreshContractTests.cs`
+
+**Interfaces:**
+- Consumes: `Config.Lang`, `Dictionary<int, LanguageInfo>`, and `LanguagePresentationPolicy.ApplyLanguageFlags(Config)`.
+- Produces: `TargetLanguageRuntimeState.Synchronize(Config, Dictionary<int, LanguageInfo>) -> LanguageInfo`, which atomically refreshes `LangDict`, `LanguageInt`, `SelectedLanguage`, and presentation flags from the configured language.
+
+- [x] **Step 1: Write failing synchronization tests**
+
+Create `TargetLanguageRuntimeStateTests.cs` with tests that save and restore all touched static fields. The key regression must start with deliberately stale English mirrors and an Arabic configuration:
+
+```csharp
+[Fact]
+public void Synchronize_ArabicConfiguration_RepairsStaleLegacyMirrors()
+{
+    var languages = Echoglossian.CreateLanguagesDictionary();
+    var configuration = new Config { Lang = 2 };
+    Echoglossian.LanguageInt = 28;
+    Echoglossian.SelectedLanguage = languages[28];
+
+    var selected = TargetLanguageRuntimeState.Synchronize(
+        configuration,
+        languages);
+
+    Assert.Same(languages[2], selected);
+    Assert.Equal(2, Echoglossian.LanguageInt);
+    Assert.Same(languages[2], Echoglossian.SelectedLanguage);
+    Assert.Same(languages, Echoglossian.LangDict);
+    Assert.True(configuration.OverlayOnlyLanguage);
+    Assert.False(configuration.UnsupportedLanguage);
+}
+```
+
+Add a second test proving an unknown configured ID throws `KeyNotFoundException` without partially changing `LanguageInt` or `SelectedLanguage`. Restore the prior static values in `finally` blocks so parallel test order cannot leak state.
+
+- [x] **Step 2: Run the focused tests and verify the red state**
+
+Run:
+
+```powershell
+dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter FullyQualifiedName~TargetLanguageRuntimeStateTests -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: compilation fails because `TargetLanguageRuntimeState` does not yet exist.
+
+- [x] **Step 3: Implement the smallest synchronization helper**
+
+Create the helper as an internal static class. Validate dictionary membership before performing any mutations, then update all mirrors and language flags:
+
+```csharp
+internal static class TargetLanguageRuntimeState
+{
+    internal static LanguageInfo Synchronize(
+        Config configuration,
+        Dictionary<int, LanguageInfo> languages)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(languages);
+
+        if (!languages.TryGetValue(configuration.Lang, out var selectedLanguage))
+        {
+            throw new KeyNotFoundException(
+                $"Configured target language id {configuration.Lang} is not registered.");
+        }
+
+        Echoglossian.LangDict = languages;
+        Echoglossian.LanguageInt = configuration.Lang;
+        Echoglossian.SelectedLanguage = selectedLanguage;
+        LanguagePresentationPolicy.ApplyLanguageFlags(configuration);
+        return selectedLanguage;
+    }
+}
+```
+
+Use this helper at plugin startup after the dictionary is created, at the beginning of configuration-window drawing, immediately after a language dropdown change, and in `ApplyPendingRuntimeConfigurationChanges()` before translation signatures are evaluated and translator services are rebuilt. Preserve the existing asset/font refresh callbacks after synchronization.
+
+- [x] **Step 4: Add an ordering contract for runtime refresh**
+
+Extend `RuntimeConfigurationRefreshContractTests` to assert that the synchronization call appears before `ComputeTranslationRuntimeSignature()` and `RebuildTranslationServiceSafely()` inside `ApplyPendingRuntimeConfigurationChanges()`. This prevents future save-coordinator changes from rebuilding a translator against stale legacy mirrors.
+
+- [x] **Step 5: Run the focused state tests**
+
+Run:
+
+```powershell
+dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~TargetLanguageRuntimeStateTests|FullyQualifiedName~RuntimeConfigurationRefreshContractTests" -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: all selected tests pass with zero failures.
+
+- [x] **Step 6: Commit the synchronized runtime state**
+
+```powershell
+git add -- GeneralHelpers\TargetLanguageRuntimeState.cs Echoglossian.Tests\TargetLanguageRuntimeStateTests.cs Echoglossian.cs PluginUI\PluginConfigWindowRenderer.cs GeneralHelpers\RuntimeConfigurationRefresh.cs Echoglossian.Tests\RuntimeConfigurationRefreshContractTests.cs
+git commit -m "fix(#274): synchronize target language runtime state"
+```
+
+---
+
+### Task 2: Make translation and presentation consume the configured target
+
+**Files:**
+- Modify: `Translators/GTranslateTranslator.cs:13-95`
+- Create: `Echoglossian.Tests/GTranslateTranslatorTargetLanguageTests.cs`
+- Modify: `UIOverlays/TranslationOverlay/TranslationOverlayRenderer.cs:90-145`
+- Modify: `Echoglossian.Tests/TranslationOverlayRendererContractTests.cs`
+- Modify: `Echoglossian.Tests/TextPresentationResolverTests.cs`
+
+**Interfaces:**
+- Consumes: the `targetLanguage` argument already defined by `ITranslator.TranslateAsync`, `Config.Lang`, and `RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(int)`.
+- Produces: `GTranslateTranslator.ResolveRequestedTargetLanguage(string) -> GTranslate.Language` as a testable provider-boundary helper; the overlay builds `TextLayoutRequest.LanguageId` and `.LanguageCode` from the same configured language.
+
+- [x] **Step 1: Write failing provider and renderer contract tests**
+
+Create a GTranslate test that deliberately leaves `SelectedLanguage` set to Arabic while asking the provider helper for English:
+
+```csharp
+[Fact]
+public void ResolveRequestedTargetLanguage_UsesMethodArgumentNotSelectedGlobal()
+{
+    var previous = Echoglossian.SelectedLanguage;
+    try
+    {
+        Echoglossian.SelectedLanguage = new LanguageInfo(
+            "ar",
+            "Arabic",
+            "NotoSansArabic-Medium.ttf",
+            string.Empty,
+            []);
+
+        var resolved = GTranslateTranslator.ResolveRequestedTargetLanguage("en");
+
+        Assert.Equal(
+            GTranslate.Language.GetLanguage("en").Name,
+            resolved.Name);
+    }
+    finally
+    {
+        Echoglossian.SelectedLanguage = previous;
+    }
+}
+```
+
+Add cases for `ar`, `fa`, and `ur`, plus an empty-code case that must throw `ArgumentException` before a network request is attempted.
+
+Extend `TranslationOverlayRendererContractTests` to read the renderer source and assert:
+
+```csharp
+Assert.Contains(
+    "RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(this.configuration.Lang)",
+    source,
+    StringComparison.Ordinal);
+Assert.DoesNotContain("SelectedLanguage.Code", source, StringComparison.Ordinal);
+```
+
+Add a `TextPresentationResolverTests` case confirming a consistent Arabic request (`2`, `ar`) selects `RtlTexture` and an English request (`28`, `en`) selects `PlainImGui`. Keep the existing policy behavior unchanged.
+
+- [x] **Step 2: Run the focused tests and verify the red state**
+
+Run:
+
+```powershell
+dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~GTranslateTranslatorTargetLanguageTests|FullyQualifiedName~TranslationOverlayRendererContractTests|FullyQualifiedName~TextPresentationResolverTests" -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: the new provider helper is missing and the renderer still contains `SelectedLanguage.Code`.
+
+- [x] **Step 3: Make GTranslate honor the request contract**
+
+Remove the constructor-captured `gTransTargetLanguage` field and the unused stored `Config` field. Add:
+
+```csharp
+internal static Language ResolveRequestedTargetLanguage(
+    string requestedTargetLanguage)
+{
+    var normalizedTargetLanguage =
+        RuntimeLanguageHelper.NormalizeLanguage(requestedTargetLanguage);
+    if (string.IsNullOrWhiteSpace(normalizedTargetLanguage))
+    {
+        throw new ArgumentException(
+            "A target language is required.",
+            nameof(requestedTargetLanguage));
+    }
+
+    return Language.GetLanguage(normalizedTargetLanguage);
+}
+```
+
+Inside the existing `try` in `TranslateAsync`, resolve from the method's `targetLanguage` argument and pass that language's provider name to `AggregateTranslator.TranslateAsync`. Do not read `SelectedLanguage` in this class. Preserve existing failure behavior: log through `PluginRuntimeLog` and return an empty string on provider errors.
+
+- [x] **Step 4: Make the overlay language metadata internally consistent**
+
+In `TranslationOverlayRenderer.Draw`, resolve once:
+
+```csharp
+var presentationLanguageId = this.configuration.Lang;
+var presentationLanguageCode =
+    RuntimeLanguageHelper.GetConfiguredTargetLanguageCode(
+        presentationLanguageId);
+```
+
+Use `presentationLanguageId` for RTL alignment and `TextLayoutRequest.LanguageId`, and `presentationLanguageCode` for `TextLayoutRequest.LanguageCode`. Remove the `SelectedLanguage.Code` read. Do not add fallback from a failed texture render to plain ImGui; the existing no-draw contract is safer than rendering broken complex text.
+
+- [x] **Step 5: Run focused provider and renderer tests**
+
+Run:
+
+```powershell
+dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~GTranslateTranslatorTargetLanguageTests|FullyQualifiedName~TranslationOverlayRendererContractTests|FullyQualifiedName~TextPresentationResolverTests" -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: all selected tests pass; no network call is made.
+
+- [x] **Step 6: Commit the provider/presentation fix**
+
+```powershell
+git add -- Translators\GTranslateTranslator.cs Echoglossian.Tests\GTranslateTranslatorTargetLanguageTests.cs UIOverlays\TranslationOverlay\TranslationOverlayRenderer.cs Echoglossian.Tests\TranslationOverlayRendererContractTests.cs Echoglossian.Tests\TextPresentationResolverTests.cs
+git commit -m "fix(#274): use configured language for RTL presentation"
+```
+
+---
+
+### Task 3: Add the real Arabic raster and preview regression gates
+
+**Files:**
+- Modify: `Echoglossian.Tests/TextImageRendererTests.cs`
+- Modify: `Echoglossian.Previewer/Scenarios/PreviewScenarioCatalog.cs`
+- Create: `Echoglossian.Previewer/Samples/issue-274-arabic.json`
+- Modify: `Echoglossian.Previewer.Tests/Scenarios/PreviewScenarioCatalogTests.cs`
+- Modify: `Echoglossian.Previewer.Tests/Session/PreviewSessionLoaderTests.cs`
+- Modify: `Echoglossian.Previewer/README.md`
+
+**Interfaces:**
+- Consumes: bundled `Font/NotoSansArabic-Medium.ttf`, the shared `TextImageRenderer`, the existing Talk preview surface, and preview configuration loading.
+- Produces: built-in scenario key `talk-arabic-274` and a secret-free preview config that deterministically selects language ID `2` and overlay-only Talk presentation.
+
+- [x] **Step 1: Write the real-font regression test**
+
+Add a test using the exact issue sentence rather than `missing-font.ttf`:
+
+```csharp
+[Fact]
+public void RenderShapedText_Issue274Arabic_UsesBundledFontAndDrawsPixels()
+{
+    var fontPath = Path.Combine(
+        FindRepositoryRoot().FullName,
+        "Font",
+        "NotoSansArabic-Medium.ttf");
+    const string text =
+        "أعتذر، ولكن أخشى أنني يجب أن أبعدك في الوقت الحالي. " +
+        "يرجى العودة في وقت لاحق.";
+
+    using var renderer = new TextImageRenderer(
+        fontPath,
+        24f,
+        FontStyle.Regular,
+        1f);
+    using var bitmap = renderer.RenderShapedText(
+        text,
+        Color.White,
+        Color.Transparent,
+        480);
+
+    Assert.False(renderer.FallbackFontUsed);
+    Assert.InRange(bitmap.Width, 1, 2048);
+    Assert.InRange(bitmap.Height, 1, 2048);
+    Assert.True(ContainsVisiblePixel(bitmap));
+}
+```
+
+Implement `FindRepositoryRoot()` and `ContainsVisiblePixel(Bitmap)` as private test helpers. Do not use a platform-sensitive PNG hash as the assertion; anti-aliasing can differ across supported Windows builds.
+
+- [x] **Step 2: Register a deterministic issue scenario and sample config**
+
+Add `talk-arabic-274` to `PreviewScenarioCatalog.Defaults`, using `TranslationOverlaySurfaceId.Talk`, the issue's Arabic sentence, and a stable speaker title. Create the sample JSON with no credentials:
+
+```json
+{
+  "Lang": 2,
+  "Translate": true,
+  "TranslateTalk": true,
+  "TalkTranslationDisplayMode": 1,
+  "FontSize": 24
+}
+```
+
+The scenario supplies content and geometry; the sample config supplies the language/font/backend selection. Do not embed API keys or a live plugin configuration.
+
+- [x] **Step 3: Add preview catalog and config-loader tests**
+
+Assert that `ResolveScenario("talk-arabic-274")` returns Talk, contains Arabic characters, and has non-empty bounds. Load the tracked sample through `PreviewSessionLoader` and assert `Lang == 2`, `TalkTranslationDisplayMode == TooltipTranslation`, and the source sample remains unchanged after preview session disposal.
+
+- [x] **Step 4: Run the raster and previewer test projects**
+
+Run:
+
+```powershell
+dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-restore --filter FullyQualifiedName~RenderShapedText_Issue274Arabic -p:VSTestMaxCpuCount=1 --nologo
+dotnet test .\Echoglossian.Previewer.Tests\Echoglossian.Previewer.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~PreviewScenarioCatalogTests|FullyQualifiedName~PreviewSessionLoaderTests" -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: the real font is used, visible pixels are produced, and the preview inputs remain deterministic and isolated.
+
+- [x] **Step 5: Document and capture the visual smoke command**
+
+Add this Windows command to the Previewer README:
+
+```powershell
+dotnet run --project .\Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-build -- --config .\Echoglossian.Previewer\Samples\issue-274-arabic.json --scenario talk-arabic-274 --viewport 1920x1080 --screenshot surface --output .\artifacts\previewer\issue-274
+```
+
+The generated manifest must report `RtlTexture`. Open the PNG and verify connected Arabic glyphs, correct RTL order, word wrapping, and no right-edge clipping. Do not commit generated artifacts.
+
+- [x] **Step 6: Commit the regression gates**
+
+```powershell
+git add -- Echoglossian.Tests\TextImageRendererTests.cs Echoglossian.Previewer\Scenarios\PreviewScenarioCatalog.cs Echoglossian.Previewer\Samples\issue-274-arabic.json Echoglossian.Previewer.Tests\Scenarios\PreviewScenarioCatalogTests.cs Echoglossian.Previewer.Tests\Session\PreviewSessionLoaderTests.cs Echoglossian.Previewer\README.md
+git commit -m "test(#274): add Arabic overlay visual regression gate"
+```
+
+---
+
+### Task 4: Validate the branch and record the remaining runtime boundary
+
+**Files:**
+- Modify: `docs/issue-274-arabic-rtl-overlay-rca.md`
+- Modify: `docs/superpowers/plans/2026-08-28-issue-274-rtl-overlay-fix.md`
+- Update if generated by the validated build: `Echoglossian.xml`
+
+**Interfaces:**
+- Consumes: all earlier commits, standard solution tests, Previewer screenshot output, and DalaMock startup validation.
+- Produces: a validated issue branch with explicit automated coverage and an honest in-game verification checklist.
+
+- [x] **Step 1: Run the standard solution validation**
+
+Run:
+
+```powershell
+dotnet build .\Echoglossian.sln -c Debug --no-restore
+dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: build succeeds and all unit tests pass with zero failures. Investigate new failures; report unrelated baseline failures without hiding them.
+
+- [x] **Step 2: Run hosted runtime validation**
+
+Run:
+
+```powershell
+dotnet build .\Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-restore
+dotnet test .\Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1 --nologo
+```
+
+Expected: startup, configuration, and shutdown tests pass. State explicitly that DalaMock startup does not prove live FFXIV Talk payload capture or GPU texture presentation.
+
+- [x] **Step 3: Build the Previewer and capture the Arabic artifact**
+
+Run:
+
+```powershell
+dotnet restore .\Echoglossian.Previewer\Echoglossian.Previewer.csproj
+dotnet build .\Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-restore
+dotnet run --project .\Echoglossian.Previewer\Echoglossian.Previewer.csproj -c Debug --no-build -- --config .\Echoglossian.Previewer\Samples\issue-274-arabic.json --scenario talk-arabic-274 --viewport 1920x1080 --screenshot surface --output .\artifacts\previewer\issue-274
+```
+
+Expected: exit code `0`, manifest backend `RtlTexture`, and a visually correct Arabic PNG. Record the artifact path in the execution report but keep `artifacts/` untracked.
+
+- [x] **Step 4: Update the RCA status and plan checkboxes**
+
+Change the RCA from preliminary mechanism to implemented corrective action only if the red/green tests demonstrate the stale-state path before and after the fix. Record:
+
+- configuration is now authoritative for both request and presentation metadata;
+- GTranslate no longer captures `SelectedLanguage.Code`;
+- the renderer no longer reads `SelectedLanguage.Code`;
+- automated preview coverage is present;
+- live in-game Talk verification remains required because Previewer/DalaMock cannot reproduce the FFXIV compositor and addon lifecycle together.
+
+- [x] **Step 5: Run final repository hygiene checks**
+
+Run:
+
+```powershell
+git diff --check
+git status --short
+git log --oneline --decorate origin/v4-series..HEAD
+```
+
+Expected: no whitespace errors, no generated screenshot artifacts, no API keys, and only issue #274 files/commits in the branch delta.
+
+- [x] **Step 6: Commit validated documentation and generated XML if changed**
+
+```powershell
+git add -- docs\issue-274-arabic-rtl-overlay-rca.md docs\superpowers\plans\2026-08-28-issue-274-rtl-overlay-fix.md
+if (-not (git diff --quiet -- Echoglossian.xml)) { git add -- Echoglossian.xml }
+git commit -m "docs(#274): record RTL overlay correction validation"
+```
+
+### Execution Notes
+
+- Focused red/green validation covered synchronization, translator target resolution, overlay language metadata, the real bundled-font Arabic raster path, and deterministic Previewer inputs.
+- Hosted Mock validation exposed one extra startup-order regression outside the original plan surface: `MigrateTranslationEngineSelection()` still read the static `LangDict` before `TargetLanguageRuntimeState.Synchronize(...)` ran. The smallest safe revision was to use `this.languagesDictionary` instead, with `TranslationEngineSelectionContractTests` guarding that constructor-time contract.
+- Final validation on August 28, 2026 passed with:
+  - `dotnet build .\Echoglossian.sln -c Debug --no-restore`
+  - `dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1 --nologo` -> `1291/1291`
+  - `dotnet test .\Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1 --nologo` -> `25/25`
+  - `dotnet test .\Echoglossian.Previewer.Tests\Echoglossian.Previewer.Tests.csproj -c Debug --no-restore -p:VSTestMaxCpuCount=1 --nologo` -> `145/145`
+- The deterministic Previewer artifact was written to `artifacts\previewer\issue-274\surface-talk-arabic-274-1920x1080.png`, and `artifacts\previewer\issue-274\manifest.json` recorded `PresentationMode: "RtlTexture"`.
+
+## Required In-Game Verification
+
+After automated validation, use the official-like Debug plugin artifact and verify all of the following in FFXIV:
+
+1. English client, Google/GTranslate engine, Arabic target, Talk set to overlay-only.
+2. Arabic Talk text uses connected glyphs, RTL reading order, word wrapping, and no right-edge clipping.
+3. Repeat with Persian and Urdu.
+4. Switch Arabic -> English -> Arabic without restarting; verify the backend changes `RtlTexture -> PlainImGui -> RtlTexture` and old-language text is cleared.
+5. Confirm overlay-only mode never modifies native Talk text.
+6. Inspect `<PluginConfigDirectory>\Echoglossian.log` for errors; do not rely on `dalamud.log` unless cross-plugin context is required.
+
+Do not close issue #274 until this in-game checklist passes or the remaining gap is explicitly assigned to the reporter with a build and capture instructions.


### PR DESCRIPTION
## Summary

- prepare `v4.2601.0829.2219` for the `#274` Arabic RTL overlay fix
- carry the validated target-language/runtime synchronization fix, per-call GTranslate target handling, deterministic Arabic Previewer regression gate, and startup migration guard into the release submission
- include the refreshed `Echoglossian.xml` produced by the validated build so release artifacts stay in sync with the committed source

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] in-game verification was performed when runtime UI behavior changed

Additional validation:
- `dotnet test Echoglossian.Mock.Tests\Echoglossian.Mock.Tests.csproj -c Debug --no-build -p:VSTestMaxCpuCount=1`
- Previewer build/tests and the deterministic Arabic screenshot path were validated during the `#274` fix flow
- manual in-game Arabic overlay verification completed on `2026-08-29`

## AI Usage Disclosure

- [ ] `Assist`
- [x] `Pair`
- [ ] `Copilot`
- [ ] `Auto`

```text
AI scope:
- tooling used: Codex for implementation, validation, release prep, and PR drafting
- files or areas most affected: target-language runtime sync, overlay RTL target resolution, GTranslate target selection, Previewer/Mock validation, release metadata
- how the result was reviewed/tested: user-directed scope, local build/test runs, Previewer screenshot validation, and manual in-game QA
```

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```
